### PR TITLE
chore: fix python warnings

### DIFF
--- a/canvas_cli/templates/plugins/default/{{ cookiecutter.__project_slug }}/protocols/my_protocol.py
+++ b/canvas_cli/templates/plugins/default/{{ cookiecutter.__project_slug }}/protocols/my_protocol.py
@@ -46,7 +46,7 @@ class Protocol(BaseProtocol):
 
         # Craft a payload to be returned with the effect(s).
         payload = {
-            "note": {"uuid": self.context["note"]["uuid"]},
+            "note": {"uuid": self.event.context["note"]["uuid"]},
             "data": {"narrative": self.NARRATIVE_STRING},
         }
 

--- a/canvas_sdk/handlers/action_button.py
+++ b/canvas_sdk/handlers/action_button.py
@@ -42,13 +42,16 @@ class ActionButton(BaseHandler):
             EventType.SHOW_NOTE_HEADER_BUTTON,
             EventType.SHOW_NOTE_FOOTER_BUTTON,
         ):
-            if self.context["location"].lower() == self.BUTTON_LOCATION.value and self.visible():
+            if (
+                self.event.context["location"].lower() == self.BUTTON_LOCATION.value
+                and self.visible()
+            ):
                 return [ShowButtonEffect(key=self.BUTTON_KEY, title=self.BUTTON_TITLE).apply()]
             else:
                 return []
         elif (
             self.event.type == EventType.ACTION_BUTTON_CLICKED
-            and self.context["key"] == self.BUTTON_KEY
+            and self.event.context["key"] == self.BUTTON_KEY
         ):
             return self.handle()
 

--- a/canvas_sdk/handlers/application.py
+++ b/canvas_sdk/handlers/application.py
@@ -14,7 +14,7 @@ class Application(BaseHandler, ABC):
         """Handle the application events."""
         match self.event.type:
             case EventType.APPLICATION__ON_OPEN:
-                return [self.on_open()] if self.target == self.identifier else []
+                return [self.on_open()] if self.event.target.id == self.identifier else []
             case _:
                 return []
 

--- a/canvas_sdk/handlers/cron_task.py
+++ b/canvas_sdk/handlers/cron_task.py
@@ -29,7 +29,7 @@ class CronTask(BaseHandler):
         """
         if not self.SCHEDULE:
             raise ValueError("You must set a SCHEDULE.")
-        datetime = arrow.get(self.target).datetime
+        datetime = arrow.get(self.event.target.id).datetime
         if datetime in Cron(self.SCHEDULE):
             return self.execute()
         return []

--- a/canvas_sdk/protocols/clinical_quality_measure.py
+++ b/canvas_sdk/protocols/clinical_quality_measure.py
@@ -94,7 +94,7 @@ class ClinicalQualityMeasure(BaseProtocol):
 
         def patient_id(model: "type[Model]") -> str:
             if model == Patient:
-                return self.target
+                return self.event.target.id
             else:
                 return cast(
                     str,

--- a/plugin_runner/plugin_installer.py
+++ b/plugin_runner/plugin_installer.py
@@ -97,7 +97,7 @@ def _extract_rows_to_dict(rows: list) -> dict[str, PluginAttributes]:
 
 
 @contextmanager
-def download_plugin(plugin_package: str) -> Generator:
+def download_plugin(plugin_package: str) -> Generator[Path, None, None]:
     """Download the plugin package from the S3 bucket."""
     method = "GET"
     host = f"s3-{settings.AWS_REGION}.amazonaws.com"

--- a/plugin_runner/tests/test_application.py
+++ b/plugin_runner/tests/test_application.py
@@ -6,7 +6,7 @@ from canvas_sdk.events import Event, EventRequest, EventType
 from canvas_sdk.handlers.application import Application
 
 
-class TestApplication(Application):
+class ExampleApplication(Application):
     """A concrete implementation of the Application class for testing."""
 
     def on_open(self) -> Effect:
@@ -15,9 +15,9 @@ class TestApplication(Application):
 
 
 @pytest.fixture
-def app_instance(event: Event) -> TestApplication:
+def app_instance(event: Event) -> ExampleApplication:
     """Provide an instance of the TestApplication with a mocked event."""
-    app = TestApplication(event)
+    app = ExampleApplication(event)
     return app
 
 
@@ -25,7 +25,7 @@ def test_compute_event_not_targeted() -> None:
     """Test that compute filters out events not targeted for the app."""
     request = EventRequest(type=EventType.APPLICATION__ON_OPEN, target="some_identifier")
     event = Event(request)
-    app = TestApplication(event)
+    app = ExampleApplication(event)
 
     result = app.compute()
 
@@ -36,10 +36,10 @@ def test_compute_event_targeted() -> None:
     """Test that compute processes events targeted for the app."""
     request = EventRequest(
         type=EventType.APPLICATION__ON_OPEN,
-        target=f"{TestApplication.__module__}:{TestApplication.__qualname__}",
+        target=f"{ExampleApplication.__module__}:{ExampleApplication.__qualname__}",
     )
     event = Event(request)
-    app = TestApplication(event)
+    app = ExampleApplication(event)
     result = app.compute()
 
     assert len(result) == 1, "Expected a single effect if the event target is the app identifier"
@@ -48,13 +48,13 @@ def test_compute_event_targeted() -> None:
 
 def test_identifier_property() -> None:
     """Test the identifier property of the Application class."""
-    expected_identifier = f"{TestApplication.__module__}:{TestApplication.__qualname__}"
+    expected_identifier = f"{ExampleApplication.__module__}:{ExampleApplication.__qualname__}"
     request = EventRequest(
         type=EventType.APPLICATION__ON_OPEN,
-        target=f"{TestApplication.__module__}:{TestApplication.__qualname__}",
+        target=f"{ExampleApplication.__module__}:{ExampleApplication.__qualname__}",
     )
     event = Event(request)
-    app = TestApplication(event)
+    app = ExampleApplication(event)
 
     assert app.identifier == expected_identifier, "The identifier property is incorrect"
 

--- a/plugin_runner/tests/test_plugin_installer.py
+++ b/plugin_runner/tests/test_plugin_installer.py
@@ -83,8 +83,19 @@ def test_plugin_installation_from_tarball(mocker: MockerFixture) -> None:
     tarball_2 = _create_tarball("plugin2")
 
     mocker.patch("plugin_runner.plugin_installer.enabled_plugins", return_value=mock_plugins)
+
+    def mock_download_plugin(package: str) -> MagicMock:
+        mock_context = mocker.Mock()
+        if package == "plugins/plugin1.tar.gz":
+            mock_context.__enter__ = mocker.Mock(return_value=tarball_1)
+        elif package == "plugins/plugin2.tar":
+            mock_context.__enter__ = mocker.Mock(return_value=tarball_2)
+        mock_context.__exit__ = mocker.Mock(return_value=None)
+        return mock_context
+
     mocker.patch(
-        "plugin_runner.plugin_installer.download_plugin", side_effect=[tarball_1, tarball_2]
+        "plugin_runner.plugin_installer.download_plugin",
+        side_effect=mock_download_plugin,
     )
 
     install_plugins()

--- a/test-plugins/my_first_plugin/protocols/protocol.py
+++ b/test-plugins/my_first_plugin/protocols/protocol.py
@@ -17,7 +17,7 @@ class Protocol(BaseProtocol):
         """This method gets called when an event of the type RESPONDS_TO is fired."""
         log.info(self.NARRATIVE_STRING)
         payload = {
-            "note": {"uuid": self.context["note"]["uuid"]},
+            "note": {"uuid": self.event.context["note"]["uuid"]},
             "data": {"narrative": self.NARRATIVE_STRING},
         }
 


### PR DESCRIPTION
This PR fixes the following deprecation warnings:

1. `plugin_runner/tests/test_application.py`
```
PytestCollectionWarning: cannot collect test class 'TestApplication' because it has a __init__ constructor (from: plugin_runner/tests/test_application.py)
    class TestApplication(Application):
```

2. `plugin_runner/tests/test_plugin_installer.py::test_plugin_installation_from_tarball`
```
DeprecationWarning: pathlib.Path.__enter__() is deprecated and scheduled for removal in Python 3.13; Path objects as a context manager is a no-op
    with download_plugin(attributes["package"]) as plugin_file_path:
```

3. `plugin_runner/tests/test_application.py::test_compute_event_not_targeted`
```
DeprecatedWarning: target is deprecated as of 0.11.0 and will be removed in 1.0.0. Use 'event.target.id' directly instead
    return [self.on_open()] if self.target == self.identifier else []
```