### PR TITLE
fix: raise on bad status from S3 in `download_plugin`

### DIFF
--- a/plugin_runner/installation.py
+++ b/plugin_runner/installation.py
@@ -170,7 +170,8 @@ def install_plugin(plugin_name: str, attributes: PluginAttributes) -> None:
 
         install_plugin_secrets(plugin_name=plugin_name, secrets=attributes["secrets"])
     except Exception as e:
-        log.error(f'Failed to install plugin "{plugin_name}", version {attributes["version"]}')
+        log.error(f'Failed to install plugin "{plugin_name}", version {attributes["version"]}: {e}')
+
         sentry_sdk.capture_exception(e)
 
         raise PluginInstallationError() from e

--- a/plugin_runner/installation.py
+++ b/plugin_runner/installation.py
@@ -147,6 +147,8 @@ def download_plugin(plugin_package: str) -> Generator[Path, None, None]:
 
         with open(download_path, "wb") as download_file:
             response = requests.request(method=method, url=f"https://{host}{path}", headers=headers)
+            response.raise_for_status()
+
             download_file.write(response.content)
 
         yield download_path


### PR DESCRIPTION
Reagan [ran into](https://canvas-medical.slack.com/archives/C055B74UKJP/p1751374815943519) an issue during local development where he was unable to install plugins but there wasn't a useful error explaining that the plugin download had failed, it was failing at the next step (archive extraction) since the file contained an error message instead of the expected archive.

The root cause was an AWS region mismatch, which affected S3 signature generation.

This change makes it easier to see why a plugin installation failed if the root cause is the download from S3.