### PR TITLE
fix: allow non-protocol imports, add tests

### DIFF
--- a/canvas_sdk/tests/caching/test_plugins.py
+++ b/canvas_sdk/tests/caching/test_plugins.py
@@ -74,6 +74,13 @@ def test_plugin_successfully_sets_gets_key_value_in_cache(
 
     assert effects[0].payload == "bar"
 
+    plugin = LOADED_PLUGINS[
+        "test_caching_api:test_caching_api.protocols.my_secondary_protocol:Protocol"
+    ]
+    effects = plugin["class"](Event(EventRequest(type=EventType.UNKNOWN))).compute()
+
+    assert effects[0].payload == "bar2bar3"
+
 
 @pytest.mark.parametrize("install_test_plugin", ["test_caching_api"], indirect=True)
 def test_plugin_access_to_private_properties_cache_is_forbidden(

--- a/canvas_sdk/tests/caching/test_plugins.py
+++ b/canvas_sdk/tests/caching/test_plugins.py
@@ -17,11 +17,14 @@ if typing.TYPE_CHECKING:
 
 
 @pytest.fixture
-def mock_plugin_caller(mocker: "MockerFixture", request: "Any") -> str:
+def mock_plugin_caller(
+    mocker: "MockerFixture",
+    request: "Any",
+) -> typing.Generator[str, None, None]:
     """A fixture that mocks plugin_only decorator.
     It generates a random plugin name and patches the plugin_only to simulate plugin behavior.
     """
-    plugin_name = "".join(random.choice(string.ascii_lowercase) for i in range(10))
+    plugin_name = "".join(random.choice(string.ascii_lowercase) for _ in range(10))
 
     def patched_plugin_only(
         func: typing.Callable[..., typing.Any],
@@ -42,7 +45,10 @@ def mock_plugin_caller(mocker: "MockerFixture", request: "Any") -> str:
     # Reload the canvas_sdk.caching.plugins module to apply the mock
     importlib.reload(canvas_sdk.caching.plugins)
 
-    return plugin_name
+    yield plugin_name
+    # Cleanup: Unpatch the plugin_only decorator after the test
+    mocker.stopall()
+    importlib.reload(canvas_sdk.caching.plugins)
 
 
 def test_get_cache_returns_the_correct_cache_client(

--- a/plugin_runner/sandbox.py
+++ b/plugin_runner/sandbox.py
@@ -868,7 +868,13 @@ class Sandbox:
         # evaluate the module in the sandbox if needed
         self._evaluate_module(name)
 
-        return __import__(name, globals, locals, fromlist, level)
+        imported_module = __import__(name, globals, locals, fromlist, level)
+
+        # If the module is part of the plugin, mark it as a plugin module
+        if self._same_module(name):
+            imported_module.__is_plugin__ = True  # type: ignore[attr-defined]
+
+        return imported_module
 
     def execute(self) -> dict:
         """Execute the given code in a restricted sandbox."""

--- a/plugin_runner/tests/fixtures/plugins/test_caching_api/CANVAS_MANIFEST.json
+++ b/plugin_runner/tests/fixtures/plugins/test_caching_api/CANVAS_MANIFEST.json
@@ -1,38 +1,47 @@
 {
-    "sdk_version": "0.1.4",
-    "plugin_version": "0.0.1",
-    "name": "test_caching_api",
-    "description": "Edit the description in CANVAS_MANIFEST.json",
-    "components": {
-        "protocols": [
-            {
-                "class": "test_caching_api.protocols.my_protocol:Protocol",
-                "description": "A protocol that does xyz...",
-                "data_access": {
-                    "event": "",
-                    "read": [],
-                    "write": []
-                }
-            },
-             {
-                "class": "test_caching_api.protocols.invalid_protocol:InvalidProtocol",
-                "description": "A protocol that does xyz...",
-                "data_access": {
-                    "event": "",
-                    "read": [],
-                    "write": []
-                }
-            }
-        ],
-        "commands": [],
-        "content": [],
-        "effects": [],
-        "views": []
-    },
-    "secrets": [],
-    "tags": {},
-    "references": [],
-    "license": "",
-    "diagram": false,
-    "readme": "./README.md"
+  "sdk_version": "0.1.4",
+  "plugin_version": "0.0.1",
+  "name": "test_caching_api",
+  "description": "Edit the description in CANVAS_MANIFEST.json",
+  "components": {
+    "protocols": [
+      {
+        "class": "test_caching_api.protocols.my_protocol:Protocol",
+        "description": "A protocol that does xyz...",
+        "data_access": {
+          "event": "",
+          "read": [],
+          "write": []
+        }
+      },
+      {
+        "class": "test_caching_api.protocols.my_secondary_protocol:Protocol",
+        "description": "A protocol that does xyz...",
+        "data_access": {
+          "event": "",
+          "read": [],
+          "write": []
+        }
+      },
+      {
+        "class": "test_caching_api.protocols.invalid_protocol:InvalidProtocol",
+        "description": "A protocol that does xyz...",
+        "data_access": {
+          "event": "",
+          "read": [],
+          "write": []
+        }
+      }
+    ],
+    "commands": [],
+    "content": [],
+    "effects": [],
+    "views": []
+  },
+  "secrets": [],
+  "tags": {},
+  "references": [],
+  "license": "",
+  "diagram": false,
+  "readme": "./README.md"
 }

--- a/plugin_runner/tests/fixtures/plugins/test_caching_api/protocols/my_secondary_protocol.py
+++ b/plugin_runner/tests/fixtures/plugins/test_caching_api/protocols/my_secondary_protocol.py
@@ -1,0 +1,30 @@
+from test_caching_api.wrapper import WrappedCache, wrapped_get_cache
+
+from canvas_sdk.effects import Effect, EffectType
+from canvas_sdk.events import EventType
+from canvas_sdk.protocols import BaseProtocol
+
+
+class Protocol(BaseProtocol):
+    """
+    You should put a helpful description of this protocol's behavior here.
+    """
+
+    # Name the event type you wish to run in response to
+    RESPONDS_TO = EventType.Name(EventType.UNKNOWN)
+
+    def compute(self) -> list[Effect]:
+        """Test that the plugin successfully sets and gets a key-value pair in the cache."""
+        cache = wrapped_get_cache()
+        cache.set("foo2", "bar2")
+
+        WrappedCache.set("foo3", "bar3")
+
+        payload = f"{cache.get('foo2')}{WrappedCache.get('foo3')}"
+
+        return [
+            Effect(
+                type=EffectType.LOG,
+                payload=payload,
+            )
+        ]

--- a/plugin_runner/tests/fixtures/plugins/test_caching_api/wrapper.py
+++ b/plugin_runner/tests/fixtures/plugins/test_caching_api/wrapper.py
@@ -1,0 +1,35 @@
+from typing import Any
+
+from canvas_sdk.caching.plugins import get_cache
+
+
+def wrapped_get_cache(*args: Any, **kwargs: Any) -> Any:
+    """
+    This contrived method just exists to ensure that we can import `get_cache`
+    from files that are imported from the main protocol.
+    """
+    return get_cache(*args, **kwargs)
+
+
+class WrappedCache:
+    """
+    Contrived class ensuring we can call get_cache from non-protocol code.
+    """
+
+    @classmethod
+    def get(cls, key: str) -> str:
+        """
+        Get a cache item.
+        """
+        if cached := get_cache().get(key):
+            return cached
+
+        return "nope"
+
+    @classmethod
+    def set(cls, key: str, value: str) -> None:
+        """
+        Set a cache item.
+        """
+        cache = get_cache()
+        cache.set(key, value)

--- a/plugin_runner/tests/fixtures/plugins/test_caching_api/wrapper.py
+++ b/plugin_runner/tests/fixtures/plugins/test_caching_api/wrapper.py
@@ -2,6 +2,8 @@ from typing import Any
 
 from canvas_sdk.caching.plugins import get_cache
 
+test_cache = get_cache()
+
 
 def wrapped_get_cache(*args: Any, **kwargs: Any) -> Any:
     """


### PR DESCRIPTION
https://canvasmedical.atlassian.net/browse/KOALA-2926

@dbajet brought up an issue importing `get_cache` here: https://github.com/canvas-medical/canvas-plugins/issues/619

I wrote a test to verify whether it was the `plugin_only` decorator and could not reproduce the issue.

@jamagalhaes pointed out that the issue with reproducing the issue is that we were mocking `plugin_only`, which hid the failure, and provided the fix. Thank you!