### PR TITLE
feat: add an inelegant way to identify a command's anchor object

### DIFF
--- a/canvas_sdk/v1/data/command.py
+++ b/canvas_sdk/v1/data/command.py
@@ -25,3 +25,5 @@ class Command(models.Model):
     schema_key = models.TextField()
     data = models.JSONField()
     origination_source = models.CharField()
+    anchor_object_type = models.CharField()
+    anchor_object_dbid = models.BigIntegerField()


### PR DESCRIPTION
Makes it possible (but inelegant) to find some records associated with commands.

Internal tracking: https://canvasmedical.atlassian.net/browse/KOALA-2407