### PR TITLE
feat: expose a pharmacy search view

### DIFF
--- a/canvas_sdk/utils/http.py
+++ b/canvas_sdk/utils/http.py
@@ -288,6 +288,44 @@ class OntologiesHttp(JsonOnlyHttp):
         self._session.headers.update({"Authorization": os.getenv("PRE_SHARED_KEY", "")})
 
 
+class PharmacyHttp:
+    """
+    An HTTP client for the pharmacy service.
+    """
+
+    def __init__(self) -> None:
+        self._http_client = JsonOnlyHttp(
+            base_url=os.getenv("PHARMACY_ENDPOINT", "https://pharmacy.canvasmedical.com")
+        )
+
+        self._http_client._session.headers.update(
+            {"Authorization": os.getenv("PRE_SHARED_KEY", "")}
+        )
+
+    def search_pharmacies(
+        self, search_term: str, latitude: str | None = None, longitude: str | None = None
+    ) -> list[dict]:
+        """Search for pharmacies by term and optional location."""
+        params = {"search": search_term}
+        if latitude and longitude:
+            params.update(
+                {
+                    "latitude": latitude,
+                    "longitude": longitude,
+                }
+            )
+
+        query_string = urllib.parse.urlencode(params)
+        response = self._http_client.get_json(f"/surescripts/pharmacy/?{query_string}")
+        response_json = response.json()
+        return response_json.get("results", []) if response_json else []
+
+    def get_pharmacy_by_ncpdp_id(self, ncpdp_id: str) -> dict[str, Any] | None:
+        """Lookup a pharmacy by its NCPDP ID."""
+        response = self._http_client.get_json(f"/surescripts/pharmacy/ncpdp_id/{ncpdp_id}/")
+        return response.json()
+
+
 class ScienceHttp(JsonOnlyHttp):
     """
     An HTTP client for the ontologies service.
@@ -303,11 +341,13 @@ class ScienceHttp(JsonOnlyHttp):
 
 ontologies_http = OntologiesHttp()
 science_http = ScienceHttp()
+pharmacy_http = PharmacyHttp()
 
 __all__ = __exports__ = (
     "ThreadPoolExecutor",
     "Http",
     "ontologies_http",
+    "pharmacy_http",
     "science_http",
     "batch_get",
     "batch_post",


### PR DESCRIPTION
Internal tracking: [KOALA-2981](https://canvasmedical.atlassian.net/browse/KOALA-2981)

This pull request introduces a new HTTP client, `PharmacyHttp`, to interact with the pharmacy service. It includes methods for searching pharmacies and retrieving pharmacy details by NCPDP ID. Additionally, the `pharmacy_http` instance is added to the module's exports.

### New HTTP client for pharmacy service:

* `canvas_sdk/utils/http.py`: Added the `PharmacyHttp` class, which includes:
  - [`search_pharmacies`](diffhunk://#diff-5a08695780c2698aa0b5c76219ff9bfef51ec931371d5743c15db57513a82b27R291-R328): A method to search for pharmacies using a search term and optional latitude/longitude parameters.
  - [`get_pharmacy_by_ncpdp_id`](diffhunk://#diff-5a08695780c2698aa0b5c76219ff9bfef51ec931371d5743c15db57513a82b27R291-R328): A method to retrieve pharmacy details using an NCPDP ID.

### Module updates:

* [`canvas_sdk/utils/http.py`](diffhunk://#diff-5a08695780c2698aa0b5c76219ff9bfef51ec931371d5743c15db57513a82b27R344-R350): Added the `pharmacy_http` instance to the module's exports (`__all__`) for external use.

[KOALA-2981]: https://canvasmedical.atlassian.net/browse/KOALA-2981?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ