### PR TITLE
feat: add environment dict containing the customer identifier to plugin handler scope

### DIFF
--- a/canvas_sdk/handlers/base.py
+++ b/canvas_sdk/handlers/base.py
@@ -13,6 +13,7 @@ version = importlib.metadata.version("canvas")
 class BaseHandler(ABC):
     """The class that all handlers inherit from."""
 
+    environment: dict[str, Any]
     secrets: dict[str, Any]
     event: Event
 
@@ -20,9 +21,11 @@ class BaseHandler(ABC):
         self,
         event: Event,
         secrets: dict[str, Any] | None = None,
+        environment: dict[str, Any] | None = None,
     ) -> None:
         self.event = event
         self.secrets = secrets or {}
+        self.environment = environment or {}
 
     @property
     @deprecation.deprecated(

--- a/plugin_runner/plugin_runner.py
+++ b/plugin_runner/plugin_runner.py
@@ -34,6 +34,7 @@ from plugin_runner.installation import install_plugins
 from plugin_runner.sandbox import Sandbox
 from settings import (
     CHANNEL_NAME,
+    CUSTOMER_IDENTIFIER,
     IS_TESTING,
     MANIFEST_FILE_NAME,
     PLUGIN_DIRECTORY,
@@ -48,6 +49,11 @@ sys.path.append(PLUGIN_DIRECTORY)
 # a global dictionary of loaded plugins
 # TODO: create typings here for the subkeys
 LOADED_PLUGINS: dict = {}
+
+# a global dictionary of values made available to all plugins
+ENVIRONMENT: dict = {
+    "CUSTOMER_IDENTIFIER": CUSTOMER_IDENTIFIER,
+}
 
 # a global dictionary of events to handler class names
 EVENT_HANDLER_MAP: dict[str, list] = defaultdict(list)
@@ -174,7 +180,7 @@ class PluginRunner(PluginRunnerServicer):
             )
 
             try:
-                handler = handler_class(event, secrets)
+                handler = handler_class(event, secrets, ENVIRONMENT)
 
                 if not handler.accept_event():
                     continue


### PR DESCRIPTION
https://canvasmedical.atlassian.net/browse/KOALA-2741

Resolves https://github.com/canvas-medical/canvas-plugins/issues/290
Resolves https://github.com/canvas-medical/canvas-plugins/issues/503

This adds the ability to know which customer instance your code is executing on.

<img width="1703" alt="Screenshot 2025-04-04 at 5 02 20 PM" src="https://github.com/user-attachments/assets/73c5b5a1-167c-4dd7-8339-8fcaf0218325" />
