### PR TITLE
Prepend the hostname to log lines if the hostname is defined in the env

### DIFF
--- a/canvas_sdk/commands/tests/test_utils.py
+++ b/canvas_sdk/commands/tests/test_utils.py
@@ -22,6 +22,17 @@ from canvas_sdk.commands import (
 from canvas_sdk.commands.constants import Coding
 
 
+class Secret:
+    def __init__(self, value):
+        self.value = value
+
+    def __repr__(self) -> str:
+        return "Secret(********)"
+
+    def __str___(self) -> str:
+        return "*******"
+
+
 def get_field_type_unformatted(field_props: dict[str, Any]) -> str:
     if t := field_props.get("type"):
         return field_props.get("format") or t

--- a/canvas_sdk/commands/tests/test_utils.py
+++ b/canvas_sdk/commands/tests/test_utils.py
@@ -22,12 +22,12 @@ from canvas_sdk.commands import (
 from canvas_sdk.commands.constants import Coding
 
 
-class Secret:
+class MaskedValue:
     def __init__(self, value):
         self.value = value
 
     def __repr__(self) -> str:
-        return "Secret(********)"
+        return "MaskedValue(********)"
 
     def __str___(self) -> str:
         return "*******"

--- a/canvas_sdk/commands/tests/tests.py
+++ b/canvas_sdk/commands/tests/tests.py
@@ -21,7 +21,7 @@ from canvas_sdk.commands import (
 )
 from canvas_sdk.commands.constants import Coding
 from canvas_sdk.commands.tests.test_utils import (
-    Secret,
+    MaskedValue,
     fake,
     get_field_type,
     raises_none_error_for_effect_method,
@@ -326,8 +326,8 @@ def test_command_allows_kwarg_with_correct_type(
 
 
 @pytest.fixture(scope="session")
-def token() -> Secret:
-    return Secret(
+def token() -> MaskedValue:
+    return MaskedValue(
         requests.post(
             f"{settings.INTEGRATION_TEST_URL}/auth/token/",
             headers={"Content-Type": "application/x-www-form-urlencoded"},
@@ -341,7 +341,7 @@ def token() -> Secret:
 
 
 @pytest.fixture
-def note_uuid(token: Secret) -> str:
+def note_uuid(token: MaskedValue) -> str:
     headers = {
         "Authorization": f"Bearer {token.value}",
         "Content-Type": "application/json",
@@ -392,7 +392,7 @@ def command_type_map() -> dict[str, type]:
     ],
 )
 def test_command_schema_matches_command_api(
-    token: Secret,
+    token: MaskedValue,
     command_type_map: dict[str, str],
     note_uuid: str,
     Command: (

--- a/logger/logger.py
+++ b/logger/logger.py
@@ -18,7 +18,10 @@ class PluginLogger:
     def __init__(self) -> None:
         self.logger = logging.getLogger("plugin_runner_logger")
         self.logger.setLevel(logging.INFO)
-        formatter = logging.Formatter("%(levelname)s %(asctime)s %(message)s")
+        log_prefix = os.getenv("HOSTNAME", "")
+        if log_prefix != "":
+            log_prefix = f"[{log_prefix}] "
+        formatter = logging.Formatter(f"{log_prefix}%(levelname)s %(asctime)s %(message)s")
 
         streaming_handler = logging.StreamHandler()
         streaming_handler.setFormatter(formatter)


### PR DESCRIPTION
This will help separate log messages between containers in multi-container deployments.