### PR TITLE
fix: add support for single plugin reloads

### DIFF
--- a/canvas_generated/messages/plugins_pb2.py
+++ b/canvas_generated/messages/plugins_pb2.py
@@ -14,7 +14,7 @@ _sym_db = _symbol_database.Default()
 
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\'canvas_generated/messages/plugins.proto\"\x16\n\x14ReloadPluginsRequest\"(\n\x15ReloadPluginsResponse\x12\x0f\n\x07success\x18\x01 \x01(\x08\x62\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\'canvas_generated/messages/plugins.proto\"&\n\x14ReloadPluginsRequest\x12\x0e\n\x06plugin\x18\x01 \x01(\t\"(\n\x15ReloadPluginsResponse\x12\x0f\n\x07success\x18\x01 \x01(\x08\x62\x06proto3')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
@@ -22,7 +22,7 @@ _builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'canvas_generated.messages.p
 if _descriptor._USE_C_DESCRIPTORS == False:
   DESCRIPTOR._options = None
   _globals['_RELOADPLUGINSREQUEST']._serialized_start=43
-  _globals['_RELOADPLUGINSREQUEST']._serialized_end=65
-  _globals['_RELOADPLUGINSRESPONSE']._serialized_start=67
-  _globals['_RELOADPLUGINSRESPONSE']._serialized_end=107
+  _globals['_RELOADPLUGINSREQUEST']._serialized_end=81
+  _globals['_RELOADPLUGINSRESPONSE']._serialized_start=83
+  _globals['_RELOADPLUGINSRESPONSE']._serialized_end=123
 # @@protoc_insertion_point(module_scope)

--- a/canvas_generated/messages/plugins_pb2.pyi
+++ b/canvas_generated/messages/plugins_pb2.pyi
@@ -5,8 +5,10 @@ from typing import ClassVar as _ClassVar, Optional as _Optional
 DESCRIPTOR: _descriptor.FileDescriptor
 
 class ReloadPluginsRequest(_message.Message):
-    __slots__ = ()
-    def __init__(self) -> None: ...
+    __slots__ = ("plugin",)
+    PLUGIN_FIELD_NUMBER: _ClassVar[int]
+    plugin: str
+    def __init__(self, plugin: _Optional[str] = ...) -> None: ...
 
 class ReloadPluginsResponse(_message.Message):
     __slots__ = ("success",)

--- a/plugin_runner/exceptions.py
+++ b/plugin_runner/exceptions.py
@@ -12,3 +12,7 @@ class InvalidPluginFormat(PluginValidationError):
 
 class PluginInstallationError(PluginError):
     """An exception raised when a plugin fails to install."""
+
+
+class PluginUninstallationError(PluginError):
+    """An exception raised when a plugin fails to uninstall."""

--- a/plugin_runner/installation.py
+++ b/plugin_runner/installation.py
@@ -17,7 +17,11 @@ from psycopg.rows import dict_row
 
 from logger import log
 from plugin_runner.aws_headers import aws_sig_v4_headers
-from plugin_runner.exceptions import InvalidPluginFormat, PluginInstallationError
+from plugin_runner.exceptions import (
+    InvalidPluginFormat,
+    PluginInstallationError,
+    PluginUninstallationError,
+)
 from settings import (
     AWS_ACCESS_KEY_ID,
     AWS_REGION,
@@ -68,15 +72,28 @@ class PluginAttributes(TypedDict):
     secrets: dict[str, str]
 
 
-def enabled_plugins() -> dict[str, PluginAttributes]:
-    """Returns a dictionary of enabled plugins and their attributes."""
+def enabled_plugins(plugin_names: list[str] | None = None) -> dict[str, PluginAttributes]:
+    """Returns a dictionary of enabled plugins and their attributes.
+
+    If `plugin_names` is provided, only returns those plugins (if enabled).
+    """
     conn = open_database_connection()
 
     with conn.cursor(row_factory=dict_row) as cursor:
-        cursor.execute(
-            "SELECT name, package, version, key, value FROM plugin_io_plugin p "
-            "LEFT JOIN plugin_io_pluginsecret s ON p.id = s.plugin_id WHERE is_enabled"
+        base_query = (
+            "SELECT name, package, version, key, value "
+            "FROM plugin_io_plugin p "
+            "LEFT JOIN plugin_io_pluginsecret s ON p.id = s.plugin_id "
+            "WHERE is_enabled"
         )
+
+        params = []
+        if plugin_names:
+            placeholders = ",".join(["%s"] * len(plugin_names))
+            base_query += f" AND name IN ({placeholders})"
+            params.extend(plugin_names)
+
+        cursor.execute(base_query, params)
         rows = cursor.fetchall()
         plugins = _extract_rows_to_dict(rows)
 
@@ -210,12 +227,15 @@ def disable_plugin(plugin_name: str) -> None:
 
 def uninstall_plugin(plugin_name: str) -> None:
     """Remove the plugin from the filesystem."""
-    log.info(f'Uninstalling plugin "{plugin_name}"')
+    try:
+        log.info(f'Uninstalling plugin "{plugin_name}"')
 
-    plugin_path = Path(PLUGIN_DIRECTORY) / plugin_name
+        plugin_path = Path(PLUGIN_DIRECTORY) / plugin_name
 
-    if plugin_path.exists():
-        shutil.rmtree(plugin_path)
+        if plugin_path.exists():
+            shutil.rmtree(plugin_path)
+    except Exception as e:
+        raise PluginUninstallationError() from e
 
 
 def install_plugins() -> None:

--- a/plugin_runner/plugin_runner.py
+++ b/plugin_runner/plugin_runner.py
@@ -38,7 +38,13 @@ from canvas_sdk.utils import metrics
 from canvas_sdk.utils.metrics import measured
 from logger import log
 from plugin_runner.authentication import token_for_plugin
-from plugin_runner.installation import install_plugins
+from plugin_runner.exceptions import PluginInstallationError, PluginUninstallationError
+from plugin_runner.installation import (
+    enabled_plugins,
+    install_plugin,
+    install_plugins,
+    uninstall_plugin,
+)
 from plugin_runner.sandbox import Sandbox, sandbox_from_module
 from settings import (
     CHANNEL_NAME,
@@ -296,9 +302,10 @@ class PluginRunner(PluginRunnerServicer):
         self, request: ReloadPluginsRequest, context: Any
     ) -> Iterable[ReloadPluginsResponse]:
         """This is invoked when we need to reload plugins."""
-        log.info("Reloading plugins...")
+        if not request.plugin:
+            log.info("Reloading all plugins...")
         try:
-            publish_message(message={"action": "reload"})
+            publish_message(message={"action": "reload", "plugin": request.plugin})
         except ImportError:
             yield ReloadPluginsResponse(success=False)
         else:
@@ -338,18 +345,39 @@ def synchronize_plugins(run_once: bool = False) -> None:
             continue
 
         if data["action"] == "reload":
-            log.info("synchronize_plugins: installing/reloading plugins for action=reload")
-
+            plugin_name = data.get("plugin", None)
             try:
-                install_plugins()
-            except Exception as e:
-                log.error(f"synchronize_plugins: install_plugins failed: {e}")
-                sentry_sdk.capture_exception(e)
+                if plugin_name:
+                    plugin = enabled_plugins([plugin_name]).get(plugin_name, None)
 
-            try:
-                load_plugins()
+                    if plugin:
+                        log.info(
+                            f'synchronize_plugins: installing/reloading plugin "{plugin_name}"'
+                        )
+                        install_plugin(plugin_name, attributes=plugin)
+                        plugin_dir = pathlib.Path(PLUGIN_DIRECTORY) / plugin_name
+                        load_or_reload_plugin(plugin_dir.resolve())
+                    else:
+                        log.info(f'synchronize_plugins: uninstalling plugin "{plugin_name}"')
+                        unload_plugin(plugin_name)
+                        uninstall_plugin(plugin_name)
+                else:
+                    log.info("synchronize_plugins: installing/reloading plugins for action=reload")
+                    install_plugins()
+                    load_plugins()
+
             except Exception as e:
-                log.error(f"synchronize_plugins: load_plugins failed: {e}")
+                if isinstance(e, PluginInstallationError):
+                    message = "install_plugins failed"
+                elif isinstance(e, PluginUninstallationError):
+                    message = "uninstall_plugin failed"
+                else:
+                    message = "load_plugins failed"
+
+                if plugin_name:
+                    message += f' for plugin "{plugin_name}"'
+
+                log.error(f"synchronize_plugins: {message}: {e}")
                 sentry_sdk.capture_exception(e)
 
         if run_once:
@@ -514,7 +542,7 @@ def load_or_reload_plugin(path: pathlib.Path) -> bool:
             result = sandbox.execute()
 
             if name_and_class in LOADED_PLUGINS:
-                log.info(f"Reloading plugin '{name_and_class}'")
+                log.info(f"Reloading handler '{name_and_class}'")
 
                 LOADED_PLUGINS[name_and_class]["active"] = True
 
@@ -522,7 +550,7 @@ def load_or_reload_plugin(path: pathlib.Path) -> bool:
                 LOADED_PLUGINS[name_and_class]["sandbox"] = result
                 LOADED_PLUGINS[name_and_class]["secrets"] = secrets_json
             else:
-                log.info(f"Loading plugin '{name_and_class}'")
+                log.info(f'Loading handler "{name_and_class}"')
 
                 LOADED_PLUGINS[name_and_class] = {
                     "active": True,
@@ -542,6 +570,23 @@ def load_or_reload_plugin(path: pathlib.Path) -> bool:
             any_failed = True
 
     return not any_failed
+
+
+def unload_plugin(name: str) -> None:
+    """Unload a plugin by its name."""
+    handlers_removed = False
+
+    for handler_name in LOADED_PLUGINS.copy():
+        if handler_name.startswith(f"{name}:"):
+            log.info(f'Unloading handler "{handler_name}"')
+            del LOADED_PLUGINS[handler_name]
+            handlers_removed = True
+
+    if handlers_removed:
+        # Refresh the event type map to remove any handlers for the unloaded plugin
+        refresh_event_type_map()
+    else:
+        log.warning(f"No handlers found for plugin '{name}' to unload.")
 
 
 def refresh_event_type_map() -> None:

--- a/protobufs/canvas_generated/messages/plugins.proto
+++ b/protobufs/canvas_generated/messages/plugins.proto
@@ -1,7 +1,7 @@
 syntax = "proto3";
 
 message ReloadPluginsRequest {
-
+  string plugin = 1; // The name of the plugin to reload. If empty, all plugins will be reloaded.
 }
 
 message ReloadPluginsResponse {


### PR DESCRIPTION
This pull request introduces enhancements to plugin management, including the ability to reload specific plugins, improved error handling, and extended functionality for enabling, disabling, and uninstalling plugins. The most important changes are grouped below by theme:

### Plugin Management Enhancements:
* Updated `ReloadPluginsRequest` in `protobufs/canvas_generated/messages/plugins.proto` to include a `plugin` field, allowing reloading of specific plugins. Corresponding changes were made in the Python-generated files (`plugins_pb2.py` and `plugins_pb2.pyi`) to reflect this new field. [[1]](diffhunk://#diff-808581b3c65131f0168ae86145ff87b9006bcb6dcd5bf021dbcf7f95bb0ac6f3L17-R27) [[2]](diffhunk://#diff-6dc28fa342a54b3b09ba0eedbb3ffaf19c9a64a02b61ec27f9b760bd68fea813L8-R11) [[3]](diffhunk://#diff-20a048199eab54a7182c9add70e47b90b6cc3eca5f5717bf0045aa1b94a67488L4-R4)
* Modified `enabled_plugins` in `plugin_runner/installation.py` to accept an optional `plugin_names` parameter, enabling filtering of enabled plugins by name.

### Error Handling Improvements:
* Added a new exception class, `PluginUninstallationError`, in `plugin_runner/exceptions.py` to handle errors during plugin uninstallation.
* Updated `uninstall_plugin` in `plugin_runner/installation.py` to raise `PluginUninstallationError` on failure.

### Plugin Reloading and Synchronization:
* Enhanced `ReloadPlugins` in `plugin_runner/plugin_runner.py` to support reloading specific plugins by name.
* Updated `synchronize_plugins` to handle plugin-specific reloads, including installation, reloading, and uninstallation of individual plugins.

### Plugin Loading and Unloading:
* Added `unload_plugin` in `plugin_runner/plugin_runner.py` to unload a plugin by name, including removing its handlers and refreshing the event type map.