### PR TITLE
fix: fix settings error in canvas-cli

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ packages = [
   {include = "canvas_generated"},
   {include = "canvas_sdk"},
   {include = "logger"},
-  {include = "settings"}
+  {include = "settings.py"}
 ]
 readme = "README.md"
 version = "0.2.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,8 @@ packages = [
   {include = "canvas_cli"},
   {include = "canvas_generated"},
   {include = "canvas_sdk"},
-  {include = "logger"}
+  {include = "logger"},
+  {include = "settings"}
 ]
 readme = "README.md"
 version = "0.2.10"


### PR DESCRIPTION
The canvas-cli is erroring out when using because of not finding the settings file. When instantiating a command (i.e. `canvas init`), the following error is thrown:

```
ModuleNotFoundError: No module named 'settings'
```

This PR adds the settings file to `pyproject.toml` so that it can be found and referenced in the Django setup process. 

<!-- ## Title Guidelines

A title always has a prefix and a subject.

### Prefix
Make sure the title is prefixed with one of the following:

| Prefix | When to use |
|--------|-------------|
| `feat:`     | New feature |
| `fix:`      | Bug fix |
| `docs:`     | Documentation only changes |
| `style:`    | Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc) |
| `refactor:` | Code changes that neither fixes a bug nor adds a feature |
| `perf:`     | Code change that improves performance |
| `test:`     | Adding missing or correcting existing tests |
| `chore:`    | Changes to the build process or auxiliary tools and libraries such as documentation generation, ci, etc |

### Subject

Ensure the subject contains succinct description of the change.
* Use the imperative, present tense: "change", not "changed" nor "changes"
* Don’t capitalize first letter
* No dot (.) at the end
-->
