### PR TITLE
fix: correct a typo

### DIFF
--- a/canvas_sdk/caching/__init__.py
+++ b/canvas_sdk/caching/__init__.py
@@ -1,1 +1,1 @@
-__al__ = __exports__ = ()
+__exports__ = ()


### PR DESCRIPTION
there was a typo in `__all__`, but it's not needed in that file so I removed it entirely.