### PR TITLE
fix: don't block for Redis messages

### DIFF
--- a/logger/logger.py
+++ b/logger/logger.py
@@ -2,6 +2,8 @@ import logging
 import os
 from typing import Any
 
+import redis
+
 from pubsub.pubsub import Publisher
 
 
@@ -15,7 +17,11 @@ class PubSubLogHandler(logging.Handler):
     def emit(self, record: Any) -> None:
         """Publishes the log message to the pub/sub channel."""
         message = self.format(record)
-        self.publisher.publish(message)
+
+        try:
+            self.publisher.publish(message)
+        except redis.ConnectionError as e:
+            print(f"PubSubLogHandler: failed to log message due to redis error: {e}")
 
 
 class PluginLogger:

--- a/plugin_runner/plugin_runner.py
+++ b/plugin_runner/plugin_runner.py
@@ -323,7 +323,7 @@ async def synchronize_plugins_and_report_errors() -> None:
         try:
             await synchronize_plugins()
         except Exception as e:
-            log.warning(f"synchronize_plugins: error: {e}")
+            log.error(f"synchronize_plugins: error: {e}")
 
         # don't crush redis if we're retrying in a tight loop
         await asyncio.sleep(0.5)

--- a/plugin_runner/plugin_runner.py
+++ b/plugin_runner/plugin_runner.py
@@ -302,15 +302,15 @@ async def synchronize_plugins(run_once: bool = False) -> None:
     await pubsub.psubscribe(**{CHANNEL_NAME: handle_message})
 
     while True:
-        if run_once:
-            break
-
         await pubsub.get_message(timeout=5.0)
         await pubsub.check_health()
 
         if not pubsub.connection.is_connected:  # type: ignore
             log.info("synchronize_plugins: reconnecting to Redis")
             await pubsub.connection.connect()  # type: ignore
+
+        if run_once:
+            break
 
 
 async def synchronize_plugins_and_report_errors() -> None:


### PR DESCRIPTION
https://canvasmedical.atlassian.net/browse/KOALA-2765

Blocking for Redis messages with no timeouts leads to situations where Redis disconnects but our code continues to block forever.

This PR updates our Redis `PSUBSCRIBE` consumer to wait for 5 seconds and then check the connection health so as to keep the Redis connection alive.