### PR TITLE
Create CQM protocol subclass 

### DIFF
--- a/canvas_cli/apps/plugin/plugin.py
+++ b/canvas_cli/apps/plugin/plugin.py
@@ -1,6 +1,7 @@
 import importlib
 import json
 import os
+import sys
 import tarfile
 import tempfile
 from pathlib import Path
@@ -75,11 +76,10 @@ def _get_protocols_with_new_cqm_properties(
     protocol_classes: List[dict[str, Any]]
 ) -> List[dict[str, Any]] | None:
     """Extract the meta properties of any ClinicalQualityMeasure Protocols included in the plugin if they have changed."""
-    cwd = os.getcwd().split("/")[-1]
 
     def get_new_meta_properties(protocol_class: dict[str, str]) -> dict[str, str]:
         mod, classname = protocol_class["class"].split(":")
-        module = importlib.import_module(f"{cwd}.{mod}")
+        module = importlib.import_module(mod)
         _class = getattr(module, classname)
         if not hasattr(_class, "_meta") or _class._meta() == protocol_class.get("meta"):
             return {}
@@ -332,6 +332,7 @@ def validate_manifest(
     try:
         manifest_json = json.loads(manifest.read_text())
 
+        sys.path.append(str(plugin_name.parent.absolute()))
         if new_protocols := _get_protocols_with_new_cqm_properties(
             manifest_json.get("components", {}).get("protocols", [])
         ):

--- a/canvas_cli/apps/plugin/plugin.py
+++ b/canvas_cli/apps/plugin/plugin.py
@@ -1,8 +1,10 @@
+import importlib
 import json
+import os
 import tarfile
 import tempfile
 from pathlib import Path
-from typing import Optional
+from typing import Any, List, Optional
 from urllib.parse import urljoin
 
 import requests
@@ -67,6 +69,31 @@ def _get_name_from_metadata(host: str, token: str, package: Path) -> Optional[st
 
     metadata = metadata_response.json()
     return metadata.get("name")
+
+
+def _get_protocols_with_new_cqm_properties(
+    protocol_classes: List[dict[str, Any]]
+) -> List[dict[str, Any]] | None:
+    """Extract the meta properties of any ClinicalQualityMeasure Protocols included in the plugin if they have changed."""
+    cwd = os.getcwd().split("/")[-1]
+
+    def get_new_meta_properties(protocol_class: dict[str, str]) -> dict[str, str]:
+        mod, classname = protocol_class["class"].split(":")
+        module = importlib.import_module(f"{cwd}.{mod}")
+        _class = getattr(module, classname)
+        if not hasattr(_class, "_meta") or _class._meta() == protocol_class.get("meta"):
+            return {}
+        return {"meta": _class._meta()}
+
+    has_updates = False
+    new_protocols = []
+    for p in protocol_classes:
+        m = get_new_meta_properties(p)
+        new_protocols.append(p | m)
+        if m:
+            has_updates = True
+
+    return new_protocols if has_updates else None
 
 
 def get_base_plugin_template_path() -> Path:
@@ -304,6 +331,17 @@ def validate_manifest(
 
     try:
         manifest_json = json.loads(manifest.read_text())
+
+        if new_protocols := _get_protocols_with_new_cqm_properties(
+            manifest_json.get("components", {}).get("protocols", [])
+        ):
+            print(
+                f"Updating the CANVAS_MANIFEST.json file for {plugin_name} with CQM meta properties"
+            )
+            manifest_json["components"]["protocols"] = new_protocols
+            manifest.write_text(json.dumps(manifest_json))
+            manifest_json = json.loads(manifest.read_text())
+
     except json.JSONDecodeError:
         print("There was a problem loading the manifest file, please ensure it's valid JSON")
         raise typer.Abort()

--- a/canvas_cli/utils/validators/manifest_schema.py
+++ b/canvas_cli/utils/validators/manifest_schema.py
@@ -61,6 +61,7 @@ manifest_schema = {
                 "properties": {
                     "class": {"type": "string"},
                     "description": {"type": "string"},
+                    "meta": {"type": "object"},
                     "data_access": {
                         "type": "object",
                         "properties": {

--- a/canvas_sdk/protocols/clinical_quality_measure.py
+++ b/canvas_sdk/protocols/clinical_quality_measure.py
@@ -1,0 +1,41 @@
+from typing import Any
+
+from canvas_sdk.protocols.base import BaseProtocol
+
+
+class ClinicalQualityMeasure(BaseProtocol):
+    """
+    The class that ClinicalQualityMeasure protocols inherit from.
+    """
+
+    class Meta:
+        title: str = ""
+        identifiers: list[str] = []
+        description: str = ""
+        information: str = ""
+        references: list[str] = []
+        types: list[str] = []
+        authors: list[str] = []
+        show_in_chart: bool = True
+        show_in_population: bool = True
+        can_be_snoozed: bool = True
+        is_abstract: bool = False
+
+    @classmethod
+    def _meta(cls) -> dict[str, Any]:
+        """
+        Meta properties of the protocol in dictionary form.
+        """
+        base_meta = {
+            k: v for k, v in ClinicalQualityMeasure.Meta.__dict__.items() if not k.startswith("__")
+        }
+        class_meta = {k: v for k, v in cls.Meta.__dict__.items() if not k.startswith("__")}
+
+        return base_meta | class_meta
+
+    @classmethod
+    def protocol_key(cls) -> str:
+        """
+        External key used to identify the protocol.
+        """
+        return cls.__name__


### PR DESCRIPTION
https://canvasmedical.atlassian.net/browse/KOALA-1858

This PR creates the base class for ClinicalQualityMeasures that will be uploaded via plugins. It is a subclass of the Protocol class and adds the necessary meta properties that will be used in home-app. 

In order to get these meta properties over to home-app, i decided to edit the manifest file to include the cqm properties for any protocols that use this base class. this file editing only happens if what's in the meanifest file does not match what's in the protocol. that way the developer does not need to worry about keeping them in sync. 

still to do:
- [ ] unit tests
- [ ] integration tests (completed in separate pr after home-app pr is merged)