### PR TITLE
feat: add note state change event models

### DIFF
--- a/canvas_sdk/v1/data/note.py
+++ b/canvas_sdk/v1/data/note.py
@@ -87,6 +87,30 @@ class NoteTypes(models.TextChoices):
     CCDA = "ccda", "C-CDA Import"
 
 
+class NoteStates(models.TextChoices):
+    """Note states."""
+
+    NEW = "NEW", "Created"
+    PUSHED = "PSH", "Pushed the charges for"
+    LOCKED = "LKD", "Locked"
+    UNLOCKED = "ULK", "Unlocked"
+    DELETED = "DLT", "Deleted"
+    RELOCKED = "RLK", "Relocked"
+    RESTORED = "RST", "Restored"
+    RECALLED = "RCL", "Recalled"
+    UNDELETED = "UND", "Undeleted"
+    DISCHARGED = "DSC", "Discharged"
+    # Appointment note
+    SCHEDULING = "SCH", "Scheduling"
+    BOOKED = "BKD", "Booked"
+    CONVERTED = "CVD", "Checked in"
+    CANCELLED = "CLD", "Canceled"
+    NOSHOW = "NSW", "No show"
+    REVERTED = "RVT", "Reverted"
+    # C-CDA Import note
+    CONFIRM_IMPORT = "CNF", "Confirmed"
+
+
 class NoteType(models.Model):
     """NoteType."""
 
@@ -175,7 +199,7 @@ class NoteStateChangeEvent(models.Model):
     modified = models.DateTimeField()
     note = models.ForeignKey("v1.Note", on_delete=models.DO_NOTHING, related_name="state_history")
     originator = models.ForeignKey("v1.CanvasUser", on_delete=models.DO_NOTHING, null=True)
-    state = models.CharField()
+    state = models.CharField(choices=NoteStates.choices)
     note_state_document = models.CharField()
     note_state_html = models.TextField()
 
@@ -186,16 +210,6 @@ class CurrentNoteStateEvent(models.Model):
     NoteStateChangeEvent for any given note_id.
     """
 
-    NEW = "NEW"
-    PUSHED = "PSH"
-    LOCKED = "LKD"
-    UNLOCKED = "ULK"
-    DELETED = "DLT"
-    RELOCKED = "RLK"
-    RESTORED = "RST"
-    RECALLED = "RCL"
-    UNDELETED = "UND"
-
     class Meta:
         managed = False
         app_label = "canvas_sdk"
@@ -203,12 +217,18 @@ class CurrentNoteStateEvent(models.Model):
 
     id = models.UUIDField()
     dbid: models.BigIntegerField = models.BigIntegerField(primary_key=True)
-    state: models.CharField = models.CharField()
+    state: models.CharField = models.CharField(choices=NoteStates.choices)
     note = models.ForeignKey("v1.Note", on_delete=models.DO_NOTHING, related_name="+")
 
     def editable(self) -> bool:
         """Returns a boolean to indicate if the related note can be edited."""
-        return self.state in [self.NEW, self.PUSHED, self.UNLOCKED, self.RESTORED, self.UNDELETED]
+        return self.state in [
+            NoteStates.NEW,
+            NoteStates.PUSHED,
+            NoteStates.UNLOCKED,
+            NoteStates.RESTORED,
+            NoteStates.UNDELETED,
+        ]
 
 
 __exports__ = (
@@ -217,6 +237,7 @@ __exports__ = (
     "NoteTypes",
     "NoteType",
     "Note",
+    "NoteStates",
     "NoteStateChangeEvent",
     "CurrentNoteStateEvent",
 )


### PR DESCRIPTION
Internal tracking: https://canvasmedical.atlassian.net/browse/KOALA-3031

Adds two new models to the data module:

- NoteStateChangeEvent
  - Note history
- CurrentNoteStateEvent
  - The most recent event in a note's history