### PR TITLE
chore: do not run auto update action on forks

### DIFF
--- a/.github/workflows/pre-commit-auto-update.yml
+++ b/.github/workflows/pre-commit-auto-update.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   pre-commit-auto-update:
-    if: github.repository == 'canvas-medical/canvas-plugins'
+    if: github.repository_owner == 'canvas-medical'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/pre-commit-auto-update.yml
+++ b/.github/workflows/pre-commit-auto-update.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   pre-commit-auto-update:
+    if: github.repository == 'canvas-medical/canvas-plugins'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
The `pre-commit-auto-update` action is scheduled to run nightly and runs on all forks as well. Forks do not have access to `PROJECT_AND_REPO_PAT` (correctly) but this causes the job to fail and email alerts to be sent nightly on every fork

Update workflow to only run on `canvas-medical/canvas-plugins` to reduce the noise