### PR TITLE
refactor: moved construction of SimpleAPI route registry to __init_subclass__

### DIFF
--- a/canvas_sdk/handlers/simple_api/api.py
+++ b/canvas_sdk/handlers/simple_api/api.py
@@ -114,8 +114,8 @@ class SimpleAPIBase(BaseHandler, ABC):
         super().__init_subclass__(**kwargs)
 
         # Build the registry of routes so that requests can be routed to the correct handler. This
-        # is done by iterating over the methods on the class instance and looking for methods that
-        # have been marked by the handler decorators (get, post, etc.).
+        # is done by iterating over the methods on the class and looking for methods that have been
+        # marked by the handler decorators (get, post, etc.).
         cls._ROUTES = {}
         for attr in cls.__dict__.values():
             if callable(attr) and (route := getattr(attr, "route", None)):

--- a/canvas_sdk/handlers/simple_api/api.py
+++ b/canvas_sdk/handlers/simple_api/api.py
@@ -262,7 +262,10 @@ class SimpleAPI(SimpleAPIBase, ABC):
 
     @classmethod
     def _path_prefix(cls) -> str:
-        return getattr(cls, "PREFIX", "")
+        # getattr needs a default else it will raise an exception. We also need to ensure that the
+        # final value is a string if the user specifies "None" as the prefix because this value gets
+        # prepended to the URL path
+        return getattr(cls, "PREFIX", "") or ""
 
 
 class SimpleAPIRoute(SimpleAPIBase, ABC):

--- a/canvas_sdk/handlers/simple_api/api.py
+++ b/canvas_sdk/handlers/simple_api/api.py
@@ -262,7 +262,7 @@ class SimpleAPI(SimpleAPIBase, ABC):
 
     @classmethod
     def _path_prefix(cls) -> str:
-        return getattr(cls, "PREFIX", None) or ""
+        return getattr(cls, "PREFIX", "")
 
 
 class SimpleAPIRoute(SimpleAPIBase, ABC):


### PR DESCRIPTION
<!-- ## Title Guidelines

A title always has a prefix and a subject.

### Prefix
Make sure the title is prefixed with one of the following:

| Prefix | When to use |
|--------|-------------|
| `feat:`     | New feature |
| `fix:`      | Bug fix |
| `docs:`     | Documentation only changes |
| `style:`    | Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc) |
| `refactor:` | Code changes that neither fixes a bug nor adds a feature |
| `perf:`     | Code change that improves performance |
| `test:`     | Adding missing or correcting existing tests |
| `chore:`    | Changes to the build process or auxiliary tools and libraries such as documentation generation, ci, etc |

### Subject

Ensure the subject contains succinct description of the change.
* Use the imperative, present tense: "change", not "changed" nor "changes"
* Don’t capitalize first letter
* No dot (.) at the end
-->

It's more appropriate for the SimpleAPI route registry to live at the class level rather than the instance level. The changes in this PR moves construction of the route registry to `__init_subclass__`.