### PR TITLE
Make banner alert effects have all optional params and validate on apply

### DIFF
--- a/canvas_sdk/commands/tests/test_utils.py
+++ b/canvas_sdk/commands/tests/test_utils.py
@@ -171,6 +171,7 @@ def raises_none_error_for_effect_method(
     missing_fields = [field for field in method_required_fields if getattr(cmd, field) is None]
     num_errs = len(missing_fields)
     assert f"{num_errs} validation error{'s' if num_errs > 1 else ''} for {cmd_name}" in e_msg
+
     for f in missing_fields:
         assert (
             f"Field '{f}' is required to {method.replace('_', ' ')} {cmd_name_article} {cmd_name} [type=missing, input_value=None, input_type=NoneType]"

--- a/canvas_sdk/effects/banner_alert/add_banner_alert.py
+++ b/canvas_sdk/effects/banner_alert/add_banner_alert.py
@@ -13,6 +13,7 @@ class AddBannerAlert(_BaseEffect):
 
     class Meta:
         effect_type = EffectType.ADD_BANNER_ALERT
+        apply_required_fields = ("patient_id", "key", "narrative", "placement", "intent")
 
     class Placement(Enum):
         CHART = "chart"
@@ -26,11 +27,11 @@ class AddBannerAlert(_BaseEffect):
         WARNING = "warning"
         ALERT = "alert"
 
-    patient_id: str
-    key: str
-    narrative: str = Field(max_length=90)
-    placement: list[Placement] = Field(min_length=1)
-    intent: Intent
+    patient_id: str | None = None
+    key: str | None = None
+    narrative: str | None = Field(max_length=90, default=None)
+    placement: list[Placement] | None = Field(min_length=1, default=None)
+    intent: Intent | None = None
     href: str | None = None
 
     @property
@@ -38,8 +39,8 @@ class AddBannerAlert(_BaseEffect):
         """The BannerAlert's values."""
         return {
             "narrative": self.narrative,
-            "placement": [p.value for p in self.placement],
-            "intent": self.intent.value,
+            "placement": [p.value for p in self.placement] if self.placement else None,
+            "intent": self.intent.value if self.intent else None,
             "href": self.href,
         }
 

--- a/canvas_sdk/effects/banner_alert/remove_banner_alert.py
+++ b/canvas_sdk/effects/banner_alert/remove_banner_alert.py
@@ -10,9 +10,10 @@ class RemoveBannerAlert(_BaseEffect):
 
     class Meta:
         effect_type = EffectType.REMOVE_BANNER_ALERT
+        apply_required_fields = ("patient_id", "key")
 
-    patient_id: str
-    key: str
+    patient_id: str | None = None
+    key: str | None = None
 
     @property
     def effect_payload(self) -> dict[str, Any]:


### PR DESCRIPTION
While creating the ProtocolCard effect, I leveraged the canvas_sdk base class that has validation before effects are applied. I realized that banner alerts weren't using that class yet, so this pr makes that change! it makes the experience very nice because instantiating the class does not require any specific params. 