### PR TITLE
feat: add support for the match operator

### DIFF
--- a/plugin_runner/sandbox.py
+++ b/plugin_runner/sandbox.py
@@ -347,7 +347,7 @@ class Sandbox:
 
         def visit_AnnAssign(self, node: AnnAssign) -> AnnAssign:
             """Allow type annotations."""
-            return node
+            return self.node_contents_visit(node)
 
         def visit_Match(self, node: ast.Match) -> ast.Match:
             """Allow `match`."""

--- a/plugin_runner/tests/test_sandbox.py
+++ b/plugin_runner/tests/test_sandbox.py
@@ -172,6 +172,21 @@ def test_support_match_tuple() -> None:
     sandbox.execute()
 
 
+def test_support_type_annotations() -> None:
+    """Test that type annotations work."""
+    sandbox = _sandbox_from_code(
+        """
+            point: int = 5
+            name: str = "name"
+
+            assert point == 5
+            assert name == "name"
+        """
+    )
+
+    sandbox.execute()
+
+
 @pytest.mark.parametrize("canvas_module", CANVAS_SUBMODULE_NAMES)
 def test_all_modules_implement_canvas_allowed_attributes(canvas_module: str) -> None:
     """


### PR DESCRIPTION
Add support for the Python `match` operator and associated tests. This allows plugin code to use the `match` operator.

https://canvasmedical.atlassian.net/browse/KOALA-3127