### PR TITLE
feat: add `cast` to allowed imports

### DIFF
--- a/plugin_runner/sandbox.py
+++ b/plugin_runner/sandbox.py
@@ -199,6 +199,7 @@ STANDARD_LIBRARY_MODULES = {
     },
     "typing": {
         "Any",
+        "cast",
         "Dict",
         "Final",
         "Iterable",


### PR DESCRIPTION
While pairing today we ran into an issue where we needed to cast a value but `cast` was not an allowed import.