### PR TITLE
feat: implement question toggles for questionnaire based commands

### DIFF
--- a/canvas_sdk/commands/commands/exam.py
+++ b/canvas_sdk/commands/commands/exam.py
@@ -1,7 +1,8 @@
 from canvas_sdk.commands.commands.questionnaire import QuestionnaireCommand
+from canvas_sdk.commands.commands.questionnaire.toggle_questions import ToggleQuestionsMixin
 
 
-class PhysicalExamCommand(QuestionnaireCommand):
+class PhysicalExamCommand(ToggleQuestionsMixin, QuestionnaireCommand):
     """A class for managing physical exam command."""
 
     class Meta:

--- a/canvas_sdk/commands/commands/questionnaire/__init__.py
+++ b/canvas_sdk/commands/commands/questionnaire/__init__.py
@@ -63,6 +63,7 @@ class QuestionnaireCommand(_BaseCommand):
 
         for question in self._questionnaire.questions.all():
             qdata: dict[str, Any] = {
+                "id": question.pk,
                 "name": f"question-{question.pk}",
                 "label": question.name,
                 "coding": {

--- a/canvas_sdk/commands/commands/questionnaire/__init__.py
+++ b/canvas_sdk/commands/commands/questionnaire/__init__.py
@@ -36,15 +36,20 @@ class QuestionnaireCommand(_BaseCommand):
 
     @cached_property
     def _questionnaire(self) -> Questionnaire | None:
-        if not self.questionnaire_id and (command_uuid := self.command_uuid):
-            # If the questionnaire is not set, try to fetch it from the command
-            try:
-                command_data = Command.objects.values_list("data", flat=True).get(id=command_uuid)
-                if questionnaire_dbid := command_data.get("questionnaire", {}).get("value"):
-                    questionnaire = Questionnaire.objects.get(dbid=questionnaire_dbid)
-                    self.questionnaire_id = str(questionnaire.id)
-                    return questionnaire
-            except (Command.DoesNotExist, Questionnaire.DoesNotExist):
+        if not self.questionnaire_id:
+            if command_uuid := self.command_uuid:
+                # If the questionnaire is not set, try to fetch it from the command
+                try:
+                    command_data = Command.objects.values_list("data", flat=True).get(
+                        id=command_uuid
+                    )
+                    if questionnaire_dbid := command_data.get("questionnaire", {}).get("value"):
+                        questionnaire = Questionnaire.objects.get(dbid=questionnaire_dbid)
+                        self.questionnaire_id = str(questionnaire.id)
+                        return questionnaire
+                except (Command.DoesNotExist, Questionnaire.DoesNotExist):
+                    return None
+            else:
                 return None
 
         return Questionnaire.objects.get(id=self.questionnaire_id)  # type: ignore[misc]

--- a/canvas_sdk/commands/commands/questionnaire/question.py
+++ b/canvas_sdk/commands/commands/questionnaire/question.py
@@ -38,8 +38,9 @@ class BaseQuestion(ABC):
     type: str
 
     def __init__(
-        self, name: str, label: str, coding: dict[str, str], options: list[ResponseOption]
+        self, id: str, name: str, label: str, coding: dict[str, str], options: list[ResponseOption]
     ) -> None:
+        self.id: str = id
         self.name: str = name
         self.label: str = label
         self.coding: dict[str, str] = coding
@@ -47,7 +48,7 @@ class BaseQuestion(ABC):
         self.response: Any | None = None
 
     def __repr__(self) -> str:
-        return f"Question({self.name=!r}, {self.label=!r}, {self.type=!r}, {self.options=!r}, {self.response=!r})"
+        return f"Question({self.id=!r}, {self.name=!r}, {self.label=!r}, {self.type=!r}, {self.options=!r}, {self.response=!r})"
 
     @abstractmethod
     def add_response(self, *args: Any, **kwargs: Any) -> None:

--- a/canvas_sdk/commands/commands/questionnaire/toggle_questions.py
+++ b/canvas_sdk/commands/commands/questionnaire/toggle_questions.py
@@ -63,3 +63,6 @@ class ToggleQuestionsMixin:
             values[f"skip-{question_id}"] = enabled
 
         return values
+
+
+__exports__ = ()

--- a/canvas_sdk/commands/commands/questionnaire/toggle_questions.py
+++ b/canvas_sdk/commands/commands/questionnaire/toggle_questions.py
@@ -1,0 +1,65 @@
+from canvas_sdk.v1.data import Command
+
+
+class ToggleQuestionsMixin:
+    """Mixin that adds toggle functionality to questionnaire-based commands.
+
+    This mixin should be used with classes that inherit from QuestionnaireCommand
+    and provides the ability to skip/enable individual questions.
+
+    Note: In the data model, skip=true means the question is ENABLED (not skipped).
+    This is counterintuitive but matches the existing behavior.
+    """
+
+    # All toggle states (persisted + runtime changes)
+    _question_toggles: dict[str, bool] | None = None
+
+    def _ensure_toggles_loaded(self) -> None:
+        """Load toggle states from the database if not already loaded."""
+        if self._question_toggles is not None:
+            return
+
+        self._question_toggles = {}
+
+        if hasattr(self, "command_uuid") and self.command_uuid:
+            try:
+                command_data = Command.objects.values_list("data", flat=True).get(
+                    id=self.command_uuid
+                )
+                for key, value in command_data.items():
+                    if key.startswith("skip-"):
+                        question_id = key.replace("skip-", "")
+                        self._question_toggles[question_id] = bool(value)
+            except Command.DoesNotExist:
+                pass
+
+    @property
+    def question_toggles(self) -> dict[str, bool]:
+        """Get the current toggle states for questions (question_id -> enabled)."""
+        self._ensure_toggles_loaded()
+        return self._question_toggles.copy()  # type: ignore[union-attr]
+
+    def is_question_enabled(self, question_id: str | int) -> bool | None:
+        """Check if a question is enabled."""
+        self._ensure_toggles_loaded()
+        question_id = str(question_id)
+        return self._question_toggles.get(question_id, None)  # type: ignore[union-attr]
+
+    def set_question_enabled(self, question_id: str | int, enabled: bool) -> None:
+        """Enable or disable a question."""
+        self._ensure_toggles_loaded()
+        self._question_toggles[str(question_id)] = enabled  # type: ignore[index]
+
+    @property
+    def values(self) -> dict:
+        """Include skip states in command values."""
+        values = super().values  # type: ignore[misc]
+
+        # Get all current toggle states
+        all_toggles = self.question_toggles
+
+        # Add skip- prefix for the values dict
+        for question_id, enabled in all_toggles.items():
+            values[f"skip-{question_id}"] = enabled
+
+        return values

--- a/canvas_sdk/commands/commands/review_of_systems.py
+++ b/canvas_sdk/commands/commands/review_of_systems.py
@@ -1,7 +1,8 @@
 from canvas_sdk.commands.commands.questionnaire import QuestionnaireCommand
+from canvas_sdk.commands.commands.questionnaire.toggle_questions import ToggleQuestionsMixin
 
 
-class ReviewOfSystemsCommand(QuestionnaireCommand):
+class ReviewOfSystemsCommand(ToggleQuestionsMixin, QuestionnaireCommand):
     """A class for managing physical exam command."""
 
     class Meta:

--- a/canvas_sdk/commands/commands/structured_assessment.py
+++ b/canvas_sdk/commands/commands/structured_assessment.py
@@ -1,7 +1,8 @@
 from canvas_sdk.commands.commands.questionnaire import QuestionnaireCommand
+from canvas_sdk.commands.commands.questionnaire.toggle_questions import ToggleQuestionsMixin
 
 
-class StructuredAssessmentCommand(QuestionnaireCommand):
+class StructuredAssessmentCommand(ToggleQuestionsMixin, QuestionnaireCommand):
     """A class for managing physical exam command."""
 
     class Meta:

--- a/canvas_sdk/commands/commands/structured_assessment.py
+++ b/canvas_sdk/commands/commands/structured_assessment.py
@@ -1,8 +1,7 @@
 from canvas_sdk.commands.commands.questionnaire import QuestionnaireCommand
-from canvas_sdk.commands.commands.questionnaire.toggle_questions import ToggleQuestionsMixin
 
 
-class StructuredAssessmentCommand(ToggleQuestionsMixin, QuestionnaireCommand):
+class StructuredAssessmentCommand(QuestionnaireCommand):
     """A class for managing physical exam command."""
 
     class Meta:

--- a/canvas_sdk/tests/commands/test_toggle_questions_mixin.py
+++ b/canvas_sdk/tests/commands/test_toggle_questions_mixin.py
@@ -1,0 +1,306 @@
+import uuid
+from unittest.mock import Mock, PropertyMock, patch
+
+import pytest
+
+from canvas_sdk.commands.commands.questionnaire import QuestionnaireCommand
+from canvas_sdk.commands.commands.questionnaire.toggle_questions import ToggleQuestionsMixin
+from canvas_sdk.v1.data import Command
+
+
+class TestCommand(ToggleQuestionsMixin, QuestionnaireCommand):
+    """Test command that uses the ToggleQuestionsMixin."""
+
+    class Meta:
+        key = "test"
+
+
+COMMAND_ID = str(uuid.uuid4())
+QUESTIONNAIRE_ID = str(uuid.uuid4())
+
+
+@pytest.fixture
+def command_without_uuid() -> TestCommand:
+    """Create a command instance without a command_uuid."""
+    return TestCommand(questionnaire_id=QUESTIONNAIRE_ID)
+
+
+@pytest.fixture
+def command_with_uuid() -> TestCommand:
+    """Create a command instance with a command_uuid."""
+    cmd = TestCommand(questionnaire_id=QUESTIONNAIRE_ID)
+    cmd.command_uuid = COMMAND_ID
+    return cmd
+
+
+def test_initial_state_without_command_uuid(command_without_uuid: TestCommand) -> None:
+    """Test that a new command without UUID has empty toggle states."""
+    assert command_without_uuid._question_toggles is None
+    toggles = command_without_uuid.question_toggles
+    assert toggles == {}
+    assert command_without_uuid._question_toggles == {}
+
+
+@patch.object(Command.objects, "values_list")
+def test_load_persisted_toggles_success(
+    mock_values_list: Mock, command_with_uuid: TestCommand
+) -> None:
+    """Test loading toggle states from an existing command."""
+    # Mock the database response
+    mock_get = Mock()
+    mock_get.get.return_value = {
+        "skip-123": True,
+        "skip-456": False,
+        "skip-789": True,
+        "other-field": "ignored",
+    }
+    mock_values_list.return_value = mock_get
+
+    # Trigger loading
+    toggles = command_with_uuid.question_toggles
+
+    # Verify correct loading
+    assert toggles == {"123": True, "456": False, "789": True}
+    mock_values_list.assert_called_once_with("data", flat=True)
+    mock_get.get.assert_called_once_with(id=COMMAND_ID)
+
+
+@patch.object(Command.objects, "values_list")
+def test_load_persisted_toggles_command_not_found(
+    mock_values_list: Mock, command_with_uuid: TestCommand
+) -> None:
+    """Test behavior when command doesn't exist in database."""
+    # Mock DoesNotExist exception
+    mock_get = Mock()
+    mock_get.get.side_effect = Command.DoesNotExist()
+    mock_values_list.return_value = mock_get
+
+    # Should not raise, just return empty
+    toggles = command_with_uuid.question_toggles
+    assert toggles == {}
+
+
+def test_is_question_enabled_default(command_without_uuid: TestCommand) -> None:
+    """Test that questions default to None when not found."""
+    assert command_without_uuid.is_question_enabled("123") is None
+    assert command_without_uuid.is_question_enabled(456) is None
+
+
+@patch.object(Command.objects, "values_list")
+def test_is_question_enabled_with_persisted_state(
+    mock_values_list: Mock, command_with_uuid: TestCommand
+) -> None:
+    """Test is_question_enabled with persisted states."""
+    # Mock persisted states
+    mock_get = Mock()
+    mock_get.get.return_value = {
+        "skip-123": True,
+        "skip-456": False,
+    }
+    mock_values_list.return_value = mock_get
+
+    assert command_with_uuid.is_question_enabled("123") is True
+    assert command_with_uuid.is_question_enabled("456") is False
+    assert command_with_uuid.is_question_enabled("789") is None
+
+
+def test_set_question_enabled(command_without_uuid: TestCommand) -> None:
+    """Test setting question enabled states."""
+    # Enable a question
+    command_without_uuid.set_question_enabled("123", True)
+    assert command_without_uuid.is_question_enabled("123") is True
+
+    # Disable a question
+    command_without_uuid.set_question_enabled("123", False)
+    assert command_without_uuid.is_question_enabled("123") is False
+
+    # Test with int input
+    command_without_uuid.set_question_enabled(456, True)
+    assert command_without_uuid.is_question_enabled("456") is True
+
+
+@patch.object(Command.objects, "values_list")
+def test_runtime_changes_override_persisted(
+    mock_values_list: Mock, command_with_uuid: TestCommand
+) -> None:
+    """Test that runtime changes override persisted states."""
+    # Mock persisted state
+    mock_get = Mock()
+    mock_get.get.return_value = {"skip-123": True}  # Persisted as enabled
+    mock_values_list.return_value = mock_get
+
+    # Runtime change to disabled
+    command_with_uuid.set_question_enabled("123", False)
+    assert command_with_uuid.is_question_enabled("123") is False
+
+    # Verify toggles show runtime state
+    toggles = command_with_uuid.question_toggles
+    assert toggles["123"] is False
+
+
+@patch(
+    "canvas_sdk.commands.commands.questionnaire.QuestionnaireCommand.values",
+    new_callable=PropertyMock,
+)
+def test_values_includes_skip_prefix(
+    mock_parent_values: PropertyMock, command_without_uuid: TestCommand
+) -> None:
+    """Test that values property adds skip- prefix correctly."""
+    # Mock parent class values to avoid DB access
+    mock_parent_values.return_value = {"questionnaire_id": QUESTIONNAIRE_ID}
+
+    command_without_uuid.set_question_enabled("123", True)
+    command_without_uuid.set_question_enabled("456", False)
+
+    values = command_without_uuid.values
+
+    # Should include questionnaire_id from parent class
+    assert values["questionnaire_id"] == QUESTIONNAIRE_ID
+
+    # Should include skip states with prefix
+    assert values["skip-123"] is True
+    assert values["skip-456"] is False
+
+
+@patch(
+    "canvas_sdk.commands.commands.questionnaire.QuestionnaireCommand.values",
+    new_callable=PropertyMock,
+)
+@patch.object(Command.objects, "values_list")
+def test_values_merges_persisted_and_runtime(
+    mock_values_list: Mock, mock_parent_values: PropertyMock, command_with_uuid: TestCommand
+) -> None:
+    """Test that values merges persisted and runtime states correctly."""
+    # Mock parent class values
+    mock_parent_values.return_value = {"questionnaire_id": QUESTIONNAIRE_ID}
+
+    # Mock persisted states
+    mock_get = Mock()
+    mock_get.get.return_value = {
+        "skip-123": True,
+        "skip-456": False,
+    }
+    mock_values_list.return_value = mock_get
+
+    # Add runtime changes
+    command_with_uuid.set_question_enabled("456", True)  # Override persisted
+    command_with_uuid.set_question_enabled("789", False)  # New toggle
+
+    values = command_with_uuid.values
+
+    assert values["skip-123"] is True  # From persisted
+    assert values["skip-456"] is True  # Runtime override
+    assert values["skip-789"] is False  # New runtime
+
+
+def test_question_toggles_returns_copy(command_without_uuid: TestCommand) -> None:
+    """Test that question_toggles returns a copy, not the internal dict."""
+    command_without_uuid.set_question_enabled("123", True)
+
+    toggles = command_without_uuid.question_toggles
+    toggles["456"] = False  # Modify returned dict
+
+    # Internal state should not be affected
+    assert command_without_uuid.is_question_enabled("456") is None
+
+
+@patch.object(Command.objects, "values_list")
+def test_ensure_toggles_loaded_called_once(
+    mock_values_list: Mock, command_with_uuid: TestCommand
+) -> None:
+    """Test that database is only queried once, not on every access."""
+    mock_get = Mock()
+    mock_get.get.return_value = {"skip-123": True}
+    mock_values_list.return_value = mock_get
+
+    # Multiple accesses
+    command_with_uuid.is_question_enabled("123")
+    command_with_uuid.set_question_enabled("456", True)
+    _ = command_with_uuid.question_toggles
+
+    # Access values with mocked parent
+    with patch(
+        "canvas_sdk.commands.commands.questionnaire.QuestionnaireCommand.values",
+        new_callable=PropertyMock,
+    ) as mock_parent_values:
+        mock_parent_values.return_value = {"questionnaire_id": QUESTIONNAIRE_ID}
+        _ = command_with_uuid.values
+
+    # Database should only be queried once
+    assert mock_values_list.call_count == 1
+
+
+def test_type_conversion_for_question_ids(command_without_uuid: TestCommand) -> None:
+    """Test that question IDs are consistently converted to strings."""
+    command_without_uuid.set_question_enabled(123, True)
+    command_without_uuid.set_question_enabled("456", False)
+
+    # Both should work with string or int lookup
+    assert command_without_uuid.is_question_enabled(123) is True
+    assert command_without_uuid.is_question_enabled("123") is True
+    assert command_without_uuid.is_question_enabled(456) is False
+    assert command_without_uuid.is_question_enabled("456") is False
+
+    # Internal storage should use strings
+    toggles = command_without_uuid.question_toggles
+    assert all(isinstance(k, str) for k in toggles)
+
+
+@patch(
+    "canvas_sdk.commands.commands.questionnaire.QuestionnaireCommand.values",
+    new_callable=PropertyMock,
+)
+def test_values_with_no_toggles(
+    mock_parent_values: PropertyMock, command_without_uuid: TestCommand
+) -> None:
+    """Test values property when no toggles are set."""
+    mock_parent_values.return_value = {"questionnaire_id": QUESTIONNAIRE_ID}
+
+    values = command_without_uuid.values
+
+    # Should only have parent values, no skip fields
+    assert values == {"questionnaire_id": QUESTIONNAIRE_ID}
+
+
+@patch(
+    "canvas_sdk.commands.commands.questionnaire.QuestionnaireCommand.values",
+    new_callable=PropertyMock,
+)
+@patch.object(Command.objects, "values_list")
+def test_complex_scenario(
+    mock_values_list: Mock, mock_parent_values: PropertyMock, command_with_uuid: TestCommand
+) -> None:
+    """Test a complex scenario with multiple operations."""
+    # Mock parent values
+    mock_parent_values.return_value = {
+        "questionnaire_id": QUESTIONNAIRE_ID,
+        "questions": {"question-123": "response"},
+    }
+
+    # Mock persisted states
+    mock_get = Mock()
+    mock_get.get.return_value = {
+        "skip-123": True,
+        "skip-456": False,
+        "skip-789": True,
+    }
+    mock_values_list.return_value = mock_get
+
+    # Check initial state
+    assert command_with_uuid.is_question_enabled("123") is True
+    assert command_with_uuid.is_question_enabled("456") is False
+
+    # Make changes
+    command_with_uuid.set_question_enabled("123", False)  # Disable previously enabled
+    command_with_uuid.set_question_enabled("999", True)  # Add new
+
+    # Get final values
+    values = command_with_uuid.values
+
+    # Should have all parent values plus all skip states
+    assert values["questionnaire_id"] == QUESTIONNAIRE_ID
+    assert values["questions"] == {"question-123": "response"}
+    assert values["skip-123"] is False  # Changed
+    assert values["skip-456"] is False  # Unchanged
+    assert values["skip-789"] is True  # Unchanged
+    assert values["skip-999"] is True  # New


### PR DESCRIPTION
Internal tracking: [KOALA-2903](https://canvasmedical.atlassian.net/browse/KOALA-2903)

This pull request introduces a new `ToggleQuestionsMixin` class to enhance questionnaire-based commands with functionality for toggling question states. It also updates several command classes to use this mixin and adds comprehensive tests for its behavior. The most important changes include the implementation of the mixin, integration with existing commands, and extensive test coverage.

### New functionality for toggling question states:
* [`canvas_sdk/commands/commands/questionnaire/toggle_questions.py`](diffhunk://#diff-896337de07ef1271b01ae2f7a5735be5d370f19867dfc26136e9ddc8bde2ebc4R1-R65): Added the `ToggleQuestionsMixin` class, which provides methods to enable/disable questions, retrieve toggle states, and integrate these states into command values.

### Integration with existing commands:
* Updated `PhysicalExamCommand`, `ReviewOfSystemsCommand`, and `StructuredAssessmentCommand` to inherit from `ToggleQuestionsMixin` in addition to `QuestionnaireCommand`. [[1]](diffhunk://#diff-615acbe3c1f86919e9ed6e46b5d287d7fecd5364bf301c8371295442a94b08c1R2-R5) [[2]](diffhunk://#diff-27f1386810a616e35ec0844c02e97bbf6d65e3a1bc3e04d1b38f4437b7557b20R2-R5) [[3]](diffhunk://#diff-70d7888109a9b90f546533adab362236151c031e7b2676e06ef27743281876bdR2-R5)

### Improvements to questionnaire handling:
* [`canvas_sdk/commands/commands/questionnaire/__init__.py`](diffhunk://#diff-d6d0878221db23cd27b32d83da9e85dd8a2d2969c9194551eab2f60b8b68b93cL39-R50): Enhanced `_questionnaire` property to fetch questionnaire data from the associated command if `questionnaire_id` is not set.


[KOALA-2903]: https://canvasmedical.atlassian.net/browse/KOALA-2903?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ