### PR TITLE
feat: add warnings if many files, large files, or large total size are found

### DIFF
--- a/canvas_cli/apps/plugin/plugin.py
+++ b/canvas_cli/apps/plugin/plugin.py
@@ -73,6 +73,7 @@ def _build_package(package: Path) -> Path:
 
                 # Skip files and directories matching the ignore patterns
                 if ignore_patterns.match_file(path):
+                    continue
 
                 file_count += 1
 

--- a/canvas_cli/apps/plugin/plugin.py
+++ b/canvas_cli/apps/plugin/plugin.py
@@ -100,7 +100,7 @@ def _build_package(package: Path) -> Path:
 
             if file_size_total > ONE_MEGABYTE:
                 print(
-                    "Warning: >1mb of content found when packaging plug, "
+                    "Warning: >1mb of content found when packaging plugin, "
                     "ensure that unneeded files are not included in the "
                     "plugin directory"
                 )

--- a/canvas_cli/apps/plugin/plugin.py
+++ b/canvas_cli/apps/plugin/plugin.py
@@ -19,6 +19,8 @@ from canvas_cli.utils.validators import validate_manifest_file
 
 CANVAS_IGNORE_FILENAME = ".canvasignore"
 
+ONE_MEGABYTE = 1024 * 1024
+
 
 def plugin_url(host: str, *paths: str) -> str:
     """Generates the plugin url for managing plugins in a Canvas instance."""
@@ -80,6 +82,13 @@ def _build_package(package: Path) -> Path:
                 stat = path.stat()
                 file_size_total += stat.st_size
 
+                if stat.st_size > ONE_MEGABYTE:
+                    print(
+                        f'Warning: >1mb file found: "{path.name}", '
+                        "ensure that unneeded files are not included in the "
+                        "plugin directory"
+                    )
+
                 tar.add(path, arcname=path.relative_to(package))
 
             if file_count > 100:
@@ -89,7 +98,7 @@ def _build_package(package: Path) -> Path:
                     "plugin directory"
                 )
 
-            if file_size_total > (1024 * 1024):
+            if file_size_total > ONE_MEGABYTE:
                 print(
                     "Warning: >1mb of content found when packaging plug, "
                     "ensure that unneeded files are not included in the "


### PR DESCRIPTION
Based on a need surfaced when we had a customer use a virtualenv inside their plugin directory that was not prefixed with a `.`.

 Uploading this plugin resulted in a 500 error from the instance when it ran out of memory and was killed.

I used limits of 100 files and 1 megabyte for the warnings.