### PR TITLE
chore(metrics): log nr event handlers

### DIFF
--- a/canvas_sdk/utils/stats.py
+++ b/canvas_sdk/utils/stats.py
@@ -1,5 +1,8 @@
+from datetime import timedelta
 from time import time
 from typing import Any
+
+from statsd.defaults.env import statsd as default_statsd_client
 
 
 def get_duration_ms(start_time: float) -> int:
@@ -26,3 +29,35 @@ def tags_to_line_protocol(tags: dict[str, Any]) -> str:
         f"{tag_name}={str(tag_value).translate(LINE_PROTOCOL_TRANSLATION)}"
         for tag_name, tag_value in tags.items()
     )
+
+
+class StatsDClientProxy:
+    """Proxy for a StatsD client."""
+
+    def __init__(self) -> None:
+        self.client = default_statsd_client
+
+    def gauge(self, metric_name: str, value: float, tags: dict[str, str]) -> None:
+        """Sends a gauge metric to StatsD with properly formatted tags.
+
+        Args:
+            metric_name (str): The name of the metric.
+            value (float): The value to report.
+            tags (dict[str, str]): Dictionary of tags to attach to the metric.
+        """
+        statsd_tags = tags_to_line_protocol(tags)
+        self.client.gauge(f"{metric_name},{statsd_tags}", value)
+
+    def timing(self, metric_name: str, delta: float | timedelta, tags: dict[str, str]) -> None:
+        """Sends a timing metric to StatsD with properly formatted tags.
+
+        Args:
+            metric_name (str): The name of the metric.
+            delta (float | timedelta): The value to report.
+            tags (dict[str, str]): Dictionary of tags to attach to the metric.
+        """
+        statsd_tags = tags_to_line_protocol(tags)
+        self.client.timing(f"{metric_name},{statsd_tags}", delta)
+
+
+statsd_client = StatsDClientProxy()


### PR DESCRIPTION
[KOALA-2564](https://canvasmedical.atlassian.net/browse/KOALA-2564)

This PR logs the number of event handlers per event whenever plugins are reloaded. This enables the ability to run queries like the following in Grafana:

```sql
SELECT event, customer, LAST(value) AS nr_handlers  FROM "plugins_event_nr_handlers" GROUP BY event, customer
```

| Time                | Event                                 | Customer | Nr. Handlers |
|---------------------|--------------------------------------|----------|--------------|
| 1739810042000000000 | PLAN_COMMAND__POST_INSERTED_INTO_NOTE | local    | 1            |
| 1739810042000000000 | VITAL_SIGN_UPDATED                   | local    | 0            |





[KOALA-2564]: https://canvasmedical.atlassian.net/browse/KOALA-2564?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ