### PR TITLE
fix: ensure that meta props still get created for cqms where type annotations are included

### DIFF
--- a/canvas_cli/apps/plugin/plugin.py
+++ b/canvas_cli/apps/plugin/plugin.py
@@ -100,9 +100,10 @@ def _get_meta_properties(protocol_path: Path, classname: str) -> dict[str, str]:
         return meta
 
     for meta_b in meta_class.body:
-        if not isinstance(meta_b, ast.Assign):
+        if not isinstance(meta_b, ast.Assign | ast.AnnAssign):
             continue
-        target_id = next((t.id for t in meta_b.targets if isinstance(t, ast.Name)), None)
+        targets = [meta_b.target] if isinstance(meta_b, ast.AnnAssign) else meta_b.targets
+        target_id = next((t.id for t in targets if isinstance(t, ast.Name)), None)
         if not target_id:
             continue
         if isinstance(meta_b.value, ast.Constant):


### PR DESCRIPTION
<!-- ## Title Guidelines

A title always has a prefix and a subject.

### Prefix
Make sure the title is prefixed with one of the following:

| Prefix | When to use |
|--------|-------------|
| `feat:`     | New feature |
| `fix:`      | Bug fix |
| `docs:`     | Documentation only changes |
| `style:`    | Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc) |
| `refactor:` | Code changes that neither fixes a bug nor adds a feature |
| `perf:`     | Code change that improves performance |
| `test:`     | Adding missing or correcting existing tests |
| `chore:`    | Changes to the build process or auxiliary tools and libraries such as documentation generation, ci, etc |

### Subject

Ensure the subject contains succinct description of the change.
* Use the imperative, present tense: "change", not "changed" nor "changes"
* Don’t capitalize first letter
* No dot (.) at the end
-->

Duo Health was having an issue using the ClinicalQualityMeasure class where the ProtocolUpload wasn't getting created. This is because they were using type annotations when defining the meta properties on the class, which is a different `ast` class to parse. This PR updates the parsing to check for both. 