### PR TITLE
for enable/disable check for status ok to give success message

### DIFF
--- a/canvas_cli/apps/plugin/plugin.py
+++ b/canvas_cli/apps/plugin/plugin.py
@@ -204,7 +204,7 @@ def enable(
         print(f"Failed to connect to {host}")
         raise typer.Exit(1)
 
-    if r.status_code == requests.codes.ok:
+    if r.ok:
         print(f"Plugin {name} successfully enabled!")
     else:
         print(f"Status code {r.status_code}: {r.text}")
@@ -241,7 +241,7 @@ def disable(
         print(f"Failed to connect to {host}")
         raise typer.Exit(1)
 
-    if r.status_code == requests.codes.ok:
+    if r.ok:
         print(f"Plugin {name} successfully disabled!")
     else:
         print(f"Status code {r.status_code}: {r.text}")

--- a/canvas_cli/apps/plugin/plugin.py
+++ b/canvas_cli/apps/plugin/plugin.py
@@ -204,8 +204,8 @@ def enable(
         print(f"Failed to connect to {host}")
         raise typer.Exit(1)
 
-    if r.status_code == requests.codes.no_content:
-        print(r.text)
+    if r.status_code == requests.codes.ok:
+        print(f"Plugin {name} successfully enabled!")
     else:
         print(f"Status code {r.status_code}: {r.text}")
         raise typer.Exit(1)
@@ -241,8 +241,8 @@ def disable(
         print(f"Failed to connect to {host}")
         raise typer.Exit(1)
 
-    if r.status_code == requests.codes.no_content:
-        print(r.text)
+    if r.status_code == requests.codes.ok:
+        print(f"Plugin {name} successfully disabled!")
     else:
         print(f"Status code {r.status_code}: {r.text}")
         raise typer.Exit(1)


### PR DESCRIPTION
Reagan noticed that enable/disable from the cli was returning non-zero exit codes. that's because we were looking for the wrong code on response (aka not `ok`). this pr fixes that.  

here is what enable/disable look like from the cli now:

<img width="841" alt="image" src="https://github.com/user-attachments/assets/c10bc430-9032-4f4e-a9c1-6b38d6a9dea4">
