### PR TITLE
feat: implement helper to create compounds when originating prescribe command

### DIFF
--- a/canvas_sdk/commands/commands/prescribe.py
+++ b/canvas_sdk/commands/commands/prescribe.py
@@ -1,10 +1,18 @@
+import json
 from decimal import Decimal
 from enum import Enum
+from typing import Any
 
 from pydantic import Field, conlist
+from pydantic_core import InitErrorDetails
 
 from canvas_sdk.commands.base import _BaseCommand
 from canvas_sdk.commands.constants import ClinicalQuantity
+from canvas_sdk.effects import Effect
+from canvas_sdk.effects.compound_medications.compound_medication import (
+    CompoundMedication as CompoundMedicationEffect,
+)
+from canvas_sdk.v1.data.compound_medication import CompoundMedication as CompoundMedicationModel
 
 
 class PrescribeCommand(_BaseCommand):
@@ -36,6 +44,114 @@ class PrescribeCommand(_BaseCommand):
     )
     note_to_pharmacist: str | None = None
 
+    # Compound medication fields
+    compound_medication_id: str | None = Field(
+        default=None, json_schema_extra={"commands_api_name": "compound_medication_id"}
+    )
+    compound_medication_formulation: str | None = Field(
+        default=None, json_schema_extra={"commands_api_name": "compound_medication_formulation"}
+    )
+    compound_medication_potency_unit_code: str | None = Field(
+        default=None,
+        json_schema_extra={"commands_api_name": "compound_medication_potency_unit_code"},
+    )
+    compound_medication_controlled_substance: str | None = Field(
+        default=None,
+        json_schema_extra={"commands_api_name": "compound_medication_controlled_substance"},
+    )
+    compound_medication_controlled_substance_ndc: str | None = Field(
+        default=None,
+        json_schema_extra={"commands_api_name": "compound_medication_controlled_substance_ndc"},
+    )
+    compound_medication_active: bool | None = Field(
+        default=None, json_schema_extra={"commands_api_name": "compound_medication_active"}
+    )
+
+    def _get_error_details(self, method: str) -> list[InitErrorDetails]:
+        """Add compound medication validation to the base validation."""
+        errors = super()._get_error_details(method)
+
+        # Validate that exactly one medication type is provided
+        if method == "originate":
+            has_fdb_code = self.fdb_code is not None and self.fdb_code.strip() != ""
+            has_compound_medication_id = (
+                self.compound_medication_id is not None
+                and self.compound_medication_id.strip() != ""
+            )
+            has_compound_medication_formulation = (
+                self.compound_medication_formulation is not None
+                and self.compound_medication_formulation.strip() != ""
+            )
+
+            medication_types_provided = sum(
+                [has_fdb_code, has_compound_medication_id, has_compound_medication_formulation]
+            )
+
+            if medication_types_provided == 0:
+                errors.append(
+                    self._create_error_detail(
+                        "missing",
+                        "Must provide one of: 'fdb_code', 'compound_medication_id', or 'compound_medication_formulation' to prescribe a medication.",
+                        None,
+                    )
+                )
+            elif medication_types_provided > 1:
+                errors.append(
+                    self._create_error_detail(
+                        "value",
+                        "Cannot specify multiple medication types. Choose one of: 'fdb_code', 'compound_medication_id', or 'compound_medication_formulation'.",
+                        None,
+                    )
+                )
+
+        # Validate compound medication ID if provided
+        if (
+            self.compound_medication_id
+            and self.compound_medication_id.strip() != ""
+            and
+            # Check if compound medication exists
+            not CompoundMedicationModel.objects.filter(id=self.compound_medication_id).exists()
+        ):
+            errors.append(
+                self._create_error_detail(
+                    "value",
+                    f"Compound medication with ID {self.compound_medication_id} does not exist.",
+                    self.compound_medication_id,
+                )
+            )
+
+        # Use static validation method for compound medication fields
+        if self.compound_medication_formulation is not None:
+            compound_med_errors = CompoundMedicationEffect.validate_compound_medication_fields(
+                formulation=self.compound_medication_formulation,
+                potency_unit_code=self.compound_medication_potency_unit_code,
+                controlled_substance=self.compound_medication_controlled_substance,
+                controlled_substance_ndc=self.compound_medication_controlled_substance_ndc,
+            )
+            errors.extend(compound_med_errors)
+
+        return errors
+
+    def _process_compound_medication_fields(self, data: dict[str, Any]) -> dict[str, Any]:
+        """
+        Process compound medication fields in prescription data.
+
+        Args:
+            data: Dictionary containing prescription data
+
+        Returns:
+            Processed dictionary with compound medication transformations applied
+        """
+        # Process nested compound medication values if present
+        if "compound_medication_values" in data:
+            compound_med_data = data["compound_medication_values"]
+            processed_compound_data = CompoundMedicationEffect.process_compound_medication_data(
+                compound_med_data
+            )
+            data["compound_medication_values"] = processed_compound_data
+
+        return data
+
     @property
     def values(self) -> dict:
         """The Prescribe command's field values."""
@@ -46,7 +162,72 @@ class PrescribeCommand(_BaseCommand):
                 str(Decimal(self.quantity_to_dispense)) if self.quantity_to_dispense else None
             )
 
+        # Group compound medication fields under a single key
+        compound_medication_values = {}
+
+        if "compound_medication_id" in values:
+            compound_medication_values["id"] = values.pop("compound_medication_id")
+        if "compound_medication_formulation" in values:
+            compound_medication_values["formulation"] = values.pop(
+                "compound_medication_formulation"
+            )
+        if "compound_medication_potency_unit_code" in values:
+            compound_medication_values["potency_unit_code"] = values.pop(
+                "compound_medication_potency_unit_code"
+            )
+        if "compound_medication_controlled_substance" in values:
+            compound_medication_values["controlled_substance"] = values.pop(
+                "compound_medication_controlled_substance"
+            )
+        if "compound_medication_controlled_substance_ndc" in values:
+            compound_medication_values["controlled_substance_ndc"] = values.pop(
+                "compound_medication_controlled_substance_ndc"
+            )
+        if "compound_medication_active" in values:
+            compound_medication_values["active"] = values.pop("compound_medication_active")
+
+        if compound_medication_values:
+            values["compound_medication_values"] = compound_medication_values
+
         return values
+
+    def originate(self, line_number: int = -1) -> Effect:
+        """Originate a new command in the note body with explicit compound medication processing."""
+        self._validate_before_effect("originate")
+
+        # Get raw values and apply explicit processing for compound medications
+        raw_data = self.values
+        processed_data = self._process_compound_medication_fields(raw_data)
+
+        return Effect(
+            type=f"ORIGINATE_{self.constantized_key()}_COMMAND",
+            payload=json.dumps(
+                {
+                    "command": self.command_uuid,
+                    "note": self.note_uuid,
+                    "data": processed_data,
+                    "line_number": line_number,
+                }
+            ),
+        )
+
+    def edit(self) -> Effect:
+        """Edit the command with explicit compound medication processing."""
+        self._validate_before_effect("edit")
+
+        # Get raw values and apply explicit processing for compound medications
+        raw_data = self.values
+        processed_data = self._process_compound_medication_fields(raw_data)
+
+        return Effect(
+            type=f"EDIT_{self.constantized_key()}_COMMAND",
+            payload=json.dumps(
+                {
+                    "command": self.command_uuid,
+                    "data": processed_data,
+                }
+            ),
+        )
 
 
 __exports__ = (

--- a/canvas_sdk/tests/commands/test_prescribe_compound_medication.py
+++ b/canvas_sdk/tests/commands/test_prescribe_compound_medication.py
@@ -1,0 +1,562 @@
+import json
+from collections.abc import Generator
+from typing import Any
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+import pytest
+from pydantic_core import ValidationError
+
+from canvas_generated.messages.effects_pb2 import EffectType
+from canvas_sdk.commands.commands.prescribe import PrescribeCommand
+from canvas_sdk.v1.data.compound_medication import CompoundMedication as CompoundMedicationModel
+
+
+@pytest.fixture
+def mock_db_queries() -> Generator[dict[str, MagicMock]]:
+    """Mock all database queries to return True/exist by default."""
+    with patch(
+        "canvas_sdk.v1.data.compound_medication.CompoundMedication.objects"
+    ) as mock_compound_med:
+        # Setup default behaviors
+        mock_compound_med.filter.return_value.exists.return_value = True
+
+        yield {
+            "compound_medication": mock_compound_med,
+        }
+
+
+@pytest.fixture
+def valid_regular_prescription_data() -> dict[str, Any]:
+    """Valid data for creating a regular prescription."""
+    return {
+        "note_uuid": str(uuid4()),
+        "fdb_code": "123456",
+        "sig": "Take one tablet by mouth daily",
+        "days_supply": 30,
+        "quantity_to_dispense": 30,
+        "refills": 5,
+    }
+
+
+@pytest.fixture
+def valid_compound_medication_prescription_data() -> dict[str, Any]:
+    """Valid data for creating a compound medication prescription."""
+    return {
+        "note_uuid": str(uuid4()),
+        "compound_medication_formulation": "Test Compound Formulation",
+        "compound_medication_potency_unit_code": CompoundMedicationModel.PotencyUnits.TABLET,
+        "compound_medication_controlled_substance": CompoundMedicationModel.ControlledSubstanceOptions.SCHEDULE_NOT_SCHEDULED,
+        "compound_medication_controlled_substance_ndc": "",
+        "compound_medication_active": True,
+        "sig": "Take one tablet by mouth daily",
+        "days_supply": 30,
+        "quantity_to_dispense": 30,
+        "refills": 5,
+    }
+
+
+@pytest.fixture
+def valid_scheduled_compound_medication_prescription_data() -> dict[str, Any]:
+    """Valid data for creating a scheduled compound medication prescription."""
+    return {
+        "note_uuid": str(uuid4()),
+        "compound_medication_formulation": "Scheduled Compound Formulation",
+        "compound_medication_potency_unit_code": CompoundMedicationModel.PotencyUnits.CAPSULE,
+        "compound_medication_controlled_substance": CompoundMedicationModel.ControlledSubstanceOptions.SCHEDULE_II,
+        "compound_medication_controlled_substance_ndc": "12345-678-90",
+        "compound_medication_active": True,
+        "sig": "Take one capsule by mouth daily",
+        "days_supply": 30,
+        "quantity_to_dispense": 30,
+        "refills": 0,  # Scheduled substances typically have no refills
+    }
+
+
+@pytest.fixture
+def valid_existing_compound_medication_prescription_data() -> dict[str, Any]:
+    """Valid data for creating a prescription with an existing compound medication."""
+    return {
+        "note_uuid": str(uuid4()),
+        "compound_medication_id": str(uuid4()),
+        "sig": "Take one tablet by mouth daily",
+        "days_supply": 30,
+        "quantity_to_dispense": 30,
+        "refills": 2,
+    }
+
+
+def test_prescribe_regular_medication_success(
+    mock_db_queries: dict[str, MagicMock], valid_regular_prescription_data: dict[str, Any]
+) -> None:
+    """Test successful regular medication prescription."""
+    prescribe_cmd = PrescribeCommand(**valid_regular_prescription_data)
+    effect = prescribe_cmd.originate()
+
+    assert effect.type == EffectType.ORIGINATE_PRESCRIBE_COMMAND
+    payload = json.loads(effect.payload)
+    assert payload["data"]["fdb_code"] == "123456"
+    assert payload["data"]["sig"] == "Take one tablet by mouth daily"
+    assert "compound_medication_formulation" not in payload["data"]
+
+
+def test_prescribe_compound_medication_success(
+    mock_db_queries: dict[str, MagicMock],
+    valid_compound_medication_prescription_data: dict[str, Any],
+) -> None:
+    """Test successful compound medication prescription."""
+    prescribe_cmd = PrescribeCommand(**valid_compound_medication_prescription_data)
+    effect = prescribe_cmd.originate()
+
+    assert effect.type == EffectType.ORIGINATE_PRESCRIBE_COMMAND
+    payload = json.loads(effect.payload)
+    assert "compound_medication_values" in payload["data"]
+    compound_med_data = payload["data"]["compound_medication_values"]
+    assert compound_med_data["formulation"] == "Test Compound Formulation"
+    assert compound_med_data["potency_unit_code"] == CompoundMedicationModel.PotencyUnits.TABLET
+    assert (
+        compound_med_data["controlled_substance"]
+        == CompoundMedicationModel.ControlledSubstanceOptions.SCHEDULE_NOT_SCHEDULED
+    )
+    assert compound_med_data["controlled_substance_ndc"] == ""
+    assert compound_med_data["active"] is True
+    assert "fdb_code" not in payload["data"]
+
+
+def test_prescribe_scheduled_compound_medication_success(
+    mock_db_queries: dict[str, MagicMock],
+    valid_scheduled_compound_medication_prescription_data: dict[str, Any],
+) -> None:
+    """Test successful scheduled compound medication prescription."""
+    prescribe_cmd = PrescribeCommand(**valid_scheduled_compound_medication_prescription_data)
+    effect = prescribe_cmd.originate()
+
+    assert effect.type == EffectType.ORIGINATE_PRESCRIBE_COMMAND
+    payload = json.loads(effect.payload)
+    assert "compound_medication_values" in payload["data"]
+    compound_med_data = payload["data"]["compound_medication_values"]
+    assert compound_med_data["formulation"] == "Scheduled Compound Formulation"
+    assert (
+        compound_med_data["controlled_substance"]
+        == CompoundMedicationModel.ControlledSubstanceOptions.SCHEDULE_II
+    )
+    # NDC should have dashes removed
+    assert compound_med_data["controlled_substance_ndc"] == "1234567890"
+
+
+def test_prescribe_existing_compound_medication_success(
+    mock_db_queries: dict[str, MagicMock],
+    valid_existing_compound_medication_prescription_data: dict[str, Any],
+) -> None:
+    """Test successful prescription with existing compound medication."""
+    prescribe_cmd = PrescribeCommand(**valid_existing_compound_medication_prescription_data)
+    effect = prescribe_cmd.originate()
+
+    assert effect.type == EffectType.ORIGINATE_PRESCRIBE_COMMAND
+    payload = json.loads(effect.payload)
+    assert "compound_medication_values" in payload["data"]
+    compound_med_data = payload["data"]["compound_medication_values"]
+    assert (
+        compound_med_data["id"]
+        == valid_existing_compound_medication_prescription_data["compound_medication_id"]
+    )
+    assert payload["data"]["sig"] == "Take one tablet by mouth daily"
+    assert "compound_medication_formulation" not in payload["data"]
+    assert "fdb_code" not in payload["data"]
+
+
+def test_prescribe_missing_all_medication_types(
+    mock_db_queries: dict[str, MagicMock],
+) -> None:
+    """Test that prescription fails when no medication type is provided."""
+    prescribe_cmd = PrescribeCommand(
+        note_uuid=str(uuid4()),
+        sig="Take one tablet by mouth daily",
+    )
+
+    with pytest.raises(ValidationError) as exc_info:
+        prescribe_cmd.originate()
+
+    errors = exc_info.value.errors()
+    error_messages = [e["msg"] for e in errors]
+    assert any(
+        "Must provide one of: 'fdb_code', 'compound_medication_id', or 'compound_medication_formulation'"
+        in msg
+        for msg in error_messages
+    )
+
+
+def test_prescribe_multiple_medication_types(
+    mock_db_queries: dict[str, MagicMock],
+) -> None:
+    """Test that prescription fails when multiple medication types are provided."""
+    prescribe_cmd = PrescribeCommand(
+        note_uuid=str(uuid4()),
+        fdb_code="123456",
+        compound_medication_formulation="Test Compound Formulation",
+        sig="Take one tablet by mouth daily",
+    )
+
+    with pytest.raises(ValidationError) as exc_info:
+        prescribe_cmd.originate()
+
+    errors = exc_info.value.errors()
+    error_messages = [e["msg"] for e in errors]
+    assert any("Cannot specify multiple medication types" in msg for msg in error_messages)
+
+
+def test_prescribe_compound_medication_empty_formulation(
+    mock_db_queries: dict[str, MagicMock],
+) -> None:
+    """Test compound medication prescription with empty formulation."""
+    prescribe_cmd = PrescribeCommand(
+        note_uuid=str(uuid4()),
+        compound_medication_formulation="",
+        sig="Take one tablet by mouth daily",
+    )
+
+    with pytest.raises(ValidationError) as exc_info:
+        prescribe_cmd.originate()
+
+    errors = exc_info.value.errors()
+    error_messages = [e["msg"] for e in errors]
+    assert any("Field 'formulation' cannot be empty" in msg for msg in error_messages)
+
+
+def test_prescribe_compound_medication_formulation_too_long(
+    mock_db_queries: dict[str, MagicMock],
+) -> None:
+    """Test compound medication prescription with formulation too long."""
+    long_formulation = "A" * 106
+    prescribe_cmd = PrescribeCommand(
+        note_uuid=str(uuid4()),
+        compound_medication_formulation=long_formulation,
+        sig="Take one tablet by mouth daily",
+    )
+
+    with pytest.raises(ValidationError) as exc_info:
+        prescribe_cmd.originate()
+
+    errors = exc_info.value.errors()
+    error_messages = [e["msg"] for e in errors]
+    assert any(
+        "Field 'formulation' must be 105 characters or less" in msg for msg in error_messages
+    )
+
+
+def test_prescribe_compound_medication_strips_formulation_whitespace(
+    mock_db_queries: dict[str, MagicMock],
+) -> None:
+    """Test that formulation whitespace is stripped."""
+    prescribe_cmd = PrescribeCommand(
+        note_uuid=str(uuid4()),
+        compound_medication_formulation="  Test Formulation  ",
+        compound_medication_potency_unit_code=CompoundMedicationModel.PotencyUnits.TABLET,
+        compound_medication_controlled_substance=CompoundMedicationModel.ControlledSubstanceOptions.SCHEDULE_NOT_SCHEDULED,
+        sig="Take one tablet by mouth daily",
+    )
+    effect = prescribe_cmd.originate()
+
+    payload = json.loads(effect.payload)
+    assert "compound_medication_values" in payload["data"]
+    compound_med_data = payload["data"]["compound_medication_values"]
+    assert compound_med_data["formulation"] == "Test Formulation"
+
+
+def test_prescribe_compound_medication_invalid_potency_unit(
+    mock_db_queries: dict[str, MagicMock],
+) -> None:
+    """Test compound medication prescription with invalid potency unit."""
+    prescribe_cmd = PrescribeCommand(
+        note_uuid=str(uuid4()),
+        compound_medication_formulation="Test Formulation",
+        compound_medication_potency_unit_code="INVALID_CODE",
+        sig="Take one tablet by mouth daily",
+    )
+
+    with pytest.raises(ValidationError) as exc_info:
+        prescribe_cmd.originate()
+
+    errors = exc_info.value.errors()
+    error_messages = [e["msg"] for e in errors]
+    assert any("Invalid potency unit code" in msg for msg in error_messages)
+
+
+def test_prescribe_compound_medication_invalid_controlled_substance(
+    mock_db_queries: dict[str, MagicMock],
+) -> None:
+    """Test compound medication prescription with invalid controlled substance."""
+    prescribe_cmd = PrescribeCommand(
+        note_uuid=str(uuid4()),
+        compound_medication_formulation="Test Formulation",
+        compound_medication_controlled_substance="INVALID_SCHEDULE",
+        sig="Take one tablet by mouth daily",
+    )
+
+    with pytest.raises(ValidationError) as exc_info:
+        prescribe_cmd.originate()
+
+    errors = exc_info.value.errors()
+    error_messages = [e["msg"] for e in errors]
+    assert any("Invalid controlled substance" in msg for msg in error_messages)
+
+
+def test_prescribe_compound_medication_ndc_required_for_scheduled(
+    mock_db_queries: dict[str, MagicMock],
+) -> None:
+    """Test that NDC is required for scheduled substances."""
+    prescribe_cmd = PrescribeCommand(
+        note_uuid=str(uuid4()),
+        compound_medication_formulation="Test Formulation",
+        compound_medication_controlled_substance=CompoundMedicationModel.ControlledSubstanceOptions.SCHEDULE_II,
+        compound_medication_controlled_substance_ndc="",
+        sig="Take one tablet by mouth daily",
+    )
+
+    with pytest.raises(ValidationError) as exc_info:
+        prescribe_cmd.originate()
+
+    errors = exc_info.value.errors()
+    error_messages = [e["msg"] for e in errors]
+    assert any(
+        "NDC is required when a Controlled Substance is specified" in msg for msg in error_messages
+    )
+
+
+def test_prescribe_compound_medication_ndc_cleaning(
+    mock_db_queries: dict[str, MagicMock],
+) -> None:
+    """Test that NDC dashes are removed."""
+    prescribe_cmd = PrescribeCommand(
+        note_uuid=str(uuid4()),
+        compound_medication_formulation="Test Formulation",
+        compound_medication_controlled_substance=CompoundMedicationModel.ControlledSubstanceOptions.SCHEDULE_II,
+        compound_medication_controlled_substance_ndc="12345-678-90",
+        sig="Take one tablet by mouth daily",
+    )
+    effect = prescribe_cmd.originate()
+
+    payload = json.loads(effect.payload)
+    assert "compound_medication_values" in payload["data"]
+    compound_med_data = payload["data"]["compound_medication_values"]
+    assert compound_med_data["controlled_substance_ndc"] == "1234567890"
+
+
+def test_prescribe_compound_medication_values_property(
+    mock_db_queries: dict[str, MagicMock],
+) -> None:
+    """Test that the values property returns correct data for compound medications."""
+    prescribe_cmd = PrescribeCommand(
+        note_uuid=str(uuid4()),
+        compound_medication_formulation="  Test Formulation  ",  # With whitespace
+        compound_medication_potency_unit_code=CompoundMedicationModel.PotencyUnits.TABLET,
+        compound_medication_controlled_substance=CompoundMedicationModel.ControlledSubstanceOptions.SCHEDULE_II,
+        compound_medication_controlled_substance_ndc="12345-678-90",  # With dashes
+        compound_medication_active=True,
+        sig="Take one tablet by mouth daily",
+    )
+
+    values = prescribe_cmd.values
+    assert "compound_medication_values" in values
+    compound_med_values = values["compound_medication_values"]
+    assert compound_med_values["formulation"] == "  Test Formulation  "  # Raw unprocessed data
+    assert compound_med_values["controlled_substance_ndc"] == "12345-678-90"  # Raw unprocessed data
+    assert compound_med_values["potency_unit_code"] == CompoundMedicationModel.PotencyUnits.TABLET
+    assert (
+        compound_med_values["controlled_substance"]
+        == CompoundMedicationModel.ControlledSubstanceOptions.SCHEDULE_II
+    )
+    assert compound_med_values["active"] is True
+
+
+def test_prescribe_compound_medication_edit_command(
+    mock_db_queries: dict[str, MagicMock],
+) -> None:
+    """Test editing a compound medication prescription."""
+    prescribe_cmd = PrescribeCommand(
+        command_uuid=str(uuid4()),
+        compound_medication_formulation="Updated Formulation",
+        sig="Take two tablets by mouth daily",
+    )
+    effect = prescribe_cmd.edit()
+
+    assert effect.type == EffectType.EDIT_PRESCRIBE_COMMAND
+    payload = json.loads(effect.payload)
+    assert "compound_medication_values" in payload["data"]
+    compound_med_data = payload["data"]["compound_medication_values"]
+    assert compound_med_data["formulation"] == "Updated Formulation"
+    assert payload["data"]["sig"] == "Take two tablets by mouth daily"
+
+
+def test_prescribe_compound_medication_multiple_validation_errors(
+    mock_db_queries: dict[str, MagicMock],
+) -> None:
+    """Test that multiple validation errors are collected and reported together."""
+    prescribe_cmd = PrescribeCommand(
+        note_uuid=str(uuid4()),
+        compound_medication_formulation="",  # Empty formulation
+        compound_medication_potency_unit_code="INVALID_CODE",  # Invalid potency unit
+        compound_medication_controlled_substance="INVALID_SCHEDULE",  # Invalid controlled substance
+        sig="Take one tablet by mouth daily",
+    )
+
+    with pytest.raises(ValidationError) as exc_info:
+        prescribe_cmd.originate()
+
+    errors = exc_info.value.errors()
+    assert len(errors) == 5  # Five validation errors
+
+    error_messages = [e["msg"] for e in errors]
+    assert any(
+        "Must provide one of: 'fdb_code', 'compound_medication_id', or 'compound_medication_formulation'"
+        in msg
+        for msg in error_messages
+    )
+    assert any("Field 'formulation' cannot be empty" in msg for msg in error_messages)
+    assert any("Invalid potency unit code" in msg for msg in error_messages)
+    assert any("Invalid controlled substance" in msg for msg in error_messages)
+    assert any(
+        "NDC is required when a Controlled Substance is specified" in msg for msg in error_messages
+    )
+
+
+def test_prescribe_compound_medication_all_potency_units_valid(
+    mock_db_queries: dict[str, MagicMock],
+) -> None:
+    """Test that all defined potency units are valid."""
+    for potency_unit_code, _ in CompoundMedicationModel.PotencyUnits.choices:
+        prescribe_cmd = PrescribeCommand(
+            note_uuid=str(uuid4()),
+            compound_medication_formulation="Test Formulation",
+            compound_medication_potency_unit_code=potency_unit_code,
+            compound_medication_controlled_substance=CompoundMedicationModel.ControlledSubstanceOptions.SCHEDULE_NOT_SCHEDULED,
+            sig="Take one tablet by mouth daily",
+        )
+
+        # Should not raise validation error
+        effect = prescribe_cmd.originate()
+        assert effect.type == EffectType.ORIGINATE_PRESCRIBE_COMMAND
+
+
+def test_prescribe_compound_medication_all_controlled_substances_valid(
+    mock_db_queries: dict[str, MagicMock],
+) -> None:
+    """Test that all defined controlled substances are valid."""
+    for controlled_substance, _ in CompoundMedicationModel.ControlledSubstanceOptions.choices:
+        ndc = "12345-678-90" if controlled_substance != "N" else ""
+
+        prescribe_cmd = PrescribeCommand(
+            note_uuid=str(uuid4()),
+            compound_medication_formulation="Test Formulation",
+            compound_medication_controlled_substance=controlled_substance,
+            compound_medication_controlled_substance_ndc=ndc,
+            sig="Take one tablet by mouth daily",
+        )
+
+        # Should not raise validation error
+        effect = prescribe_cmd.originate()
+        assert effect.type == EffectType.ORIGINATE_PRESCRIBE_COMMAND
+
+
+def test_prescribe_compound_medication_edge_case_formulation_length(
+    mock_db_queries: dict[str, MagicMock],
+) -> None:
+    """Test formulation at exactly 105 characters (boundary case)."""
+    formulation_105 = "A" * 105
+    prescribe_cmd = PrescribeCommand(
+        note_uuid=str(uuid4()),
+        compound_medication_formulation=formulation_105,
+        compound_medication_controlled_substance=CompoundMedicationModel.ControlledSubstanceOptions.SCHEDULE_NOT_SCHEDULED,
+        sig="Take one tablet by mouth daily",
+    )
+
+    # Should not raise validation error
+    effect = prescribe_cmd.originate()
+    assert effect.type == EffectType.ORIGINATE_PRESCRIBE_COMMAND
+
+    payload = json.loads(effect.payload)
+    assert "compound_medication_values" in payload["data"]
+    compound_med_data = payload["data"]["compound_medication_values"]
+    assert compound_med_data["formulation"] == formulation_105
+
+
+def test_prescribe_compound_medication_ndc_whitespace_validation(
+    mock_db_queries: dict[str, MagicMock],
+) -> None:
+    """Test that whitespace-only NDC fails validation for scheduled substances."""
+    prescribe_cmd = PrescribeCommand(
+        note_uuid=str(uuid4()),
+        compound_medication_formulation="Test Formulation",
+        compound_medication_controlled_substance=CompoundMedicationModel.ControlledSubstanceOptions.SCHEDULE_II,
+        compound_medication_controlled_substance_ndc="   ",  # Only whitespace
+        sig="Take one tablet by mouth daily",
+    )
+
+    with pytest.raises(ValidationError) as exc_info:
+        prescribe_cmd.originate()
+
+    errors = exc_info.value.errors()
+    error_messages = [e["msg"] for e in errors]
+    assert any(
+        "NDC is required when a Controlled Substance is specified" in msg for msg in error_messages
+    )
+
+
+def test_prescribe_existing_compound_medication_nonexistent_id(
+    mock_db_queries: dict[str, MagicMock],
+) -> None:
+    """Test that prescription fails when compound medication ID doesn't exist."""
+    mock_db_queries["compound_medication"].filter.return_value.exists.return_value = False
+
+    prescribe_cmd = PrescribeCommand(
+        note_uuid=str(uuid4()),
+        compound_medication_id=str(uuid4()),
+        sig="Take one tablet by mouth daily",
+    )
+
+    with pytest.raises(ValidationError) as exc_info:
+        prescribe_cmd.originate()
+
+    errors = exc_info.value.errors()
+    error_messages = [e["msg"] for e in errors]
+    assert any(
+        "Compound medication with ID" in msg and "does not exist" in msg for msg in error_messages
+    )
+
+
+def test_prescribe_fdb_code_and_compound_medication_id_conflict(
+    mock_db_queries: dict[str, MagicMock],
+) -> None:
+    """Test that prescription fails when both fdb_code and compound_medication_id are provided."""
+    prescribe_cmd = PrescribeCommand(
+        note_uuid=str(uuid4()),
+        fdb_code="123456",
+        compound_medication_id=str(uuid4()),
+        sig="Take one tablet by mouth daily",
+    )
+
+    with pytest.raises(ValidationError) as exc_info:
+        prescribe_cmd.originate()
+
+    errors = exc_info.value.errors()
+    error_messages = [e["msg"] for e in errors]
+    assert any("Cannot specify multiple medication types" in msg for msg in error_messages)
+
+
+def test_prescribe_compound_medication_id_and_formulation_conflict(
+    mock_db_queries: dict[str, MagicMock],
+) -> None:
+    """Test that prescription fails when both compound_medication_id and formulation are provided."""
+    prescribe_cmd = PrescribeCommand(
+        note_uuid=str(uuid4()),
+        compound_medication_id=str(uuid4()),
+        compound_medication_formulation="Test Compound Formulation",
+        sig="Take one tablet by mouth daily",
+    )
+
+    with pytest.raises(ValidationError) as exc_info:
+        prescribe_cmd.originate()
+
+    errors = exc_info.value.errors()
+    error_messages = [e["msg"] for e in errors]
+    assert any("Cannot specify multiple medication types" in msg for msg in error_messages)

--- a/canvas_sdk/tests/effects/compound_medications/test_compound_medication.py
+++ b/canvas_sdk/tests/effects/compound_medications/test_compound_medication.py
@@ -366,8 +366,8 @@ def test_compound_medication_values_property(mock_db_queries: dict[str, MagicMoc
     )
 
     values = compound_med.values
-    assert values["formulation"] == "Test Formulation"  # Stripped
-    assert values["controlled_substance_ndc"] == "1234567890"  # Dashes removed
+    assert values["formulation"] == "  Test Formulation  "  # Raw unprocessed data
+    assert values["controlled_substance_ndc"] == "12345-678-90"  # Raw unprocessed data
     assert values["potency_unit_code"] == CompoundMedicationModel.PotencyUnits.TABLET
     assert (
         values["controlled_substance"]

--- a/canvas_sdk/tests/effects/compound_medications/test_processing_methods.py
+++ b/canvas_sdk/tests/effects/compound_medications/test_processing_methods.py
@@ -1,0 +1,201 @@
+from canvas_sdk.effects.compound_medications.compound_medication import CompoundMedication
+
+
+def test_process_formulation_method() -> None:
+    """Test the process_formulation static method."""
+    # Test normal formulation
+    result = CompoundMedication.process_formulation("Test Formulation")
+    assert result == "Test Formulation"
+
+    # Test formulation with whitespace
+    result = CompoundMedication.process_formulation("  Test Formulation  ")
+    assert result == "Test Formulation"
+
+    # Test None input
+    result = CompoundMedication.process_formulation(None)
+    assert result is None
+
+    # Test empty string
+    result = CompoundMedication.process_formulation("")
+    assert result == ""
+
+    # Test whitespace only
+    result = CompoundMedication.process_formulation("   ")
+    assert result == ""
+
+
+def test_process_ndc_method() -> None:
+    """Test the process_ndc static method."""
+    # Test normal NDC
+    result = CompoundMedication.process_ndc("1234567890")
+    assert result == "1234567890"
+
+    # Test NDC with dashes
+    result = CompoundMedication.process_ndc("12345-678-90")
+    assert result == "1234567890"
+
+    # Test NDC with multiple dashes
+    result = CompoundMedication.process_ndc("12-34-56-78-90")
+    assert result == "1234567890"
+
+    # Test None input
+    result = CompoundMedication.process_ndc(None)
+    assert result is None
+
+    # Test empty string
+    result = CompoundMedication.process_ndc("")
+    assert result == ""
+
+
+def test_process_compound_medication_data_method() -> None:
+    """Test the process_compound_medication_data static method."""
+    # Test data with both formulation and NDC
+    input_data = {
+        "formulation": "  Test Formulation  ",
+        "controlled_substance_ndc": "12345-678-90",
+        "potency_unit_code": "C48542",
+        "controlled_substance": "N",
+        "active": True,
+    }
+
+    result = CompoundMedication.process_compound_medication_data(input_data)
+
+    assert result["formulation"] == "Test Formulation"
+    assert result["controlled_substance_ndc"] == "1234567890"
+    assert result["potency_unit_code"] == "C48542"  # Unchanged
+    assert result["controlled_substance"] == "N"  # Unchanged
+    assert result["active"] is True  # Unchanged
+
+    # Test data with None values
+    input_data = {
+        "formulation": None,
+        "controlled_substance_ndc": None,
+        "potency_unit_code": "C48542",
+    }
+
+    result = CompoundMedication.process_compound_medication_data(input_data)
+
+    assert result["formulation"] is None
+    assert result["controlled_substance_ndc"] is None
+    assert result["potency_unit_code"] == "C48542"
+
+    # Test empty data
+    input_data = {}
+    result = CompoundMedication.process_compound_medication_data(input_data)
+    assert result == {}
+
+    # Test data without compound medication fields
+    input_data = {
+        "other_field": "value",
+        "another_field": 123,
+    }
+
+    result = CompoundMedication.process_compound_medication_data(input_data)
+    assert result == input_data  # Should be unchanged
+
+
+def test_process_compound_medication_data_doesnt_modify_original() -> None:
+    """Test that process_compound_medication_data doesn't modify the original dictionary."""
+    original_data = {
+        "formulation": "  Test Formulation  ",
+        "controlled_substance_ndc": "12345-678-90",
+        "potency_unit_code": "C48542",
+    }
+
+    # Store original values
+    original_formulation = original_data["formulation"]
+    original_ndc = original_data["controlled_substance_ndc"]
+
+    # Process data
+    result = CompoundMedication.process_compound_medication_data(original_data)
+
+    # Original data should be unchanged
+    assert original_data["formulation"] == original_formulation
+    assert original_data["controlled_substance_ndc"] == original_ndc
+
+    # Result should be processed
+    assert result["formulation"] == "Test Formulation"
+    assert result["controlled_substance_ndc"] == "1234567890"
+
+
+def test_process_compound_medication_data_with_mixed_fields() -> None:
+    """Test processing with a mix of fields that need and don't need processing."""
+    input_data = {
+        "formulation": "  Valid Formulation  ",
+        "potency_unit_code": "C48542",
+        "controlled_substance": "II",
+        "controlled_substance_ndc": "98765-432-10",
+        "active": False,
+        "other_field": "unchanged",
+    }
+
+    result = CompoundMedication.process_compound_medication_data(input_data)
+
+    # Processed fields
+    assert result["formulation"] == "Valid Formulation"
+    assert result["controlled_substance_ndc"] == "9876543210"
+
+    # Unchanged fields
+    assert result["potency_unit_code"] == "C48542"
+    assert result["controlled_substance"] == "II"
+    assert result["active"] is False
+    assert result["other_field"] == "unchanged"
+
+
+def test_process_compound_medication_data_edge_cases() -> None:
+    """Test edge cases for compound medication data processing."""
+    # Test with empty strings
+    input_data = {
+        "formulation": "",
+        "controlled_substance_ndc": "",
+    }
+
+    result = CompoundMedication.process_compound_medication_data(input_data)
+
+    assert result["formulation"] == ""
+    assert result["controlled_substance_ndc"] == ""
+
+    # Test with whitespace strings
+    input_data = {
+        "formulation": "   ",
+        "controlled_substance_ndc": "   ",
+    }
+
+    result = CompoundMedication.process_compound_medication_data(input_data)
+
+    assert result["formulation"] == ""
+    assert result["controlled_substance_ndc"] == "   "  # NDC processing only removes dashes
+
+
+def test_process_formulation_edge_cases() -> None:
+    """Test edge cases for formulation processing."""
+    # Test with newlines and tabs
+    result = CompoundMedication.process_formulation("  \n\t  Test Formulation  \n\t  ")
+    assert result == "Test Formulation"
+
+    # Test with multiple spaces
+    result = CompoundMedication.process_formulation("Test     Formulation")
+    assert result == "Test     Formulation"  # Internal spaces preserved
+
+    # Test with special characters
+    result = CompoundMedication.process_formulation("  Test-Formulation 2.5%  ")
+    assert result == "Test-Formulation 2.5%"
+
+
+def test_process_ndc_edge_cases() -> None:
+    """Test edge cases for NDC processing."""
+    # Test with no dashes
+    result = CompoundMedication.process_ndc("1234567890")
+    assert result == "1234567890"
+
+    # Test with only dashes
+    result = CompoundMedication.process_ndc("---")
+    assert result == ""
+
+    # Test with mixed characters
+    result = CompoundMedication.process_ndc("ABC-123-XYZ")
+    assert result == "ABC123XYZ"
+
+    # Test with spaces (should not be affected)
+    result = CompoundMedication.process_ndc("123 45-678 90")
+    assert result == "123 45678 90"

--- a/canvas_sdk/tests/effects/compound_medications/test_static_validation.py
+++ b/canvas_sdk/tests/effects/compound_medications/test_static_validation.py
@@ -1,0 +1,215 @@
+from canvas_sdk.effects.compound_medications.compound_medication import CompoundMedication
+from canvas_sdk.v1.data.compound_medication import CompoundMedication as CompoundMedicationModel
+
+
+def test_static_validation_method_valid_data() -> None:
+    """Test that static validation method passes for valid data."""
+    errors = CompoundMedication.validate_compound_medication_fields(
+        formulation="Valid Formulation",
+        potency_unit_code=CompoundMedicationModel.PotencyUnits.TABLET,
+        controlled_substance=CompoundMedicationModel.ControlledSubstanceOptions.SCHEDULE_NOT_SCHEDULED,
+        controlled_substance_ndc="",
+    )
+
+    assert len(errors) == 0
+
+
+def test_static_validation_method_empty_formulation() -> None:
+    """Test that static validation method catches empty formulation."""
+    errors = CompoundMedication.validate_compound_medication_fields(
+        formulation="",
+        potency_unit_code=CompoundMedicationModel.PotencyUnits.TABLET,
+        controlled_substance=CompoundMedicationModel.ControlledSubstanceOptions.SCHEDULE_NOT_SCHEDULED,
+        controlled_substance_ndc="",
+    )
+
+    assert len(errors) == 1
+    assert "Field 'formulation' cannot be empty" in str(errors[0])
+
+
+def test_static_validation_method_formulation_too_long() -> None:
+    """Test that static validation method catches formulation that's too long."""
+    long_formulation = "A" * 106
+    errors = CompoundMedication.validate_compound_medication_fields(
+        formulation=long_formulation,
+        potency_unit_code=CompoundMedicationModel.PotencyUnits.TABLET,
+        controlled_substance=CompoundMedicationModel.ControlledSubstanceOptions.SCHEDULE_NOT_SCHEDULED,
+        controlled_substance_ndc="",
+    )
+
+    assert len(errors) == 1
+    assert "Field 'formulation' must be 105 characters or less" in str(errors[0])
+
+
+def test_static_validation_method_invalid_potency_unit() -> None:
+    """Test that static validation method catches invalid potency unit."""
+    errors = CompoundMedication.validate_compound_medication_fields(
+        formulation="Valid Formulation",
+        potency_unit_code="INVALID_CODE",
+        controlled_substance=CompoundMedicationModel.ControlledSubstanceOptions.SCHEDULE_NOT_SCHEDULED,
+        controlled_substance_ndc="",
+    )
+
+    assert len(errors) == 1
+    assert "Invalid potency unit code: INVALID_CODE" in str(errors[0])
+
+
+def test_static_validation_method_invalid_controlled_substance() -> None:
+    """Test that static validation method catches invalid controlled substance."""
+    errors = CompoundMedication.validate_compound_medication_fields(
+        formulation="Valid Formulation",
+        potency_unit_code=CompoundMedicationModel.PotencyUnits.TABLET,
+        controlled_substance="INVALID_SCHEDULE",
+        controlled_substance_ndc="",
+    )
+
+    assert len(errors) == 2  # Invalid controlled substance + NDC validation
+    error_messages = [str(error) for error in errors]
+    assert any("Invalid controlled substance: INVALID_SCHEDULE" in msg for msg in error_messages)
+    assert any(
+        "NDC is required when a Controlled Substance is specified" in msg for msg in error_messages
+    )
+
+
+def test_static_validation_method_ndc_required_for_scheduled() -> None:
+    """Test that static validation method catches missing NDC for scheduled substances."""
+    errors = CompoundMedication.validate_compound_medication_fields(
+        formulation="Valid Formulation",
+        potency_unit_code=CompoundMedicationModel.PotencyUnits.TABLET,
+        controlled_substance=CompoundMedicationModel.ControlledSubstanceOptions.SCHEDULE_II,
+        controlled_substance_ndc="",
+    )
+
+    assert len(errors) == 1
+    assert "NDC is required when a Controlled Substance is specified" in str(errors[0])
+
+
+def test_static_validation_method_ndc_whitespace_validation() -> None:
+    """Test that static validation method catches whitespace-only NDC for scheduled substances."""
+    errors = CompoundMedication.validate_compound_medication_fields(
+        formulation="Valid Formulation",
+        potency_unit_code=CompoundMedicationModel.PotencyUnits.TABLET,
+        controlled_substance=CompoundMedicationModel.ControlledSubstanceOptions.SCHEDULE_II,
+        controlled_substance_ndc="   ",
+    )
+
+    assert len(errors) == 1
+    assert "NDC is required when a Controlled Substance is specified" in str(errors[0])
+
+
+def test_static_validation_method_none_values() -> None:
+    """Test that static validation method handles None values correctly."""
+    errors = CompoundMedication.validate_compound_medication_fields(
+        formulation=None,
+        potency_unit_code=None,
+        controlled_substance=None,
+        controlled_substance_ndc=None,
+    )
+
+    assert len(errors) == 0
+
+
+def test_static_validation_method_multiple_errors() -> None:
+    """Test that static validation method collects multiple errors."""
+    errors = CompoundMedication.validate_compound_medication_fields(
+        formulation="",
+        potency_unit_code="INVALID_CODE",
+        controlled_substance="INVALID_SCHEDULE",
+        controlled_substance_ndc="",
+    )
+
+    assert (
+        len(errors) == 4
+    )  # Empty formulation, invalid potency unit, invalid controlled substance, NDC required
+
+    error_messages = [str(error) for error in errors]
+    assert any("Field 'formulation' cannot be empty" in msg for msg in error_messages)
+    assert any("Invalid potency unit code: INVALID_CODE" in msg for msg in error_messages)
+    assert any("Invalid controlled substance: INVALID_SCHEDULE" in msg for msg in error_messages)
+    assert any(
+        "NDC is required when a Controlled Substance is specified" in msg for msg in error_messages
+    )
+
+
+def test_static_validation_method_valid_ndc_for_scheduled() -> None:
+    """Test that static validation method passes for valid NDC with scheduled substance."""
+    errors = CompoundMedication.validate_compound_medication_fields(
+        formulation="Valid Formulation",
+        potency_unit_code=CompoundMedicationModel.PotencyUnits.TABLET,
+        controlled_substance=CompoundMedicationModel.ControlledSubstanceOptions.SCHEDULE_II,
+        controlled_substance_ndc="12345-678-90",
+    )
+
+    assert len(errors) == 0
+
+
+def test_static_validation_method_all_potency_units_valid() -> None:
+    """Test that static validation method passes for all valid potency units."""
+    for potency_unit_code, _ in CompoundMedicationModel.PotencyUnits.choices:
+        errors = CompoundMedication.validate_compound_medication_fields(
+            formulation="Valid Formulation",
+            potency_unit_code=potency_unit_code,
+            controlled_substance=CompoundMedicationModel.ControlledSubstanceOptions.SCHEDULE_NOT_SCHEDULED,
+            controlled_substance_ndc="",
+        )
+
+        assert len(errors) == 0, f"Potency unit {potency_unit_code} should be valid"
+
+
+def test_static_validation_method_all_controlled_substances_valid() -> None:
+    """Test that static validation method passes for all valid controlled substances."""
+    for controlled_substance, _ in CompoundMedicationModel.ControlledSubstanceOptions.choices:
+        ndc = (
+            "12345-678-90"
+            if controlled_substance
+            != CompoundMedicationModel.ControlledSubstanceOptions.SCHEDULE_NOT_SCHEDULED.value
+            else ""
+        )
+
+        errors = CompoundMedication.validate_compound_medication_fields(
+            formulation="Valid Formulation",
+            potency_unit_code=CompoundMedicationModel.PotencyUnits.TABLET,
+            controlled_substance=controlled_substance,
+            controlled_substance_ndc=ndc,
+        )
+
+        assert len(errors) == 0, f"Controlled substance {controlled_substance} should be valid"
+
+
+def test_static_validation_method_formulation_whitespace() -> None:
+    """Test that static validation method catches whitespace-only formulation."""
+    errors = CompoundMedication.validate_compound_medication_fields(
+        formulation="   ",
+        potency_unit_code=CompoundMedicationModel.PotencyUnits.TABLET,
+        controlled_substance=CompoundMedicationModel.ControlledSubstanceOptions.SCHEDULE_NOT_SCHEDULED,
+        controlled_substance_ndc="",
+    )
+
+    assert len(errors) == 1
+    assert "Field 'formulation' cannot be empty" in str(errors[0])
+
+
+def test_static_validation_method_boundary_formulation_length() -> None:
+    """Test that static validation method handles boundary case for formulation length."""
+    # Test exactly 105 characters (should pass)
+    formulation_105 = "A" * 105
+    errors = CompoundMedication.validate_compound_medication_fields(
+        formulation=formulation_105,
+        potency_unit_code=CompoundMedicationModel.PotencyUnits.TABLET,
+        controlled_substance=CompoundMedicationModel.ControlledSubstanceOptions.SCHEDULE_NOT_SCHEDULED,
+        controlled_substance_ndc="",
+    )
+
+    assert len(errors) == 0
+
+    # Test 106 characters (should fail)
+    formulation_106 = "A" * 106
+    errors = CompoundMedication.validate_compound_medication_fields(
+        formulation=formulation_106,
+        potency_unit_code=CompoundMedicationModel.PotencyUnits.TABLET,
+        controlled_substance=CompoundMedicationModel.ControlledSubstanceOptions.SCHEDULE_NOT_SCHEDULED,
+        controlled_substance_ndc="",
+    )
+
+    assert len(errors) == 1
+    assert "Field 'formulation' must be 105 characters or less" in str(errors[0])


### PR DESCRIPTION
Please review the base branch PR first: https://github.com/canvas-medical/canvas-plugins/pull/789

This pull request introduces comprehensive enhancements to the handling of compound medications in the `canvas_sdk` library. It primarily focuses on improving validation, processing, and error handling for compound medication fields, while also restructuring related logic for better maintainability. Key changes include the addition of new fields and methods in the `PrescribeCommand` class, refactoring of compound medication processing in the `CompoundMedication` class, and updates to associated tests.

### Enhancements to `PrescribeCommand` for compound medications:
* Added new fields to support compound medication attributes, such as `compound_medication_id`, `compound_medication_formulation`, and others, with validation logic to ensure only one medication type is specified. (`canvas_sdk/commands/commands/prescribe.py`, [canvas_sdk/commands/commands/prescribe.pyR47-R154](diffhunk://#diff-1e1a93716aa021330b243fdd4ad4f021a4ed6064dad656b64094395cd26812e4R47-R154))
* Introduced `_process_compound_medication_fields` to transform nested compound medication data and `_get_error_details` to validate compound medication fields. (`canvas_sdk/commands/commands/prescribe.py`, [canvas_sdk/commands/commands/prescribe.pyR47-R154](diffhunk://#diff-1e1a93716aa021330b243fdd4ad4f021a4ed6064dad656b64094395cd26812e4R47-R154))
* Enhanced `values` method to group compound medication fields under a single key and added explicit processing for compound medications in `originate` and `edit` methods. (`canvas_sdk/commands/commands/prescribe.py`, [canvas_sdk/commands/commands/prescribe.pyR165-R231](diffhunk://#diff-1e1a93716aa021330b243fdd4ad4f021a4ed6064dad656b64094395cd26812e4R165-R231))

### Refactoring in `CompoundMedication` class:
* Added static methods for processing (`process_formulation`, `process_ndc`, `process_compound_medication_data`) and validating (`validate_compound_medication_fields`) compound medication fields, replacing inline logic. (`canvas_sdk/effects/compound_medications/compound_medication.py`, [canvas_sdk/effects/compound_medications/compound_medication.pyL27-R176](diffhunk://#diff-928bdfa7592649b4b8e8e3d7aeb812a30c6396adfe580c5aeff85f63813e228bL27-R176))
* Updated `create` and `update` methods to apply explicit processing to compound medication data before generating effects. (`canvas_sdk/effects/compound_medications/compound_medication.py`, [canvas_sdk/effects/compound_medications/compound_medication.pyL168-R266](diffhunk://#diff-928bdfa7592649b4b8e8e3d7aeb812a30c6396adfe580c5aeff85f63813e228bL168-R266))

### Updates to tests:
* Modified tests to validate raw, unprocessed data for compound medication fields, aligning with the updated `values` method behavior. (`canvas_sdk/tests/effects/compound_medications/test_compound_medication.py`, [canvas_sdk/tests/effects/compound_medications/test_compound_medication.pyL369-R370](diffhunk://#diff-360706e18b37696cdb382bf7eec6f51c2b015d2d9ca050fbc6f7b71e6a8dc6abL369-R370))
