### PR TITLE
fix: make path matching regex compatible with root paths ('/')

### DIFF
--- a/canvas_sdk/handlers/simple_api/api.py
+++ b/canvas_sdk/handlers/simple_api/api.py
@@ -296,10 +296,7 @@ class SimpleAPIBase(BaseHandler, ABC):
         self._path_pattern = None
         self._handler = None
         for path_pattern, handler in self._ROUTES.get(self.event.context["method"], ()):
-            request_path = self.event.context["path"]
-            if "?" in request_path:
-                request_path = request_path.split("?")[0]
-            if path_pattern.fullmatch(request_path):
+            if path_pattern.fullmatch(self.event.context["path"]):
                 self._path_pattern = path_pattern
                 self._handler = handler
                 break

--- a/canvas_sdk/handlers/simple_api/api.py
+++ b/canvas_sdk/handlers/simple_api/api.py
@@ -162,7 +162,7 @@ class Request:
         self._body = event.context["body"]
         self.headers = CaseInsensitiveMultiDict(separate_headers(event.context["headers"]))
 
-        match = path_pattern.match(event.context["path"])
+        match = path_pattern.fullmatch(event.context["path"])
         self.path_params = match.groupdict() if match else {}
 
         self.query_params = MultiDict(parse_qsl(self.query_string))

--- a/canvas_sdk/handlers/simple_api/api.py
+++ b/canvas_sdk/handlers/simple_api/api.py
@@ -275,7 +275,7 @@ class SimpleAPIBase(BaseHandler, ABC):
         for attr in cls.__dict__.values():
             if callable(attr) and (route := getattr(attr, "route", None)):
                 method, relative_path = route
-                path = f"{cls._path_prefix()}{relative_path}"
+                path = f"^{cls._path_prefix()}{relative_path}$"
 
                 # Convert the path to a regular expression pattern so that any path parameters can
                 # be extracted later
@@ -296,7 +296,10 @@ class SimpleAPIBase(BaseHandler, ABC):
         self._path_pattern = None
         self._handler = None
         for path_pattern, handler in self._ROUTES.get(self.event.context["method"], ()):
-            if path_pattern.match(self.event.context["path"]):
+            request_path = self.event.context["path"]
+            if "?" in request_path:
+                request_path = request_path.split("?")[0]
+            if path_pattern.match(request_path):
                 self._path_pattern = path_pattern
                 self._handler = handler
                 break

--- a/canvas_sdk/handlers/simple_api/api.py
+++ b/canvas_sdk/handlers/simple_api/api.py
@@ -275,7 +275,7 @@ class SimpleAPIBase(BaseHandler, ABC):
         for attr in cls.__dict__.values():
             if callable(attr) and (route := getattr(attr, "route", None)):
                 method, relative_path = route
-                path = f"^{cls._path_prefix()}{relative_path}$"
+                path = f"{cls._path_prefix()}{relative_path}"
 
                 # Convert the path to a regular expression pattern so that any path parameters can
                 # be extracted later
@@ -299,7 +299,7 @@ class SimpleAPIBase(BaseHandler, ABC):
             request_path = self.event.context["path"]
             if "?" in request_path:
                 request_path = request_path.split("?")[0]
-            if path_pattern.match(request_path):
+            if path_pattern.fullmatch(request_path):
                 self._path_pattern = path_pattern
                 self._handler = handler
                 break

--- a/canvas_sdk/tests/handlers/test_simple_api.py
+++ b/canvas_sdk/tests/handlers/test_simple_api.py
@@ -510,18 +510,23 @@ def test_request_routing_path_pattern(
 @pytest.mark.parametrize(
     argnames="path_pattern1,path_pattern2,path,expected_body",
     argvalues=[
-        ("/", "/path.js", "/prefix/path.js", {"handler_method": "second"}),
         ("/path/<value>", "/path/test", "/prefix/path/value", {"handler_method": "first"}),
         ("/path/<value>", "/path/test", "/prefix/path/test", {"handler_method": "first"}),
         ("/path/test", "/path/<value>", "/prefix/path/test", {"handler_method": "first"}),
         ("/path/test", "/path/<value>", "/prefix/path/value", {"handler_method": "second"}),
+        (
+            "/path/<value>",
+            "/path/<value>/test",
+            "/prefix/path/value/test",
+            {"handler_method": "second"},
+        ),
     ],
     ids=[
-        "a root path does not match all",
         "pattern registered first, path matches only pattern",
         "pattern registered first, path matches both pattern and fixed",
         "fixed registered first, path matches both pattern and fixed",
         "fixed registered first, path matches only pattern",
+        "two patterns share the same first two segments and then diverge",
     ],
 )
 def test_request_routing_path_pattern_multiple_matches(

--- a/canvas_sdk/tests/handlers/test_simple_api.py
+++ b/canvas_sdk/tests/handlers/test_simple_api.py
@@ -510,12 +510,14 @@ def test_request_routing_path_pattern(
 @pytest.mark.parametrize(
     argnames="path_pattern1,path_pattern2,path,expected_body",
     argvalues=[
+        ("/", "/path.js", "/prefix/path.js", {"handler_method": "second"}),
         ("/path/<value>", "/path/test", "/prefix/path/value", {"handler_method": "first"}),
         ("/path/<value>", "/path/test", "/prefix/path/test", {"handler_method": "first"}),
         ("/path/test", "/path/<value>", "/prefix/path/test", {"handler_method": "first"}),
         ("/path/test", "/path/<value>", "/prefix/path/value", {"handler_method": "second"}),
     ],
     ids=[
+        "a root path does not match all",
         "pattern registered first, path matches only pattern",
         "pattern registered first, path matches both pattern and fixed",
         "fixed registered first, path matches both pattern and fixed",


### PR DESCRIPTION
https://canvasmedical.atlassian.net/browse/KOALA-2742

Recent changes to SimpleAPI path parameters broke my SimpleAPI handler.

A simplified version of my handler:

```python
class CoolApp(SimpleAPI):
    @api.get("/")
    def index(self) -> list[Response | Effect]:
        return [
            HTMLResponse(
                render_to_string("static/index.html"),
                status_code=HTTPStatus.OK,
            )
        ]

    @api.get("/main.js")
    def get_main_js(self) -> list[Response | Effect]:
        return [
            Response(
                render_to_string("static/main.js").encode(),
                status_code=HTTPStatus.OK,
                content_type="text/javascript",
            )
        ]
```

Before, requests to `GET /main.js` returned the javascript as expected, and `GET /` returned the html as expected.
After the change, requests to `GET /main.js` returned the html (and the `GET /` continued to return the html).

The changes in this PR add beginning (`^`) and end (`$`) anchors to the regex used to match paths so paths defined for `/` don't match all other paths. When comparing, query parameters are ignored.

I include an additional parameterized test for this case, which failed without my change and passes with it.