### PR TITLE
fix: send sighup after installing when synchronizer boots, remove load com…

### DIFF
--- a/plugin_runner/plugin_runner.py
+++ b/plugin_runner/plugin_runner.py
@@ -193,7 +193,6 @@ class PluginRunner(PluginRunnerServicer):
     ) -> AsyncGenerator[ReloadPluginsResponse, None]:
         """This is invoked when we need to reload plugins."""
         try:
-            load_plugins()
             publish_message({"action": "restart"})
         except ImportError:
             yield ReloadPluginsResponse(success=False)

--- a/plugin_runner/plugin_synchronizer.py
+++ b/plugin_runner/plugin_synchronizer.py
@@ -48,6 +48,8 @@ def main() -> None:
     try:
         print("plugin-synchronizer: installing plugins after web container start")
         install_plugins()
+        print("plugin-synchronizer: sending SIGHUP to plugin-runner")
+        check_output(["circusctl", "signal", "plugin-runner", "1"], cwd="/app", stderr=STDOUT)
     except CalledProcessError as e:
         print("plugin-synchronizer: `install_plugins` failed:", e)
 

--- a/plugin_runner/plugin_synchronizer.py
+++ b/plugin_runner/plugin_synchronizer.py
@@ -69,7 +69,7 @@ def main() -> None:
         data = pickle.loads(message.get("data", pickle.dumps({})))
 
         if "action" not in data or "client_id" not in data:
-            return
+            continue
 
         if data["action"] == "restart":
             # Run the plugin installer process

--- a/plugin_runner/tests/test_plugin_runner.py
+++ b/plugin_runner/tests/test_plugin_runner.py
@@ -191,17 +191,3 @@ async def test_reload_plugins_event_handler_successfully_loads_plugins(
     assert len(result) == 1
     assert result[0].success is True
     assert "example_plugin:example_plugin.protocols.my_protocol:Protocol" in LOADED_PLUGINS
-
-
-@pytest.mark.asyncio
-async def test_reload_plugins_import_error(plugin_runner: PluginRunner) -> None:
-    """Test ReloadPlugins response when an ImportError occurs."""
-    request = ReloadPluginsRequest()
-
-    with patch("plugin_runner.plugin_runner.load_plugins", side_effect=ImportError):
-        responses = []
-        async for response in plugin_runner.ReloadPlugins(request, None):
-            responses.append(response)
-
-        assert len(responses) == 1
-        assert responses[0].success is False


### PR DESCRIPTION
Temporary fix to address the problem reported by Patina in which plugins fail to run reliably after a home-app deploy.

The failure mode is a race condition in which plugins may be loaded into memory before the synchronizer has finished installing them on the file system. This solution causes the synchronizer to signal the runner to restart after installation, at which time the runner will load the plugins. 

This solution results in some wasted work because the runner starts after the deploy and is shortly thereafter restarted. A better solution will embed the installation work into the plugin runner so that plugins can be loaded into memory after installation without requiring a restart. That work will be in a different changeset.