### PR TITLE
feat: add JsonOnlyResponse and a test for ontologies_http

### DIFF
--- a/canvas_sdk/utils/tests.py
+++ b/canvas_sdk/utils/tests.py
@@ -1,6 +1,40 @@
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 from canvas_sdk.utils import Http
+from canvas_sdk.utils.http import ontologies_http
+
+
+class FakeResponse:
+    """
+    A mock requests.Response.
+    """
+
+    def __init__(self) -> None:
+        self.status_code = 200
+
+    def json(self) -> dict[str, Any]:
+        """
+        Return a known response for mocking.
+        """
+        return {"abc": 123}
+
+
+@patch("requests.Session.get")
+def test_http_get_json(mock_get: MagicMock) -> None:
+    """Test that the Http.get method calls requests.get with the correct arguments."""
+    mock_get.return_value = FakeResponse()
+
+    response = ontologies_http.get_json("/fdb/medication")
+
+    mock_get.assert_called_once_with(
+        "https://ontologies.canvasmedical.com/fdb/medication",
+        headers={},
+        timeout=30,
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"abc": 123}
 
 
 @patch("requests.Session.get")

--- a/canvas_sdk/utils/tests.py
+++ b/canvas_sdk/utils/tests.py
@@ -22,7 +22,9 @@ class FakeResponse:
 
 @patch("requests.Session.get")
 def test_http_get_json(mock_get: MagicMock) -> None:
-    """Test that the Http.get method calls requests.get with the correct arguments."""
+    """
+    Test that the OntologiesHttp.get_json method calls requests.get with the correct arguments.
+    """
     mock_get.return_value = FakeResponse()
 
     response = ontologies_http.get_json("/fdb/medication")


### PR DESCRIPTION
This is primarily to support Hyperscribe by adding the `status_code` to the result of `get_json`.