### PR TITLE
fix: use super().get_queryset() in CommittableModelManager

### DIFF
--- a/canvas_sdk/v1/data/base.py
+++ b/canvas_sdk/v1/data/base.py
@@ -16,7 +16,8 @@ class CommittableModelManager(models.Manager):
     def get_queryset(self) -> "CommittableQuerySet":
         """Return a queryset that filters out deleted objects."""
         # TODO: Should we just filter these out at the view level?
-        return CommittableQuerySet(self.model, using=self._db).filter(deleted=False)
+        qs = super().get_queryset()
+        return cast("CommittableQuerySet", qs.filter(deleted=False))
 
 
 class CommittableQuerySet(models.QuerySet):


### PR DESCRIPTION
https://canvasmedical.atlassian.net/browse/KOALA-2464

Issue: Calling `Observation.objects.find(Weight)` is failing with ` AttributeError: 'CommittableQuerySet' object has no attribute 'find'`  (https://github.com/canvas-medical/canvas-plugins/issues/292) 

What's happening is that the `CommittableModelManager`'s `get_queryset()` method was explicitly returning a `CommittableQuerySet`, which means that even if we're instantiating the manager with a `from_queryset()` (i.e., `CommittableModelManager.from_queryset(ObservationQuerySet)()`), the queryset isn't being used.

The change here simply makes the `CommittableModelManager::get_queryset` call super to make sure we're pulling the qs we want. 

The problem with this is that we need to make sure every qs passed to the `from_queryset()` instantiated inherits from `CommittableQuerySet`, as that will no longer be taken as a default. 
It looks like we're already doing this (`ValueSetLookupQuerySet`, and `ValueSetLookupByNameQuerySet` already inherit from `CommittableQuerySet`), so this whole issue was probably just an oversight. 


<!-- ## Title Guidelines

A title always has a prefix and a subject.

### Prefix
Make sure the title is prefixed with one of the following:

| Prefix | When to use |
|--------|-------------|
| `feat:`     | New feature |
| `fix:`      | Bug fix |
| `docs:`     | Documentation only changes |
| `style:`    | Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc) |
| `refactor:` | Code changes that neither fixes a bug nor adds a feature |
| `perf:`     | Code change that improves performance |
| `test:`     | Adding missing or correcting existing tests |
| `chore:`    | Changes to the build process or auxiliary tools and libraries such as documentation generation, ci, etc |

### Subject

Ensure the subject contains succinct description of the change.
* Use the imperative, present tense: "change", not "changed" nor "changes"
* Don’t capitalize first letter
* No dot (.) at the end
-->
