### PR TITLE
docs: add example plugin - Note and Commands API

### DIFF
--- a/example-plugins/charting_api_examples/CANVAS_MANIFEST.json
+++ b/example-plugins/charting_api_examples/CANVAS_MANIFEST.json
@@ -13,6 +13,15 @@
                     "read": [],
                     "write": []
                 }
+            },
+            {
+                "class": "charting_api_examples.routes.billing_line_items:BillingLineItemAPI",
+                "description": "Endpoints for interacting with billing line items on a note.",
+                "data_access": {
+                    "event": "",
+                    "read": [],
+                    "write": []
+                }
             }
         ],
         "commands": [],

--- a/example-plugins/charting_api_examples/CANVAS_MANIFEST.json
+++ b/example-plugins/charting_api_examples/CANVAS_MANIFEST.json
@@ -22,6 +22,15 @@
                     "read": [],
                     "write": []
                 }
+            },
+            {
+                "class": "charting_api_examples.routes.commands:CommandAPI",
+                "description": "Endpoints for interacting with commands on a note.",
+                "data_access": {
+                    "event": "",
+                    "read": [],
+                    "write": []
+                }
             }
         ],
         "commands": [],

--- a/example-plugins/charting_api_examples/CANVAS_MANIFEST.json
+++ b/example-plugins/charting_api_examples/CANVAS_MANIFEST.json
@@ -1,0 +1,29 @@
+{
+    "sdk_version": "0.1.4",
+    "plugin_version": "0.0.1",
+    "name": "charting_api_examples",
+    "description": "A series of custom API routes that showcase SDK charting functionality",
+    "components": {
+        "protocols": [
+            {
+                "class": "charting_api_examples.routes.notes:NoteAPI",
+                "description": "Endpoints that showcase interactions with notes.",
+                "data_access": {
+                    "event": "",
+                    "read": [],
+                    "write": []
+                }
+            }
+        ],
+        "commands": [],
+        "content": [],
+        "effects": [],
+        "views": []
+    },
+    "secrets": ["simpleapi-api-key"],
+    "tags": {},
+    "references": [],
+    "license": "",
+    "diagram": false,
+    "readme": "./README.md"
+}

--- a/example-plugins/charting_api_examples/README.md
+++ b/example-plugins/charting_api_examples/README.md
@@ -1,0 +1,22 @@
+# Charting API Examples
+
+This example plugin provides several examples of how you can automate charting
+in Canvas.
+
+- Notes
+  - Creating a note
+  - Getting information about a note
+  - Searching for notes by patient, type, and date of service
+  - Adding or removing a note's billing line items
+- Commands
+  - Creating a command
+  - Creating multiple commands from a single request
+  - Committing a previously created command
+  - Creating a command and committing it in a single request
+
+## Configuration
+
+All of the example endpoints in this plugin are protected with [API key
+authentication](https://docs.canvasmedical.com/sdk/handlers-simple-api-http/#api-key-1).
+Once installed, you'll need to set the `simpleapi-api-key` value on the plugin's
+configuration page in your EHR.

--- a/example-plugins/charting_api_examples/README.md
+++ b/example-plugins/charting_api_examples/README.md
@@ -1,13 +1,13 @@
 # Charting API Examples
 
-This example plugin provides several examples of how you can automate charting
-in Canvas.
+This example plugin provides several examples of APIs you might define when
+automating charting in Canvas.
 
 - Notes
   - Creating a note
   - Getting information about a note
   - Searching for notes by patient, type, and date of service
-  - Adding or removing a note's billing line items
+  - Adding billing line items to a note
 - Commands
   - Creating a command
   - Creating multiple commands from a single request

--- a/example-plugins/charting_api_examples/README.md
+++ b/example-plugins/charting_api_examples/README.md
@@ -11,7 +11,6 @@ automating charting in Canvas.
 - Commands
   - Creating a command
   - Creating multiple commands from a single request
-  - Committing a previously created command
   - Creating a command and committing it in a single request
 
 ## Configuration
@@ -20,3 +19,198 @@ All of the example endpoints in this plugin are protected with [API key
 authentication](https://docs.canvasmedical.com/sdk/handlers-simple-api-http/#api-key-1).
 Once installed, you'll need to set the `simpleapi-api-key` value on the plugin's
 configuration page in your EHR.
+
+## Endpoint Documentation
+
+### Search Notes
+
+`GET /plugin-io/api/charting_api_examples/notes/`
+
+This endpoint allows the retrieval of an optionally filtered set of notes. The results are paginated, and the client can exert some control over the page size. The response body will include an attribute, `next_page`, which will either contain a URL to the next page of the same filtered set or be `null`, indicating there are no more records to fetch.
+
+#### Optional query parameters:
+
+##### limit
+
+*int*
+
+Determines the number of results to return per page.
+
+- If unspecified, the default is 10.
+- If a number less than 1 is specified, 1 will be used.
+- If a number greate than 100 is specified, 100 will be used.
+
+##### offset
+
+*int*
+
+Number of records to skip with returning results. When used with **limit**, this enables the pagination of results.
+
+- If unspecified, the default is 0.
+- If a number less than 0 is specified, 0 will be used.
+
+
+##### patient_id
+
+*str*
+
+Filters the notes returned to just those associated with the given patient.
+
+##### note_type
+
+*coding*
+
+You can search by just the code value or you can search by the
+system and code in the format "system|code" (e.g. `http://snomed.info/sct|308335008`).
+
+##### datetime_of_service
+
+*iso8601 formatted datetime string*
+
+Exact match for notes with the given datetime.
+
+##### datetime_of_service__gt
+
+*iso8601 formatted datetime string*
+
+Filter to notes occurring after the given datetime.
+
+##### datetime_of_service__gte
+
+*iso8601 formatted datetime string*
+
+Filter to notes occurring at or after the given datetime.
+
+##### datetime_of_service__lt
+
+*iso8601 formatted datetime string*
+
+Filter to notes occurring before the given datetime.
+
+##### datetime_of_service__lte
+
+*iso8601 formatted datetime string*
+
+Filter to notes occurring at or before the given datetime.
+
+#### Example Response
+
+```json
+{
+  "next_page": "https://training.canvasmedical.com/plugin-io/api/charting_api_examples/notes/?limit=2&offset=6",
+  "count": 2,
+  "notes": [
+    {
+      "id": "10ff2047-6301-4ab4-81cd-b500e7df8ef7",
+      "patient_id": "5350cd20de8a470aa570a852859ac87e",
+      "provider_id": "5843991a8c934118ab4f424c839b340f",
+      "datetime_of_service": "2025-02-21 23:31:45.627894+00:00",
+      "note_type": {
+        "id": "c5df4f03-58e4-442b-ad6c-0d3dadc6b726",
+        "name": "Office visit",
+        "coding": {
+          "display": "Office Visit",
+          "code": "308335008",
+          "system": "http://snomed.info/sct"
+        }
+      }
+    },
+    {
+      "id": "4dba128f-96cc-4dd0-814b-a064bfdcde7e",
+      "patient_id": "5350cd20de8a470aa570a852859ac87e",
+      "provider_id": "336159560091471cb6b0e149d9054697",
+      "datetime_of_service": "2025-02-21 23:31:45.928071+00:00",
+      "note_type": {
+        "id": "c5df4f03-58e4-442b-ad6c-0d3dadc6b726",
+        "name": "Office visit",
+        "coding": {
+          "display": "Office Visit",
+          "code": "308335008",
+          "system": "http://snomed.info/sct"
+        }
+      }
+    }
+  ]
+}
+```
+
+### Read a Note
+
+`GET /plugin-io/api/charting_api_examples/notes/<note-id>/`
+
+#### Example Response
+
+```json
+{
+  "note": {
+    "id": "1490b8db-00a9-47d9-9170-ec142460b586",
+    "patient_id": "5350cd20de8a470aa570a852859ac87e",
+    "provider_id": "6b33e69474234f299a56d480b03476d3",
+    "datetime_of_service": "2025-10-02 23:30:00+00:00",
+    "state": "NEW",
+    "note_type": {
+      "id": "c5df4f03-58e4-442b-ad6c-0d3dadc6b726",
+      "name": "Office visit",
+      "coding": {
+        "display": "Office Visit",
+        "code": "308335008",
+        "system": "http://snomed.info/sct"
+      }
+    }
+  }
+}
+```
+
+### Create a Note
+
+`POST /plugin-io/api/charting_api_examples/notes/`
+
+#### Example Request Body
+
+```json
+{
+  "practice_location_id": "306b19f0-231a-4cd4-ad2d-a55c885fd9f8",
+  "note_type_id": "c5df4f03-58e4-442b-ad6c-0d3dadc6b726",
+  "patient_id": "5350cd20de8a470aa570a852859ac87e",
+  "provider_id": "6b33e69474234f299a56d480b03476d3",
+  "datetime_of_service": "2025-10-04 23:30:00",
+  "title": "My cool note"
+}
+```
+
+### Add Billing Line Item to a Note
+
+`POST /plugin-io/api/charting_api_examples/notes/<note-id>/billing_line_items/`
+
+#### Example Request Body
+
+```json
+{
+  "cpt_code": "98008"
+}
+```
+
+### Add a Diagnose Command to a Note
+
+`POST /plugin-io/api/charting_api_examples/notes/<note-id>/diagnose/`
+
+`icd10_code` is required, but `committed` may be true, false, or omitted entirely.
+
+#### Example Request Body
+
+```json
+{
+  "icd10_code": "E119",
+  "committed": true
+}
+```
+
+### Add Multiple Commands to a Note
+
+`POST /plugin-io/api/charting_api_examples/notes/<note-id>/prechart/`
+
+#### Example Request Body
+
+```json
+null
+```

--- a/example-plugins/charting_api_examples/routes/billing_line_items.py
+++ b/example-plugins/charting_api_examples/routes/billing_line_items.py
@@ -1,0 +1,53 @@
+from http import HTTPStatus
+
+from canvas_sdk.effects import Effect
+from canvas_sdk.effects.billing_line_item import AddBillingLineItem
+from canvas_sdk.effects.simple_api import JSONResponse, Response
+from canvas_sdk.handlers.simple_api import APIKeyAuthMixin, SimpleAPI, api
+from canvas_sdk.v1.data.note import Note
+
+from charting_api_examples.util import get_note_from_path_params, note_not_found_response
+
+
+class BillingLineItemAPI(APIKeyAuthMixin, SimpleAPI):
+    PREFIX = "/notes"
+
+    """
+    POST /plugin-io/api/charting_api_examples/notes/<note-id>/billing_line_items/
+    Headers: "Authorization <your value for 'simpleapi-api-key'>"
+    Body: {
+        "cpt_code": "98006"
+    }
+    """
+    @api.post("/<id>/billing_line_items/")
+    def add_billing_line_item(self) -> list[Response | Effect]:
+        required_attributes = {"cpt_code",}
+        request_body = self.request.json()
+        missing_attributes = required_attributes - request_body.keys()
+        if len(missing_attributes) > 0:
+            return [
+                JSONResponse(
+                    {"error": f"Missing required attribute(s): {', '.join(missing_attributes)}"},
+                    # Normally you should use a constant, but this status
+                    # code's constant changes in 3.13 from
+                    # UNPROCESSABLE_ENTITY to UNPROCESSABLE_CONTENT. Using the
+                    # number directly here avoids that future breakage.
+                    status_code=422,
+                )
+            ]
+
+        note = get_note_from_path_params(self.request.path_params)
+        if not note:
+            return note_not_found_response()
+
+        # To see what else you can do with billing line items, visit our docs:
+        # https://docs.canvasmedical.com/sdk/effect-billing-line-items/#adding-a-billing-line-item
+        effect = AddBillingLineItem(
+            note_id=str(note.id),
+            cpt=request_body["cpt_code"],
+        )
+
+        return [
+            effect.apply(),
+            JSONResponse({"message": "Billing line item data accepted for creation"}, status_code=HTTPStatus.ACCEPTED)
+        ]

--- a/example-plugins/charting_api_examples/routes/commands.py
+++ b/example-plugins/charting_api_examples/routes/commands.py
@@ -1,0 +1,99 @@
+from http import HTTPStatus
+from uuid import uuid4
+
+from canvas_sdk.commands import (
+    DiagnoseCommand,
+    PhysicalExamCommand,
+    PlanCommand,
+    ReasonForVisitCommand,
+)
+from canvas_sdk.effects import Effect
+from canvas_sdk.effects.simple_api import JSONResponse, Response
+from canvas_sdk.handlers.simple_api import APIKeyAuthMixin, SimpleAPI, api
+from canvas_sdk.v1.data.note import Note
+
+from charting_api_examples.util import get_note_from_path_params, note_not_found_response
+
+
+class CommandAPI(APIKeyAuthMixin, SimpleAPI):
+    PREFIX = "/notes"
+
+    """
+    This shows how you can create an endpoint to insert a particular type of
+    command. In this example, it's a diagnose command. It can be committed or
+    left uncommitted.
+
+    POST /plugin-io/api/charting_api_examples/notes/<note-id>/diagnose/
+    Headers: "Authorization <your value for 'simpleapi-api-key'>"
+    Body: {
+        "icd10_code": "E11.9",
+        "committed": false
+    }
+    """
+    @api.post("/<id>/diagnose/")
+    def add_diagnose_command(self) -> list[Response | Effect]:
+        required_attributes = {"icd10_code",}
+        request_body = self.request.json()
+        missing_attributes = required_attributes - request_body.keys()
+        if len(missing_attributes) > 0:
+            return [
+                JSONResponse(
+                    {"error": f"Missing required attribute(s): {', '.join(missing_attributes)}"},
+                    # Normally you should use a constant, but this status
+                    # code's constant changes in 3.13 from
+                    # UNPROCESSABLE_ENTITY to UNPROCESSABLE_CONTENT. Using the
+                    # number directly here avoids that future breakage.
+                    status_code=422,
+                )
+            ]
+
+        note = get_note_from_path_params(self.request.path_params)
+        if not note:
+            return note_not_found_response()
+
+        diagnose_command = DiagnoseCommand(
+            note_uuid=str(note.id),
+            icd10_code=request_body["icd10_code"].upper(),
+        )
+
+        if request_body.get("committed"):
+            # To chain command effects, you must know what the command's id
+            # is. To accomplish that, we set the id ourselves rather than
+            # allow the database to assign one.
+            diagnose_command.command_uuid = str(uuid4())
+            command_effects = [diagnose_command.originate(), diagnose_command.commit()]
+        else:
+            command_effects = [diagnose_command.originate()]
+
+        return [
+            *command_effects,
+            JSONResponse({"message": "Command data accepted for creation"}, status_code=HTTPStatus.ACCEPTED)
+        ]
+
+    """
+    This shows how you can originate many commands from the same request.
+
+    POST /plugin-io/api/charting_api_examples/notes/<note-id>/prechart/
+    Headers: "Authorization <your value for 'simpleapi-api-key'>"
+    Body: {
+    }
+    """
+    @api.post("/<id>/prechart/")
+    def add_precharting_commands(self) -> list[Response | Effect]:
+        request_body = self.request.json()
+
+        note = get_note_from_path_params(self.request.path_params)
+        if not note:
+            return note_not_found_response()
+
+        rfv = ReasonForVisitCommand(note_uuid=str(note.id))
+        exam = PhysicalExamCommand(note_uuid=str(note.id))
+        diagnose = DiagnoseCommand(note_uuid=str(note.id))
+        plan = PlanCommand(note_uuid=str(note.id))
+        return [
+            rfv.originate(),
+            exam.originate(),
+            diagnose.originate(),
+            plan.originate(),
+            JSONResponse({"message": "Command data accepted for creation"}, status_code=HTTPStatus.ACCEPTED)
+        ]

--- a/example-plugins/charting_api_examples/routes/notes.py
+++ b/example-plugins/charting_api_examples/routes/notes.py
@@ -141,10 +141,10 @@ class NoteAPI(APIKeyAuthMixin, SimpleAPI):
         ]
 
     """
-    GET /plugin-io/api/charting_api_examples/notes/<note-id>
+    GET /plugin-io/api/charting_api_examples/notes/<note-id>/
     Headers: "Authorization <your value for 'simpleapi-api-key'>"
     """
-    @api.get("/<id>")
+    @api.get("/<id>/")
     def read(self) -> list[Response | Effect]:
         return [
             JSONResponse({"message": "Note read!"})

--- a/example-plugins/charting_api_examples/routes/notes.py
+++ b/example-plugins/charting_api_examples/routes/notes.py
@@ -1,0 +1,83 @@
+import arrow
+
+from canvas_sdk.effects import Effect
+from canvas_sdk.effects.simple_api import JSONResponse, Response
+from canvas_sdk.handlers.simple_api import APIKeyAuthMixin, SimpleAPI, api
+from canvas_sdk.v1.data.note import Note
+
+class NoteAPI(APIKeyAuthMixin, SimpleAPI):
+    PREFIX = "/notes"
+
+    """
+    GET /plugin-io/api/charting_api_examples/notes
+    Headers: "Authorization <your value for 'simpleapi-api-key'>"
+    """
+    @api.get("/")
+    def index(self) -> list[Response | Effect]:
+        notes = Note.objects.order_by('dbid')
+        query_params = self.request.query_params
+        if 'patient_id' in query_params:
+            notes = notes.filter(patient__id=query_params['patient_id'])
+        if 'note_type' in query_params:
+            # You can search by just the code value or you can search by the
+            # system and code in the format system|code (e.g
+            # http://snomed.info/sct|308335008).
+            if '|' in query_params['note_type']:
+                system, code = query_params['note_type'].split('|')
+                notes = notes.filter(note_type__system=system, note_type__code=code)
+            else:
+                notes = notes.filter(note_type__code=query_params['note_type'])
+        if 'datetime_of_service' in query_params:
+            notes = notes.filter(datetime_of_service=query_params['datetime_of_service'])
+        if 'datetime_of_service__gt' in query_params:
+            notes = notes.filter(datetime_of_service__gt=query_params['datetime_of_service__gt'])
+        if 'datetime_of_service__gte' in query_params:
+            notes = notes.filter(datetime_of_service__gte=query_params['datetime_of_service__gte'])
+        if 'datetime_of_service__lt' in query_params:
+            notes = notes.filter(datetime_of_service__lt=query_params['datetime_of_service__lt'])
+        if 'datetime_of_service__lte' in query_params:
+            notes = notes.filter(datetime_of_service__lte=query_params['datetime_of_service__lte'])
+        return [
+            JSONResponse({
+                "notes": [{
+                    "id": str(note.id),
+                    "patient_id": str(note.patient.id),
+                    "provider_id": str(note.provider.id),
+                    "datetime_of_service": str(note.datetime_of_service),
+                } for note in notes]
+            })
+        ]
+
+    """
+    POST /plugin-io/api/charting_api_examples/notes
+    Headers: "Authorization <your value for 'simpleapi-api-key'>"
+    Body: {
+    }
+    """
+    @api.post("/")
+    def create(self) -> list[Response | Effect]:
+        return [
+            JSONResponse({"message": "Note create!"})
+        ]
+
+    """
+    GET /plugin-io/api/charting_api_examples/notes/<note-id>
+    Headers: "Authorization <your value for 'simpleapi-api-key'>"
+    """
+    @api.get("/<id>")
+    def read(self) -> list[Response | Effect]:
+        return [
+            JSONResponse({"message": "Note read!"})
+        ]
+
+    """
+    POST /plugin-io/api/charting_api_examples/notes/<note-id>/billing_line_items
+    Headers: "Authorization <your value for 'simpleapi-api-key'>"
+    Body: {
+    }
+    """
+    @api.post("/<id>/billing_line_items")
+    def add_billing_line_item(self) -> list[Response | Effect]:
+        return [
+            JSONResponse({"message": "Billing line item create!"})
+        ]

--- a/example-plugins/charting_api_examples/routes/notes.py
+++ b/example-plugins/charting_api_examples/routes/notes.py
@@ -9,41 +9,76 @@ class NoteAPI(APIKeyAuthMixin, SimpleAPI):
     PREFIX = "/notes"
 
     """
-    GET /plugin-io/api/charting_api_examples/notes
+    GET /plugin-io/api/charting_api_examples/notes/
     Headers: "Authorization <your value for 'simpleapi-api-key'>"
     """
     @api.get("/")
     def index(self) -> list[Response | Effect]:
-        notes = Note.objects.order_by('dbid')
+        notes = Note.objects.select_related('patient', 'provider', 'note_type_version').order_by("dbid")
         query_params = self.request.query_params
-        if 'patient_id' in query_params:
-            notes = notes.filter(patient__id=query_params['patient_id'])
-        if 'note_type' in query_params:
+
+        # User specified, default 10, min 1, max 100
+        limit = min(max(int(query_params.get("limit", 10)), 1), 100)
+        # User specified, default 0, min 0, no max
+        offset = max(int(query_params.get("offset", 0)), 0)
+
+        if "patient_id" in query_params:
+            notes = notes.filter(patient__id=query_params["patient_id"])
+        if "note_type" in query_params:
             # You can search by just the code value or you can search by the
             # system and code in the format system|code (e.g
             # http://snomed.info/sct|308335008).
-            if '|' in query_params['note_type']:
-                system, code = query_params['note_type'].split('|')
-                notes = notes.filter(note_type__system=system, note_type__code=code)
+            if "|" in query_params["note_type"]:
+                system, code = query_params["note_type"].split("|")
+                notes = notes.filter(note_type_version__system=system, note_type_version__code=code)
             else:
-                notes = notes.filter(note_type__code=query_params['note_type'])
-        if 'datetime_of_service' in query_params:
-            notes = notes.filter(datetime_of_service=query_params['datetime_of_service'])
-        if 'datetime_of_service__gt' in query_params:
-            notes = notes.filter(datetime_of_service__gt=query_params['datetime_of_service__gt'])
-        if 'datetime_of_service__gte' in query_params:
-            notes = notes.filter(datetime_of_service__gte=query_params['datetime_of_service__gte'])
-        if 'datetime_of_service__lt' in query_params:
-            notes = notes.filter(datetime_of_service__lt=query_params['datetime_of_service__lt'])
-        if 'datetime_of_service__lte' in query_params:
-            notes = notes.filter(datetime_of_service__lte=query_params['datetime_of_service__lte'])
+                notes = notes.filter(note_type_version__code=query_params["note_type"])
+        if "datetime_of_service" in query_params:
+            notes = notes.filter(datetime_of_service=query_params["datetime_of_service"])
+        if "datetime_of_service__gt" in query_params:
+            notes = notes.filter(datetime_of_service__gt=query_params["datetime_of_service__gt"])
+        if "datetime_of_service__gte" in query_params:
+            notes = notes.filter(datetime_of_service__gte=query_params["datetime_of_service__gte"])
+        if "datetime_of_service__lt" in query_params:
+            notes = notes.filter(datetime_of_service__lt=query_params["datetime_of_service__lt"])
+        if "datetime_of_service__lte" in query_params:
+            notes = notes.filter(datetime_of_service__lte=query_params["datetime_of_service__lte"])
+
+        # If there are more results matching the filter after the ones we're
+        # returning, provide the link to the next page with the proper offset.
+        # If there aren't any more results, return None so the client can tell
+        # that there are no more results to fetch.
+        link_to_next = None
+        if notes[offset+limit:].count() > 0:
+            requested_uri = self.context.get("absolute_uri")
+            if "offset" in query_params:
+                link_to_next = requested_uri.replace(f"offset={offset}", f"offset={offset+limit}")
+            else:
+                param_separator = "?" if len(query_params) == 0 else "&"
+                link_to_next = requested_uri + f"{param_separator}offset={offset+limit}"
+
+        # Apply limit and offset
+        notes = notes[offset:offset+limit]
+
+        count = len(notes)
         return [
             JSONResponse({
+                "next_page": link_to_next,
+                "count": count,
                 "notes": [{
                     "id": str(note.id),
                     "patient_id": str(note.patient.id),
                     "provider_id": str(note.provider.id),
                     "datetime_of_service": str(note.datetime_of_service),
+                    "note_type": {
+                        "id": str(note.note_type_version.id),
+                        "name": note.note_type_version.name,
+                        "coding": {
+                            "display": note.note_type_version.display,
+                            "code": note.note_type_version.code,
+                            "system": note.note_type_version.system,
+                        },
+                    },
                 } for note in notes]
             })
         ]

--- a/example-plugins/charting_api_examples/util.py
+++ b/example-plugins/charting_api_examples/util.py
@@ -1,0 +1,33 @@
+from uuid import UUID
+from http import HTTPStatus
+
+from canvas_sdk.effects.simple_api import JSONResponse
+from canvas_sdk.v1.data.note import Note
+
+
+def is_valid_uuid(possible_uuid):
+    try:
+        uuid_obj = UUID(possible_uuid, version=4)
+    except ValueError:
+        return False
+    return str(uuid_obj) == possible_uuid
+
+
+def note_not_found_response():
+    return JSONResponse(
+        {"error": "Note not found."},
+        status_code=HTTPStatus.NOT_FOUND,
+    )
+
+
+def get_note_from_path_params(path_params) -> Note | None:
+    note_id = path_params["id"]
+    # Ensure the note id is a valid UUID
+    if not is_valid_uuid(note_id):
+        return None
+
+    try:
+        note = Note.objects.get(id=note_id)
+    except (Note.DoesNotExist):
+        return None
+    return note


### PR DESCRIPTION
This PR adds an example plugin which shows how a developer can create APIs to manage notes and commands.