### PR TITLE
fix: improve error handling for canvas_cli install command

### DIFF
--- a/canvas_cli/apps/plugin/plugin.py
+++ b/canvas_cli/apps/plugin/plugin.py
@@ -197,11 +197,12 @@ def install(
     if r.status_code == requests.codes.created:
         print(f"Plugin {plugin_name} successfully installed!")
 
-    # If we got a bad_request, means there's a duplicate plugin and install can't handle that.
+    # If we got a conflict, means there's a duplicate plugin and install can't handle that.
     # So we need to get the plugin-name from the package and call `update` directly
-    elif r.status_code == requests.codes.bad_request and (
+    elif r.status_code == requests.codes.conflict and (
         package_name := _get_name_from_metadata(host, token, built_package_path)
     ):
+        print(f"Plugin {package_name} already exists, updating instead...")
         update(package_name, built_package_path, is_enabled=True, host=host)
     else:
         print(f"Status code {r.status_code}: {r.text}")


### PR DESCRIPTION
[KOALA-2338](https://canvasmedical.atlassian.net/browse/KOALA-2338)

Depends on: https://github.com/canvas-medical/canvas/pull/17042

[KOALA-2338]: https://canvasmedical.atlassian.net/browse/KOALA-2338?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ