### PR TITLE
Validate command classes on demand and not on init

### DIFF
--- a/canvas_sdk/commands/__init__.py
+++ b/canvas_sdk/commands/__init__.py
@@ -1,16 +1,32 @@
-from canvas_sdk.commands.commands.assess import AssessCommand
-from canvas_sdk.commands.commands.diagnose import DiagnoseCommand
-from canvas_sdk.commands.commands.goal import GoalCommand
-from canvas_sdk.commands.commands.history_present_illness import (
-    HistoryOfPresentIllnessCommand,
+from canvas_sdk.commands.commands.assess import (
+    AssessCommandNoInitValidation as AssessCommand,
 )
-from canvas_sdk.commands.commands.medication_statement import MedicationStatementCommand
-from canvas_sdk.commands.commands.plan import PlanCommand
-from canvas_sdk.commands.commands.prescribe import PrescribeCommand
-from canvas_sdk.commands.commands.questionnaire import QuestionnaireCommand
-from canvas_sdk.commands.commands.reason_for_visit import ReasonForVisitCommand
-from canvas_sdk.commands.commands.stop_medication import StopMedicationCommand
-from canvas_sdk.commands.commands.update_goal import UpdateGoalCommand
+from canvas_sdk.commands.commands.diagnose import (
+    DiagnoseCommandNoInitValidation as DiagnoseCommand,
+)
+from canvas_sdk.commands.commands.goal import GoalCommandNoInitValidation as GoalCommand
+from canvas_sdk.commands.commands.history_present_illness import (
+    HistoryOfPresentIllnessCommandNoInitValidation as HistoryOfPresentIllnessCommand,
+)
+from canvas_sdk.commands.commands.medication_statement import (
+    MedicationStatementCommandNoInitValidation as MedicationStatementCommand,
+)
+from canvas_sdk.commands.commands.plan import PlanCommandNoInitValidation as PlanCommand
+from canvas_sdk.commands.commands.prescribe import (
+    PrescribeCommandNoInitValidation as PrescribeCommand,
+)
+from canvas_sdk.commands.commands.questionnaire import (
+    QuestionnaireCommandNoInitValidation as QuestionnaireCommand,
+)
+from canvas_sdk.commands.commands.reason_for_visit import (
+    ReasonForVisitCommandNoInitValidation as ReasonForVisitCommand,
+)
+from canvas_sdk.commands.commands.stop_medication import (
+    StopMedicationCommandNoInitValidation as StopMedicationCommand,
+)
+from canvas_sdk.commands.commands.update_goal import (
+    UpdateGoalCommandNoInitValidation as UpdateGoalCommand,
+)
 
 __all__ = (
     "AssessCommand",

--- a/canvas_sdk/commands/commands/assess.py
+++ b/canvas_sdk/commands/commands/assess.py
@@ -1,7 +1,8 @@
 from enum import Enum
 
-from canvas_sdk.commands.base import _BaseCommand
 from pydantic import Field
+
+from canvas_sdk.commands.base import _BaseCommand
 
 
 class AssessCommand(_BaseCommand):
@@ -29,6 +30,14 @@ class AssessCommand(_BaseCommand):
             "status": self.status.value if self.status else None,
             "narrative": self.narrative,
         }
+
+
+class AssessCommandNoInitValidation:
+    """Assess Command without validation on initialization."""
+
+    def __new__(cls, **kwargs: dict) -> AssessCommand:
+        """Returns an initialized Assess Command without any validation."""
+        return AssessCommand.model_construct(**kwargs)
 
 
 # how do we make sure that condition_id is a valid condition for the patient?

--- a/canvas_sdk/commands/commands/diagnose.py
+++ b/canvas_sdk/commands/commands/diagnose.py
@@ -29,3 +29,11 @@ class DiagnoseCommand(_BaseCommand):
             ),
             "today_assessment": self.today_assessment,
         }
+
+
+class DiagnoseCommandNoInitValidation:
+    """Diagnose Command without validation on initialization."""
+
+    def __new__(cls, **kwargs: dict) -> DiagnoseCommand:
+        """Returns an initialized Diagnose Command without any validation."""
+        return DiagnoseCommand.model_construct(**kwargs)

--- a/canvas_sdk/commands/commands/goal.py
+++ b/canvas_sdk/commands/commands/goal.py
@@ -46,3 +46,11 @@ class GoalCommand(_BaseCommand):
             "priority": (self.priority.value if self.priority else None),
             "progress": self.progress,
         }
+
+
+class GoalCommandNoInitValidation:
+    """Goal Command without validation on initialization."""
+
+    def __new__(cls, **kwargs: dict) -> GoalCommand:
+        """Returns an initialized Goal Command without any validation."""
+        return GoalCommand.model_construct(**kwargs)

--- a/canvas_sdk/commands/commands/history_present_illness.py
+++ b/canvas_sdk/commands/commands/history_present_illness.py
@@ -13,3 +13,11 @@ class HistoryOfPresentIllnessCommand(_BaseCommand):
     def values(self) -> dict:
         """The HPI command's field values."""
         return {"narrative": self.narrative}
+
+
+class HistoryOfPresentIllnessCommandNoInitValidation:
+    """HPI Command without validation on initialization."""
+
+    def __new__(cls, **kwargs: dict) -> HistoryOfPresentIllnessCommand:
+        """Returns an initialized HPI Command without any validation."""
+        return HistoryOfPresentIllnessCommand.model_construct(**kwargs)

--- a/canvas_sdk/commands/commands/medication_statement.py
+++ b/canvas_sdk/commands/commands/medication_statement.py
@@ -1,5 +1,6 @@
-from canvas_sdk.commands.base import _BaseCommand
 from pydantic import Field
+
+from canvas_sdk.commands.base import _BaseCommand
 
 
 class MedicationStatementCommand(_BaseCommand):
@@ -15,6 +16,14 @@ class MedicationStatementCommand(_BaseCommand):
     def values(self) -> dict:
         """The MedicationStatement command's field values."""
         return {"fdb_code": self.fdb_code, "sig": self.sig}
+
+
+class MedicationStatementCommandNoInitValidation:
+    """Medication Statement Command without validation on initialization."""
+
+    def __new__(cls, **kwargs: dict) -> MedicationStatementCommand:
+        """Returns an initialized Medication Statement Command without any validation."""
+        return MedicationStatementCommand.model_construct(**kwargs)
 
 
 # how do we make sure fdb_code is a valid code?

--- a/canvas_sdk/commands/commands/plan.py
+++ b/canvas_sdk/commands/commands/plan.py
@@ -13,3 +13,11 @@ class PlanCommand(_BaseCommand):
     def values(self) -> dict:
         """The Plan command's field values."""
         return {"narrative": self.narrative}
+
+
+class PlanCommandNoInitValidation:
+    """Plan Command without validation on initialization."""
+
+    def __new__(cls, **kwargs: dict) -> PlanCommand:
+        """Returns an initialized Plan Command without any validation."""
+        return PlanCommand.model_construct(**kwargs)

--- a/canvas_sdk/commands/commands/prescribe.py
+++ b/canvas_sdk/commands/commands/prescribe.py
@@ -38,9 +38,9 @@ class PrescribeCommand(_BaseCommand):
             "icd10_codes": self.icd10_codes,
             "sig": self.sig,
             "days_supply": self.days_supply,
-            "quantity_to_dispense": str(Decimal(self.quantity_to_dispense))
-            if self.quantity_to_dispense
-            else None,
+            "quantity_to_dispense": (
+                str(Decimal(self.quantity_to_dispense)) if self.quantity_to_dispense else None
+            ),
             # "type_to_dispense": self.type_to_dispense,
             "refills": self.refills,
             "substitutions": self.substitutions.value,
@@ -48,3 +48,11 @@ class PrescribeCommand(_BaseCommand):
             "prescriber_id": self.prescriber_id,
             "note_to_pharmacist": self.note_to_pharmacist,
         }
+
+
+class PrescribeCommandNoInitValidation:
+    """Prescribe Command without validation on initialization."""
+
+    def __new__(cls, **kwargs: dict) -> PrescribeCommand:
+        """Returns an initialized Prescribe Command without any validation."""
+        return PrescribeCommand.model_construct(**kwargs)

--- a/canvas_sdk/commands/commands/questionnaire.py
+++ b/canvas_sdk/commands/commands/questionnaire.py
@@ -1,5 +1,6 @@
-from canvas_sdk.commands.base import _BaseCommand
 from pydantic import Field
+
+from canvas_sdk.commands.base import _BaseCommand
 
 
 class QuestionnaireCommand(_BaseCommand):
@@ -15,3 +16,11 @@ class QuestionnaireCommand(_BaseCommand):
     def values(self) -> dict:
         """The Questionnaire command's field values."""
         return {"questionnaire_id": self.questionnaire_id, "result": self.result}
+
+
+class QuestionnaireCommandNoInitValidation:
+    """Questionnaire Command without validation on initialization."""
+
+    def __new__(cls, **kwargs: dict) -> QuestionnaireCommand:
+        """Returns an initialized Questionnaire Command without any validation."""
+        return QuestionnaireCommand.model_construct(**kwargs)

--- a/canvas_sdk/commands/commands/reason_for_visit.py
+++ b/canvas_sdk/commands/commands/reason_for_visit.py
@@ -6,7 +6,7 @@ from canvas_sdk.commands.constants import Coding
 
 
 class ReasonForVisitCommand(_BaseCommand):
-    """A class for managing a ReasonForVisit command within a specific note."""
+    """A class for managing a Reason For Visit command within a specific note."""
 
     class Meta:
         key = "reasonForVisit"
@@ -34,3 +34,11 @@ class ReasonForVisitCommand(_BaseCommand):
     def values(self) -> dict:
         """The ReasonForVisit command's field values."""
         return {"structured": self.structured, "coding": self.coding, "comment": self.comment}
+
+
+class ReasonForVisitCommandNoInitValidation:
+    """Reson For Visit Command without validation on initialization."""
+
+    def __new__(cls, **kwargs: dict) -> ReasonForVisitCommand:
+        """Returns an initialized Reson For Visit Command without any validation."""
+        return ReasonForVisitCommand.model_construct(**kwargs)

--- a/canvas_sdk/commands/commands/stop_medication.py
+++ b/canvas_sdk/commands/commands/stop_medication.py
@@ -1,5 +1,6 @@
-from canvas_sdk.commands.base import _BaseCommand
 from pydantic import Field
+
+from canvas_sdk.commands.base import _BaseCommand
 
 
 class StopMedicationCommand(_BaseCommand):
@@ -16,3 +17,11 @@ class StopMedicationCommand(_BaseCommand):
     def values(self) -> dict:
         """The StopMedication command's field values."""
         return {"medication_id": self.medication_id, "rationale": self.rationale}
+
+
+class StopMedicationCommandNoInitValidation:
+    """Stop Medication Command without validation on initialization."""
+
+    def __new__(cls, **kwargs: dict) -> StopMedicationCommand:
+        """Returns an initialized Stop Medication Command without any validation."""
+        return StopMedicationCommand.model_construct(**kwargs)

--- a/canvas_sdk/commands/commands/update_goal.py
+++ b/canvas_sdk/commands/commands/update_goal.py
@@ -46,3 +46,11 @@ class UpdateGoalCommand(_BaseCommand):
             "priority": (self.priority.value if self.priority else None),
             "progress": self.progress,
         }
+
+
+class UpdateGoalCommandNoInitValidation:
+    """Update Goal Command without validation on initialization."""
+
+    def __new__(cls, **kwargs: dict) -> UpdateGoalCommand:
+        """Returns an initialized Update Goal Command without any validation."""
+        return UpdateGoalCommand.model_construct(**kwargs)


### PR DESCRIPTION
We want to allow developers to set attributes throughout their code, and only perform the validation when its necessary (right before `originate`, `edit`, `delete`, `commit`, `enter_in_error`). this pr achieves that. 

i will fix tests tomorrow!