### PR TITLE
feat: add banner alerts to data module

### DIFF
--- a/canvas_sdk/v1/data/__init__.py
+++ b/canvas_sdk/v1/data/__init__.py
@@ -1,6 +1,7 @@
 from .allergy_intolerance import AllergyIntolerance, AllergyIntoleranceCoding
 from .appointment import Appointment, AppointmentExternalIdentifier
 from .assessment import Assessment
+from .banner_alert import BannerAlert
 from .billing import BillingLineItem, BillingLineItemModifier
 from .care_team import CareTeamMembership, CareTeamRole
 from .command import Command
@@ -59,6 +60,7 @@ __all__ = [
     "AllergyIntolerance",
     "AllergyIntoleranceCoding",
     "Assessment",
+    "BannerAlert",
     "BillingLineItem",
     "BillingLineItemModifier",
     "CanvasUser",

--- a/canvas_sdk/v1/data/banner_alert.py
+++ b/canvas_sdk/v1/data/banner_alert.py
@@ -1,0 +1,27 @@
+from django.contrib.postgres.fields import ArrayField
+from django.db import models
+
+
+class BannerAlert(models.Model):
+    """BannerAlert."""
+
+    class Meta:
+        managed = False
+        db_table = "canvas_sdk_data_api_banneralert_001"
+
+    dbid = models.BigIntegerField(db_column="dbid", primary_key=True)
+    created = models.DateTimeField()
+    modified = models.DateTimeField()
+    patient = models.ForeignKey(
+        "v1.Patient",
+        on_delete=models.DO_NOTHING,
+        related_name="banner_alerts",
+        null=True,
+    )
+    plugin_name = models.CharField()
+    key = models.CharField()
+    narrative = models.CharField()
+    placement = ArrayField(models.CharField())
+    intent = models.CharField()
+    href = models.CharField()
+    status = models.CharField()

--- a/canvas_sdk/v1/data/staff.py
+++ b/canvas_sdk/v1/data/staff.py
@@ -46,10 +46,9 @@ class Staff(models.Model):
     cultural_ethnicity_terms = ArrayField(models.CharField())
     last_known_timezone = TimeZoneField(null=True)
     active = models.BooleanField()
-    # TODO - uncomment when PracticeLocation field is developed
-    # primary_practice_location = models.ForeignKey(
-    #     'v1.PracticeLocation', on_delete=models.DO_NOTHING, null=True
-    # )
+    primary_practice_location = models.ForeignKey(
+        "v1.PracticeLocation", on_delete=models.DO_NOTHING, null=True
+    )
     npi_number = models.CharField()
     nadean_number = models.CharField()
     group_npi_number = models.CharField()


### PR DESCRIPTION
Resolves https://canvasmedical.atlassian.net/browse/KOALA-2667

Depends on home-app PR: https://github.com/canvas-medical/canvas/pull/17420

Allows a plugin developer to look up which banner alerts have already been created. Likely useful when precomputing all banner alerts up front.