### PR TITLE
Validate command classes on demand, with specific validation for each type of effect

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,7 +42,7 @@ repos:
     rev: 6.3.0
     hooks:
       - id: pydocstyle
-        exclude: *generated
+        exclude: "generated/|tests.py"
         additional_dependencies: [tomli]
 
   - repo: https://github.com/pycqa/isort

--- a/canvas_sdk/commands/base.py
+++ b/canvas_sdk/commands/base.py
@@ -1,33 +1,73 @@
 import json
 import re
 from enum import EnumType
-from typing import get_args
+from typing import Any, Literal, get_args
 
-from pydantic import BaseModel, ConfigDict, model_validator
-from typing_extensions import Self
+from pydantic import BaseModel, ConfigDict
+from pydantic_core import InitErrorDetails, PydanticCustomError, ValidationError
 
 from canvas_sdk.effects import Effect, EffectType
 
 
 class _BaseCommand(BaseModel):
-    model_config = ConfigDict(strict=True, validate_assignment=True)
+    model_config = ConfigDict(strict=True, revalidate_instances="always")
 
     class Meta:
         key = ""
+        originate_required_fields = (
+            "user_id",
+            "note_uuid",
+        )
+        edit_required_fields = (
+            "user_id",
+            "command_uuid",
+        )
+        delete_required_fields = (
+            "user_id",
+            "command_uuid",
+        )
+        commit_required_fields = (
+            "user_id",
+            "command_uuid",
+        )
+        enter_in_error_required_fields = (
+            "user_id",
+            "command_uuid",
+        )
 
     def constantized_key(self) -> str:
         return re.sub(r"(?<!^)(?=[A-Z])", "_", self.Meta.key).upper()
 
-    # todo: update int to str as we should use external identifiers
     note_uuid: str | None = None
     command_uuid: str | None = None
-    user_id: int
+    user_id: int | None = None
 
-    @model_validator(mode="after")
-    def _verify_has_note_uuid_or_command_id(self) -> Self:
-        if not self.note_uuid and not self.command_uuid:
-            raise ValueError("Command should have either a note_uuid or a command_uuid.")
-        return self
+    def _create_error_detail(self, type: str, message: str, value: Any) -> InitErrorDetails:
+        return InitErrorDetails({"type": PydanticCustomError(type, message), "input": value})
+
+    def _get_error_details(
+        self, method: Literal["originate", "edit", "delete", "commit", "enter_in_error"]
+    ) -> list[InitErrorDetails]:
+        base_required_fields: tuple = getattr(
+            _BaseCommand.Meta, f"{method}_required_fields", tuple()
+        )
+        command_required_fields: tuple = getattr(self.Meta, f"{method}_required_fields", tuple())
+        required_fields = tuple(set(base_required_fields) | set(command_required_fields))
+
+        return [
+            self._create_error_detail(
+                "missing", f"Field '{field}' is required to {method.replace('_', ' ')} a command", v
+            )
+            for field in required_fields
+            if (v := getattr(self, field)) is None
+        ]
+
+    def _validate_before_effect(
+        self, method: Literal["originate", "edit", "delete", "commit", "enter_in_error"]
+    ) -> None:
+        self.model_validate(self)
+        if error_details := self._get_error_details(method):
+            raise ValidationError.from_exception_data(self.__class__.__name__, error_details)
 
     @property
     def values(self) -> dict:
@@ -70,8 +110,7 @@ class _BaseCommand(BaseModel):
 
     def originate(self) -> Effect:
         """Originate a new command in the note body."""
-        if not self.note_uuid:
-            raise AttributeError("Note id is required to originate a command")
+        self._validate_before_effect("originate")
         return Effect(
             type=EffectType.Value(f"ORIGINATE_{self.constantized_key()}_COMMAND"),
             payload=json.dumps(
@@ -85,8 +124,7 @@ class _BaseCommand(BaseModel):
 
     def edit(self) -> Effect:
         """Edit the command."""
-        if not self.command_uuid:
-            raise AttributeError("Command uuid is required to edit a command")
+        self._validate_before_effect("edit")
         return {
             "type": f"EDIT_{self.constantized_key()}_COMMAND",
             "payload": {
@@ -98,8 +136,7 @@ class _BaseCommand(BaseModel):
 
     def delete(self) -> Effect:
         """Delete the command."""
-        if not self.command_uuid:
-            raise AttributeError("Command uuid is required to delete a command")
+        self._validate_before_effect("delete")
         return {
             "type": f"DELETE_{self.constantized_key()}_COMMAND",
             "payload": {"command": self.command_uuid, "user": self.user_id},
@@ -107,8 +144,7 @@ class _BaseCommand(BaseModel):
 
     def commit(self) -> Effect:
         """Commit the command."""
-        if not self.command_uuid:
-            raise AttributeError("Command uuid is required to commit a command")
+        self._validate_before_effect("commit")
         return {
             "type": f"COMMIT_{self.constantized_key()}_COMMAND",
             "payload": {"command": self.command_uuid, "user": self.user_id},
@@ -116,8 +152,7 @@ class _BaseCommand(BaseModel):
 
     def enter_in_error(self) -> Effect:
         """Mark the command as entered-in-error."""
-        if not self.command_uuid:
-            raise AttributeError("Command uuid is required to enter in error a command")
+        self._validate_before_effect("enter_in_error")
         return {
             "type": f"ENTER_IN_ERROR_{self.constantized_key()}_COMMAND",
             "payload": {"command": self.command_uuid, "user": self.user_id},

--- a/canvas_sdk/commands/commands/assess.py
+++ b/canvas_sdk/commands/commands/assess.py
@@ -1,7 +1,8 @@
 from enum import Enum
 
-from canvas_sdk.commands.base import _BaseCommand
 from pydantic import Field
+
+from canvas_sdk.commands.base import _BaseCommand
 
 
 class AssessCommand(_BaseCommand):
@@ -9,13 +10,16 @@ class AssessCommand(_BaseCommand):
 
     class Meta:
         key = "assess"
+        originate_required_fields = ("condition_id",)
 
     class Status(Enum):
         IMPROVED = "improved"
         STABLE = "stable"
         DETERIORATED = "deteriorated"
 
-    condition_id: str = Field(json_schema_extra={"commands_api_name": "condition"})
+    condition_id: str | None = Field(
+        default=None, json_schema_extra={"commands_api_name": "condition"}
+    )
     background: str | None = None
     status: Status | None = None
     narrative: str | None = None

--- a/canvas_sdk/commands/commands/diagnose.py
+++ b/canvas_sdk/commands/commands/diagnose.py
@@ -10,8 +10,11 @@ class DiagnoseCommand(_BaseCommand):
 
     class Meta:
         key = "diagnose"
+        originate_required_fields = ("icd10_code",)
 
-    icd10_code: str = Field(json_schema_extra={"commands_api_name": "diagnose"})
+    icd10_code: str | None = Field(
+        default=None, json_schema_extra={"commands_api_name": "diagnose"}
+    )
     background: str | None = None
     approximate_date_of_onset: datetime | None = None
     today_assessment: str | None = None

--- a/canvas_sdk/commands/commands/goal.py
+++ b/canvas_sdk/commands/commands/goal.py
@@ -9,7 +9,7 @@ class GoalCommand(_BaseCommand):
 
     class Meta:
         key = "goal"
-        originate_required_fields = ("goal_statement",)
+        originate_required_fields = ("goal_statement", "start_date")
 
     class Priority(Enum):
         HIGH = "high-priority"

--- a/canvas_sdk/commands/commands/goal.py
+++ b/canvas_sdk/commands/commands/goal.py
@@ -9,6 +9,7 @@ class GoalCommand(_BaseCommand):
 
     class Meta:
         key = "goal"
+        originate_required_fields = ("goal_statement",)
 
     class Priority(Enum):
         HIGH = "high-priority"
@@ -26,7 +27,7 @@ class GoalCommand(_BaseCommand):
         NO_PROGRESS = "no-progress"
         NOT_ATTAINABLE = "not-attainable"
 
-    goal_statement: str
+    goal_statement: str | None = None
     start_date: datetime | None = None
     due_date: datetime | None = None
     achievement_status: AchievementStatus | None = None

--- a/canvas_sdk/commands/commands/history_present_illness.py
+++ b/canvas_sdk/commands/commands/history_present_illness.py
@@ -6,8 +6,9 @@ class HistoryOfPresentIllnessCommand(_BaseCommand):
 
     class Meta:
         key = "hpi"
+        originate_required_fields = ("narrative",)
 
-    narrative: str
+    narrative: str | None
 
     @property
     def values(self) -> dict:

--- a/canvas_sdk/commands/commands/history_present_illness.py
+++ b/canvas_sdk/commands/commands/history_present_illness.py
@@ -8,7 +8,7 @@ class HistoryOfPresentIllnessCommand(_BaseCommand):
         key = "hpi"
         originate_required_fields = ("narrative",)
 
-    narrative: str | None
+    narrative: str | None = None
 
     @property
     def values(self) -> dict:

--- a/canvas_sdk/commands/commands/medication_statement.py
+++ b/canvas_sdk/commands/commands/medication_statement.py
@@ -1,5 +1,6 @@
-from canvas_sdk.commands.base import _BaseCommand
 from pydantic import Field
+
+from canvas_sdk.commands.base import _BaseCommand
 
 
 class MedicationStatementCommand(_BaseCommand):
@@ -7,8 +8,11 @@ class MedicationStatementCommand(_BaseCommand):
 
     class Meta:
         key = "medicationStatement"
+        originate_required_fields = ("fdb_code",)
 
-    fdb_code: str = Field(json_schema_extra={"commands_api_name": "medication"})
+    fdb_code: str | None = Field(
+        default=None, json_schema_extra={"commands_api_name": "medication"}
+    )
     sig: str | None = None
 
     @property

--- a/canvas_sdk/commands/commands/plan.py
+++ b/canvas_sdk/commands/commands/plan.py
@@ -6,8 +6,9 @@ class PlanCommand(_BaseCommand):
 
     class Meta:
         key = "plan"
+        originate_required_fields = ("narrative",)
 
-    narrative: str
+    narrative: str | None = None
 
     @property
     def values(self) -> dict:

--- a/canvas_sdk/commands/commands/prescribe.py
+++ b/canvas_sdk/commands/commands/prescribe.py
@@ -11,23 +11,33 @@ class PrescribeCommand(_BaseCommand):
 
     class Meta:
         key = "prescribe"
+        originate_required_fields = (
+            "fdb_code",
+            "sig",
+            "type_to_dispense",
+            "refills",
+            "substitutions",
+            "prescriber_id",
+        )
 
     class Substitutions(Enum):
         ALLOWED = "allowed"
         NOT_ALLOWED = "not_allowed"
 
-    fdb_code: str = Field(json_schema_extra={"commands_api_name": "prescribe"})
+    fdb_code: str | None = Field(default=None, json_schema_extra={"commands_api_name": "prescribe"})
     icd10_codes: list[str] | None = Field(
         None, json_schema_extra={"commands_api_name": "indications"}
     )
-    sig: str
+    sig: str | None = None
     days_supply: int | None = None
     quantity_to_dispense: Decimal | float | int | None = None
-    type_to_dispense: str
-    refills: int
+    type_to_dispense: str | None = None
+    refills: int | None = None
     substitutions: Substitutions = Substitutions.ALLOWED  # type: ignore
     pharmacy: str | None = None
-    prescriber_id: str = Field(json_schema_extra={"commands_api_name": "prescriber"})
+    prescriber_id: str | None = Field(
+        default=None, json_schema_extra={"commands_api_name": "prescriber"}
+    )
     note_to_pharmacist: str | None = None
 
     @property
@@ -38,9 +48,9 @@ class PrescribeCommand(_BaseCommand):
             "icd10_codes": self.icd10_codes,
             "sig": self.sig,
             "days_supply": self.days_supply,
-            "quantity_to_dispense": str(Decimal(self.quantity_to_dispense))
-            if self.quantity_to_dispense
-            else None,
+            "quantity_to_dispense": (
+                str(Decimal(self.quantity_to_dispense)) if self.quantity_to_dispense else None
+            ),
             # "type_to_dispense": self.type_to_dispense,
             "refills": self.refills,
             "substitutions": self.substitutions.value,

--- a/canvas_sdk/commands/commands/prescribe.py
+++ b/canvas_sdk/commands/commands/prescribe.py
@@ -14,6 +14,7 @@ class PrescribeCommand(_BaseCommand):
         originate_required_fields = (
             "fdb_code",
             "sig",
+            "quantity_to_dispense",
             "type_to_dispense",
             "refills",
             "substitutions",
@@ -33,7 +34,7 @@ class PrescribeCommand(_BaseCommand):
     quantity_to_dispense: Decimal | float | int | None = None
     type_to_dispense: str | None = None
     refills: int | None = None
-    substitutions: Substitutions = Substitutions.ALLOWED  # type: ignore
+    substitutions: Substitutions | None = None
     pharmacy: str | None = None
     prescriber_id: str | None = Field(
         default=None, json_schema_extra={"commands_api_name": "prescriber"}
@@ -53,7 +54,7 @@ class PrescribeCommand(_BaseCommand):
             ),
             # "type_to_dispense": self.type_to_dispense,
             "refills": self.refills,
-            "substitutions": self.substitutions.value,
+            "substitutions": self.substitutions.value if self.substitutions else None,
             "pharmacy": self.pharmacy,
             "prescriber_id": self.prescriber_id,
             "note_to_pharmacist": self.note_to_pharmacist,

--- a/canvas_sdk/commands/commands/questionnaire.py
+++ b/canvas_sdk/commands/commands/questionnaire.py
@@ -1,5 +1,6 @@
-from canvas_sdk.commands.base import _BaseCommand
 from pydantic import Field
+
+from canvas_sdk.commands.base import _BaseCommand
 
 
 class QuestionnaireCommand(_BaseCommand):
@@ -7,8 +8,11 @@ class QuestionnaireCommand(_BaseCommand):
 
     class Meta:
         key = "questionnaire"
+        originate_required_fields = ("questionnaire_id",)
 
-    questionnaire_id: str = Field(json_schema_extra={"commands_api_name": "questionnaire"})
+    questionnaire_id: str | None = Field(
+        default=None, json_schema_extra={"commands_api_name": "questionnaire"}
+    )
     result: str | None = None
 
     @property

--- a/canvas_sdk/commands/commands/stop_medication.py
+++ b/canvas_sdk/commands/commands/stop_medication.py
@@ -1,5 +1,6 @@
-from canvas_sdk.commands.base import _BaseCommand
 from pydantic import Field
+
+from canvas_sdk.commands.base import _BaseCommand
 
 
 class StopMedicationCommand(_BaseCommand):
@@ -7,9 +8,12 @@ class StopMedicationCommand(_BaseCommand):
 
     class Meta:
         key = "stopMedication"
+        originate_required_fields = ("medication_id",)
 
     # how do we make sure this is a valid medication_id for the patient?
-    medication_id: str = Field(json_schema_extra={"commands_api_name": "medication"})
+    medication_id: str | None = Field(
+        default=None, json_schema_extra={"commands_api_name": "medication"}
+    )
     rationale: str | None = None
 
     @property

--- a/canvas_sdk/commands/commands/update_goal.py
+++ b/canvas_sdk/commands/commands/update_goal.py
@@ -11,6 +11,7 @@ class UpdateGoalCommand(_BaseCommand):
 
     class Meta:
         key = "updateGoal"
+        originate_required_fields = ("goal_id",)
 
     class AchievementStatus(Enum):
         IN_PROGRESS = "in-progress"
@@ -28,7 +29,9 @@ class UpdateGoalCommand(_BaseCommand):
         MEDIUM = "medium-priority"
         LOW = "low-priority"
 
-    goal_id: str = Field(json_schema_extra={"commands_api_name": "goal_statement"})
+    goal_id: str | None = Field(
+        default=None, json_schema_extra={"commands_api_name": "goal_statement"}
+    )
     due_date: datetime | None = None
     achievement_status: AchievementStatus | None = None
     priority: Priority | None = None

--- a/canvas_sdk/commands/tests/tests.py
+++ b/canvas_sdk/commands/tests/tests.py
@@ -1,3 +1,4 @@
+import decimal
 from datetime import datetime
 
 import pytest
@@ -22,8 +23,7 @@ from canvas_sdk.commands.constants import Coding
 from canvas_sdk.commands.tests.test_utils import (
     fake,
     get_field_type,
-    raises_missing_error,
-    raises_none_error,
+    raises_none_error_for_effect_method,
     raises_wrong_type_error,
 )
 
@@ -96,15 +96,11 @@ def test_command_raises_generic_error_when_kwarg_given_incorrect_type(
     ),
     fields_to_test: tuple[str],
 ) -> None:
-    schema = Command.model_json_schema()
-    schema["required"].append("note_uuid")
-    required_fields = {k: v for k, v in schema["properties"].items() if k in schema["required"]}
-    base = {field: fake(props, Command) for field, props in required_fields.items()}
     for field in fields_to_test:
-        raises_wrong_type_error(base, Command, field)
-        if field in required_fields:
-            raises_missing_error(base, Command, field)
-            raises_none_error(base, Command, field)
+        raises_wrong_type_error(Command, field)
+
+    for method in ["originate", "edit", "delete", "commit", "enter_in_error"]:
+        raises_none_error_for_effect_method(Command, method)
 
 
 @pytest.mark.parametrize(
@@ -112,26 +108,26 @@ def test_command_raises_generic_error_when_kwarg_given_incorrect_type(
     [
         (
             PlanCommand,
-            {"narrative": "yo", "user_id": 1},
-            "1 validation error for PlanCommand\n  Value error, Command should have either a note_uuid or a command_uuid. [type=value",
-            {"narrative": "yo", "note_uuid": "00000000-0000-0000-0000-000000000000", "user_id": 1},
-        ),
-        (
-            PlanCommand,
-            {"narrative": "yo", "user_id": 1, "note_uuid": None},
-            "1 validation error for PlanCommand\n  Value error, Command should have either a note_uuid or a command_uuid. [type=value",
-            {"narrative": "yo", "note_uuid": "00000000-0000-0000-0000-000000000000", "user_id": 1},
-        ),
-        (
-            PlanCommand,
             {"narrative": "yo", "user_id": 5, "note_uuid": 1},
             "1 validation error for PlanCommand\nnote_uuid\n  Input should be a valid string [type=string_type",
             {"narrative": "yo", "note_uuid": "00000000-0000-0000-0000-000000000000", "user_id": 1},
         ),
         (
+            PlanCommand,
+            {"narrative": "yo", "user_id": 5, "note_uuid": "5", "command_uuid": 5},
+            "1 validation error for PlanCommand\ncommand_uuid\n  Input should be a valid string [type=string_type",
+            {"narrative": "yo", "user_id": 5, "note_uuid": "5", "command_uuid": "5"},
+        ),
+        (
+            PlanCommand,
+            {"narrative": "yo", "note_uuid": "5", "command_uuid": "4", "user_id": "5"},
+            "1 validation error for PlanCommand\nuser_id\n  Input should be a valid integer [type=int_type",
+            {"narrative": "yo", "note_uuid": "5", "command_uuid": "4", "user_id": 5},
+        ),
+        (
             ReasonForVisitCommand,
             {"note_uuid": "00000000-0000-0000-0000-000000000000", "user_id": 1, "structured": True},
-            "1 validation error for ReasonForVisitCommand\n  Value error, Structured RFV should have a coding.",
+            "1 validation error for ReasonForVisitCommand\n  Structured RFV should have a coding",
             {
                 "note_uuid": "00000000-0000-0000-0000-000000000000",
                 "user_id": 1,
@@ -217,7 +213,9 @@ def test_command_raises_specific_error_when_kwarg_given_incorrect_type(
     valid_kwargs: dict,
 ) -> None:
     with pytest.raises(ValidationError) as e1:
-        Command(**err_kwargs)
+        cmd = Command(**err_kwargs)
+        cmd.originate()
+        cmd.edit()
     assert err_msg in repr(e1.value)
 
     cmd = Command(**valid_kwargs)
@@ -226,6 +224,8 @@ def test_command_raises_specific_error_when_kwarg_given_incorrect_type(
     key, value = list(err_kwargs.items())[-1]
     with pytest.raises(ValidationError) as e2:
         setattr(cmd, key, value)
+        cmd.originate()
+        cmd.edit()
     assert err_msg in repr(e2.value)
 
 
@@ -299,21 +299,29 @@ def test_command_allows_kwarg_with_correct_type(
     fields_to_test: tuple[str],
 ) -> None:
     schema = Command.model_json_schema()
-    schema["required"].append("note_uuid")
-    required_fields = {k: v for k, v in schema["properties"].items() if k in schema["required"]}
-    base = {field: fake(props, Command) for field, props in required_fields.items()}
 
     for field in fields_to_test:
-        field_type = get_field_type(Command.model_json_schema()["properties"][field])
+        field_type = get_field_type(schema["properties"][field])
 
         init_field_value = fake({"type": field_type}, Command)
-        init_kwargs = base | {field: init_field_value}
+        init_kwargs = {field: init_field_value}
         cmd = Command(**init_kwargs)
         assert getattr(cmd, field) == init_field_value
 
         updated_field_value = fake({"type": field_type}, Command)
         setattr(cmd, field, updated_field_value)
         assert getattr(cmd, field) == updated_field_value
+
+    for method in ["originate", "edit", "delete", "commit", "enter_in_error"]:
+        required_fields = {
+            k: v
+            for k, v in schema["properties"].items()
+            if k in Command()._get_effect_method_required_fields(method)
+        }
+        base = {field: fake(props, Command) for field, props in required_fields.items()}
+        cmd = Command(**base)
+        effect = getattr(cmd, method)()
+        assert effect is not None
 
 
 @pytest.fixture(scope="session")
@@ -357,6 +365,9 @@ def command_type_map() -> dict[str, type]:
         "TextField": str,
         "ChoiceField": str,
         "DateField": datetime,
+        "ApproximateDateField": datetime,
+        "IntegerField": int,
+        "DecimalField": decimal.Decimal,
     }
 
 
@@ -365,14 +376,12 @@ def command_type_map() -> dict[str, type]:
     "Command",
     [
         (AssessCommand),
-        # todo: add Diagnose once it has an adapter in home-app
-        # (DiagnoseCommand),
+        (DiagnoseCommand),
         (GoalCommand),
         (HistoryOfPresentIllnessCommand),
         (MedicationStatementCommand),
         (PlanCommand),
-        # todo: add Prescribe once its been refactored
-        # (PrescribeCommand),
+        (PrescribeCommand),
         (QuestionnaireCommand),
         (ReasonForVisitCommand),
         (StopMedicationCommand),
@@ -427,7 +436,15 @@ def test_command_schema_matches_command_api(
         expected_type = expected_field["type"]
         if expected_type is Coding:
             expected_type = expected_type.__annotations__["code"]
-        assert expected_type == command_type_map.get(actual_field["type"])
+
+        actual_type = command_type_map.get(actual_field["type"])
+        if actual_field["type"] == "AutocompleteField" and name[-1] == "s":
+            # this condition initially created for Prescribe.indications,
+            # but could apply to other AutocompleteField fields that are lists
+            # making the assumption here that if the field ends in 's' (like indications), it is a list
+            actual_type = list[actual_type]  # type: ignore
+
+        assert expected_type == actual_type
 
         if (choices := actual_field["choices"]) is None:
             assert expected_field["choices"] is None


### PR DESCRIPTION
second attempt at this one: [Validate command classes on demand and not on init](https://github.com/canvas-medical/canvas-plugins/pull/67). 

this time around we made every field optional, so that there are no validation errors on init for empty values. 

and then for each type of effect, we have a custom validation based on the fields that we indicate are required for that type of effect. 


note: tests will fail spectacularly, but i will address tonight/tomorrow