### PR TITLE
refactor: change SimpleAPI request headers and query parameters to be a multidict structure

### DIFF
--- a/canvas_sdk/handlers/simple_api/api.py
+++ b/canvas_sdk/handlers/simple_api/api.py
@@ -6,9 +6,7 @@ from collections.abc import Callable
 from functools import cached_property
 from http import HTTPStatus
 from typing import Any, TypeVar
-from urllib.parse import parse_qs
-
-from requests.structures import CaseInsensitiveDict
+from urllib.parse import parse_qsl
 
 from canvas_sdk.effects import Effect, EffectType
 from canvas_sdk.effects.simple_api import JSONResponse, Response
@@ -19,6 +17,7 @@ from plugin_runner.exceptions import PluginError
 
 from .exceptions import AuthenticationError, InvalidCredentialsError
 from .security import Credentials
+from .tools import CaseInsensitiveMultiDict, MultiDict, separate_headers
 
 # TODO: Routing by path regex?
 # TODO: Support multipart/form-data by adding helpers to the request class
@@ -38,9 +37,8 @@ class Request:
         self.path = event.context["path"]
         self.query_string = event.context["query_string"]
         self._body = event.context["body"]
-        self.headers: CaseInsensitiveDict = CaseInsensitiveDict(event.context["headers"])
-
-        self.query_params = parse_qs(self.query_string)
+        self.headers = CaseInsensitiveMultiDict(separate_headers(event.context["headers"]))
+        self.query_params = MultiDict(parse_qsl(self.query_string))
         self.content_type = self.headers.get("Content-Type")
 
     @cached_property

--- a/canvas_sdk/handlers/simple_api/tools.py
+++ b/canvas_sdk/handlers/simple_api/tools.py
@@ -1,0 +1,106 @@
+from collections.abc import ItemsView, Iterable, Iterator, KeysView, Mapping, ValuesView
+from typing import Any, TypeVar, overload
+
+KeyType = TypeVar("KeyType")
+ValueType = TypeVar("ValueType")
+
+
+class MultiDict(Mapping[KeyType, ValueType]):
+    """Immutable key-value data structure that can store multiple values per key."""
+
+    def __init__(self, items: Iterable[tuple[KeyType, ValueType]]) -> None:
+        self._dict: dict[KeyType, ValueType] = {}
+        self._items = []
+        for key, value in items:
+            if key not in self._dict:
+                self._dict[key] = value
+            self._items.append((key, value))
+
+    def __len__(self) -> int:
+        return len(self._dict)
+
+    def __iter__(self) -> Iterator[KeyType]:
+        return iter(self.keys())
+
+    def __getitem__(self, key: KeyType, /) -> ValueType:
+        return self._dict[key]
+
+    def __contains__(self, x: object, /) -> bool:
+        return x in self._dict
+
+    @overload
+    def get(self, __key: KeyType, /) -> Any: ...
+
+    @overload
+    def get(self, __key: KeyType, /, __default: Any = None) -> Any: ...
+
+    def get(self, __key: KeyType, __default: Any | None = None) -> Any:
+        """Get a value for a key if present, and if not, return the default value."""
+        return self._dict.get(__key, __default)
+
+    def get_list(self, __key: KeyType) -> list[ValueType]:
+        """Get the values for a key if present, and if not, return an empty list."""
+        return [value for key, value in self._items if key == __key]
+
+    def items(self) -> ItemsView[KeyType, ValueType]:
+        """Return an items view of the dict."""
+        return self._dict.items()
+
+    def multi_items(self) -> Iterable[tuple[KeyType, ValueType]]:
+        """Return an iterable of tuples of the keys and values in the dict."""
+        yield from self._items
+
+    def keys(self) -> KeysView[KeyType]:
+        """Return a keys view of the dict."""
+        return self._dict.keys()
+
+    def __reversed__(self) -> Iterator[KeyType]:
+        return iter(reversed(list(self.keys())))
+
+    def values(self) -> ValuesView[ValueType]:
+        """Return a values view of the dict."""
+        return self._dict.values()
+
+
+class CaseInsensitiveMultiDict(MultiDict[str, ValueType]):
+    """
+    Case-insensitive immutable key-value data structure that can store multiple values per key.
+
+    Keys in the dict are interpreted in a case-insensitive manner.
+    """
+
+    def __init__(self, items: Iterable[tuple[str, ValueType]]) -> None:
+        super().__init__(((key.lower(), value) for key, value in items))
+
+    def __getitem__(self, key: str, /) -> ValueType:
+        return super().__getitem__(key.lower())
+
+    def __contains__(self, x: object, /) -> bool:
+        if not isinstance(x, str):
+            return False
+
+        return super().__contains__(x.lower())
+
+    def get(self, __key: KeyType, __default: Any | None = None) -> Any:
+        """Get a value for a key if present, and if not, return the default value."""
+        if not isinstance(__key, str):
+            return __default
+
+        return super().get(__key.lower(), __default)
+
+    def get_list(self, __key: str) -> list[ValueType]:
+        """Get the values for a key if present, and if not, return an empty list."""
+        return super().get_list(__key.lower())
+
+
+def separate_headers(headers: Mapping[str, str]) -> list[tuple[str, str]]:
+    """
+    Break apart header values containing comma-separated lists into discrete key-value pairs.
+    """
+    headers_list = []
+
+    for key, values in headers.items():
+        for value in values.split(","):
+            headers_list.append((key, value.strip()))
+
+    return headers_list

--- a/canvas_sdk/handlers/simple_api/tools.py
+++ b/canvas_sdk/handlers/simple_api/tools.py
@@ -2,16 +2,16 @@ from collections.abc import ItemsView, Iterable, Iterator, KeysView, Mapping, Va
 from typing import Any, TypeVar, overload
 
 KeyType = TypeVar("KeyType")
-ValueType = TypeVar("ValueType")
+ValueType = TypeVar("ValueType", covariant=True)
 
 
 class MultiDict(Mapping[KeyType, ValueType]):
     """Immutable key-value data structure that can store multiple values per key."""
 
-    def __init__(self, items: Iterable[tuple[KeyType, ValueType]]) -> None:
+    def __init__(self, items: Iterable[tuple[KeyType, ValueType]] | None = None) -> None:
         self._dict: dict[KeyType, ValueType] = {}
         self._items = []
-        for key, value in items:
+        for key, value in items or ():
             if key not in self._dict:
                 self._dict[key] = value
             self._items.append((key, value))
@@ -61,6 +61,12 @@ class MultiDict(Mapping[KeyType, ValueType]):
         """Return a values view of the dict."""
         return self._dict.values()
 
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, MultiDict):
+            return NotImplemented
+
+        return other._items == self._items
+
 
 class CaseInsensitiveMultiDict(MultiDict[str, ValueType]):
     """
@@ -69,8 +75,8 @@ class CaseInsensitiveMultiDict(MultiDict[str, ValueType]):
     Keys in the dict are interpreted in a case-insensitive manner.
     """
 
-    def __init__(self, items: Iterable[tuple[str, ValueType]]) -> None:
-        super().__init__(((key.lower(), value) for key, value in items))
+    def __init__(self, items: Iterable[tuple[str, ValueType]] | None = None) -> None:
+        super().__init__(((key.lower(), value) for key, value in items or ()))
 
     def __getitem__(self, key: str, /) -> ValueType:
         return super().__getitem__(key.lower())
@@ -88,8 +94,11 @@ class CaseInsensitiveMultiDict(MultiDict[str, ValueType]):
 
         return super().get(__key.lower(), __default)
 
-    def get_list(self, __key: str) -> list[ValueType]:
+    def get_list(self, __key: KeyType) -> list[ValueType]:
         """Get the values for a key if present, and if not, return an empty list."""
+        if not isinstance(__key, str):
+            return []
+
         return super().get_list(__key.lower())
 
 


### PR DESCRIPTION
<!-- ## Title Guidelines

A title always has a prefix and a subject.

### Prefix
Make sure the title is prefixed with one of the following:

| Prefix | When to use |
|--------|-------------|
| `feat:`     | New feature |
| `fix:`      | Bug fix |
| `docs:`     | Documentation only changes |
| `style:`    | Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc) |
| `refactor:` | Code changes that neither fixes a bug nor adds a feature |
| `perf:`     | Code change that improves performance |
| `test:`     | Adding missing or correcting existing tests |
| `chore:`    | Changes to the build process or auxiliary tools and libraries such as documentation generation, ci, etc |

### Subject

Ensure the subject contains succinct description of the change.
* Use the imperative, present tense: "change", not "changed" nor "changes"
* Don’t capitalize first letter
* No dot (.) at the end
-->

For consistency and user-interface purposes, having headers, query parameters, and form subparts represented as a "multidict" (i.e. a dict that can have multiple values per key) is a common approach.

Most of the time, developers would interact with these structures as if they were a regular Python dict, but developers that want to access additional values with a given key name would be able to.

This change is not backward compatible, and would require customer communication.