### PR TITLE
feat: add session based auth to simpleapi

### DIFF
--- a/canvas_sdk/handlers/simple_api/__init__.py
+++ b/canvas_sdk/handlers/simple_api/__init__.py
@@ -7,6 +7,9 @@ from .security import (
     BasicCredentials,
     BearerCredentials,
     Credentials,
+    PatientSessionAuthMixin,
+    SessionCredentials,
+    StaffSessionAuthMixin,
 )
 
 __all__ = [
@@ -17,6 +20,9 @@ __all__ = [
     "BasicCredentials",
     "BearerCredentials",
     "Credentials",
+    "PatientSessionAuthMixin",
+    "SessionCredentials",
     "SimpleAPI",
     "SimpleAPIRoute",
+    "StaffSessionAuthMixin",
 ]

--- a/canvas_sdk/handlers/simple_api/security.py
+++ b/canvas_sdk/handlers/simple_api/security.py
@@ -139,7 +139,7 @@ class SessionCredentials(Credentials):
             "canvas-logged-in-user-type" not in request.headers
             or "canvas-logged-in-user-id" not in request.headers
         ):
-            raise AuthenticationSchemeError
+            raise InvalidCredentialsError
 
         self.logged_in_user = {
             "id": request.headers.get("canvas-logged-in-user-id"),

--- a/canvas_sdk/handlers/simple_api/security.py
+++ b/canvas_sdk/handlers/simple_api/security.py
@@ -2,7 +2,6 @@ from base64 import b64decode
 from secrets import compare_digest
 from typing import TYPE_CHECKING, Any, Protocol
 
-from canvas_sdk.v1.data import Patient, Staff
 from logger import log
 
 from .exceptions import (
@@ -146,14 +145,6 @@ class SessionCredentials(Credentials):
             "id": request.headers.get("canvas-logged-in-user-id"),
             "type": request.headers.get("canvas-logged-in-user-type"),
         }
-
-        self.logged_in_staff = None
-        self.logged_in_patient = None
-
-        if self.logged_in_user["type"] == "Staff":
-            self.logged_in_staff = Staff.objects.get(id=self.logged_in_user["id"])
-        if self.logged_in_user["type"] == "Patient":
-            self.logged_in_patient = Patient.objects.get(id=self.logged_in_user["id"])
 
 
 class AuthSchemeMixin(Protocol):

--- a/canvas_sdk/handlers/simple_api/security.py
+++ b/canvas_sdk/handlers/simple_api/security.py
@@ -139,7 +139,7 @@ class SessionCredentials(Credentials):
             "canvas-logged-in-user-type" not in request.headers
             or "canvas-logged-in-user-id" not in request.headers
         ):
-            raise NoAuthorizationHeaderError
+            raise AuthenticationSchemeError
 
         self.logged_in_user = {
             "id": request.headers.get("canvas-logged-in-user-id"),

--- a/canvas_sdk/handlers/simple_api/security.py
+++ b/canvas_sdk/handlers/simple_api/security.py
@@ -2,6 +2,7 @@ from base64 import b64decode
 from secrets import compare_digest
 from typing import TYPE_CHECKING, Any, Protocol
 
+from canvas_sdk.v1.data import Patient, Staff
 from logger import log
 
 from .exceptions import (
@@ -145,6 +146,14 @@ class SessionCredentials(Credentials):
             "id": request.headers.get("canvas-logged-in-user-id"),
             "type": request.headers.get("canvas-logged-in-user-type"),
         }
+
+        self.logged_in_staff = None
+        self.logged_in_patient = None
+
+        if self.logged_in_user["type"] == "Staff":
+            self.logged_in_staff = Staff.objects.get(id=self.logged_in_user["id"])
+        if self.logged_in_user["type"] == "Patient":
+            self.logged_in_patient = Patient.objects.get(id=self.logged_in_user["id"])
 
 
 class AuthSchemeMixin(Protocol):

--- a/canvas_sdk/handlers/simple_api/security.py
+++ b/canvas_sdk/handlers/simple_api/security.py
@@ -136,14 +136,14 @@ class SessionCredentials(Credentials):
         super().__init__(request)
 
         if (
-            "x-canvas-logged-in-user-type" not in request.headers
-            or "x-canvas-logged-in-user-id" not in request.headers
+            "canvas-logged-in-user-type" not in request.headers
+            or "canvas-logged-in-user-id" not in request.headers
         ):
             raise NoAuthorizationHeaderError
 
         self.logged_in_user = {
-            "id": request.headers.get("x-canvas-logged-in-user-id"),
-            "type": request.headers.get("x-canvas-logged-in-user-type"),
+            "id": request.headers.get("canvas-logged-in-user-id"),
+            "type": request.headers.get("canvas-logged-in-user-type"),
         }
 
 

--- a/canvas_sdk/tests/handlers/test_simple_api.py
+++ b/canvas_sdk/tests/handlers/test_simple_api.py
@@ -897,7 +897,7 @@ def session_headers(id: str, type: str) -> dict[str, str]:
     """
     Given an id and a type, return headers that include the expected session based auth headers.
     """
-    return {"x-canvas-logged-in-user-type": type, "x-canvas-logged-in-user-id": id}
+    return {"canvas-logged-in-user-type": type, "canvas-logged-in-user-id": id}
 
 
 USERNAME = uuid4().hex

--- a/canvas_sdk/v1/data/user.py
+++ b/canvas_sdk/v1/data/user.py
@@ -9,3 +9,4 @@ class CanvasUser(models.Model):
         db_table = "canvas_sdk_data_api_auth_user_001"
 
     dbid = models.BigIntegerField(db_column="dbid", primary_key=True)
+    email = models.CharField()


### PR DESCRIPTION
Relates to https://canvasmedical.atlassian.net/browse/KOALA-2706

Depends on https://github.com/canvas-medical/canvas/pull/17443

1. Add ability to protect SimpleAPI handlers based on a valid Canvas session.
2. Add email to the CanvasUser data model. (Unrelated, but I'm grouping it into these changes since it's tiny)