### PR TITLE
chore: update question toggle tests to patch the correct method

### DIFF
--- a/canvas_sdk/tests/commands/test_toggle_questions_mixin.py
+++ b/canvas_sdk/tests/commands/test_toggle_questions_mixin.py
@@ -1,4 +1,5 @@
 import uuid
+from typing import cast
 from unittest.mock import Mock, PropertyMock, patch
 
 import pytest
@@ -8,11 +9,19 @@ from canvas_sdk.commands.commands.questionnaire.toggle_questions import ToggleQu
 from canvas_sdk.v1.data import Command
 
 
-class TestCommand(ToggleQuestionsMixin, QuestionnaireCommand):
-    """Test command that uses the ToggleQuestionsMixin."""
+@pytest.fixture(scope="module")
+def TestCommand() -> type[ToggleQuestionsMixin]:
+    """Create a test command class that uses the ToggleQuestionsMixin."""
 
-    class Meta:
-        key = "test"
+    class TestCommand(ToggleQuestionsMixin, QuestionnaireCommand):
+        """Test command that uses the ToggleQuestionsMixin."""
+
+        __test__ = False  # Prevent pytest from treating this as a test case
+
+        class Meta:
+            key = "test"
+
+    return cast(type[ToggleQuestionsMixin], TestCommand)
 
 
 COMMAND_ID = str(uuid.uuid4())
@@ -20,20 +29,20 @@ QUESTIONNAIRE_ID = str(uuid.uuid4())
 
 
 @pytest.fixture
-def command_without_uuid() -> TestCommand:
+def command_without_uuid(TestCommand: type[QuestionnaireCommand]) -> ToggleQuestionsMixin:
     """Create a command instance without a command_uuid."""
-    return TestCommand(questionnaire_id=QUESTIONNAIRE_ID)
+    return cast(ToggleQuestionsMixin, TestCommand(questionnaire_id=QUESTIONNAIRE_ID))
 
 
 @pytest.fixture
-def command_with_uuid() -> TestCommand:
+def command_with_uuid(TestCommand: type[QuestionnaireCommand]) -> ToggleQuestionsMixin:
     """Create a command instance with a command_uuid."""
     cmd = TestCommand(questionnaire_id=QUESTIONNAIRE_ID)
     cmd.command_uuid = COMMAND_ID
-    return cmd
+    return cast(ToggleQuestionsMixin, cmd)
 
 
-def test_initial_state_without_command_uuid(command_without_uuid: TestCommand) -> None:
+def test_initial_state_without_command_uuid(command_without_uuid: ToggleQuestionsMixin) -> None:
     """Test that a new command without UUID has empty toggle states."""
     assert command_without_uuid._question_toggles is None
     toggles = command_without_uuid.question_toggles
@@ -41,70 +50,70 @@ def test_initial_state_without_command_uuid(command_without_uuid: TestCommand) -
     assert command_without_uuid._question_toggles == {}
 
 
-@patch.object(Command.objects, "values_list")
-def test_load_persisted_toggles_success(
-    mock_values_list: Mock, command_with_uuid: TestCommand
-) -> None:
+def test_load_persisted_toggles_success(command_with_uuid: ToggleQuestionsMixin) -> None:
     """Test loading toggle states from an existing command."""
     # Mock the database response
-    mock_get = Mock()
-    mock_get.get.return_value = {
-        "skip-123": True,
-        "skip-456": False,
-        "skip-789": True,
-        "other-field": "ignored",
-    }
-    mock_values_list.return_value = mock_get
+    with patch(
+        "canvas_sdk.commands.commands.questionnaire.toggle_questions.Command.objects.values_list"
+    ) as mock_values_list:
+        mock_get = Mock()
+        mock_get.get.return_value = {
+            "skip-123": True,
+            "skip-456": False,
+            "skip-789": True,
+            "other-field": "ignored",
+        }
+        mock_values_list.return_value = mock_get
 
-    # Trigger loading
-    toggles = command_with_uuid.question_toggles
+        # Trigger loading
+        toggles = command_with_uuid.question_toggles
 
-    # Verify correct loading
-    assert toggles == {"123": True, "456": False, "789": True}
-    mock_values_list.assert_called_once_with("data", flat=True)
-    mock_get.get.assert_called_once_with(id=COMMAND_ID)
+        # Verify correct loading
+        assert toggles == {"123": True, "456": False, "789": True}
+        mock_values_list.assert_called_once_with("data", flat=True)
+        mock_get.get.assert_called_once_with(id=COMMAND_ID)
 
 
-@patch.object(Command.objects, "values_list")
-def test_load_persisted_toggles_command_not_found(
-    mock_values_list: Mock, command_with_uuid: TestCommand
-) -> None:
+def test_load_persisted_toggles_command_not_found(command_with_uuid: ToggleQuestionsMixin) -> None:
     """Test behavior when command doesn't exist in database."""
-    # Mock DoesNotExist exception
-    mock_get = Mock()
-    mock_get.get.side_effect = Command.DoesNotExist()
-    mock_values_list.return_value = mock_get
+    with patch(
+        "canvas_sdk.commands.commands.questionnaire.toggle_questions.Command.objects.values_list"
+    ) as mock_values_list:
+        # Mock DoesNotExist exception
+        mock_get = Mock()
+        mock_get.get.side_effect = Command.DoesNotExist()
+        mock_values_list.return_value = mock_get
 
-    # Should not raise, just return empty
-    toggles = command_with_uuid.question_toggles
-    assert toggles == {}
+        # Should not raise, just return empty
+        toggles = command_with_uuid.question_toggles
+        assert toggles == {}
 
 
-def test_is_question_enabled_default(command_without_uuid: TestCommand) -> None:
+def test_is_question_enabled_default(command_without_uuid: ToggleQuestionsMixin) -> None:
     """Test that questions default to None when not found."""
     assert command_without_uuid.is_question_enabled("123") is None
     assert command_without_uuid.is_question_enabled(456) is None
 
 
-@patch.object(Command.objects, "values_list")
-def test_is_question_enabled_with_persisted_state(
-    mock_values_list: Mock, command_with_uuid: TestCommand
-) -> None:
+def test_is_question_enabled_with_persisted_state(command_with_uuid: ToggleQuestionsMixin) -> None:
     """Test is_question_enabled with persisted states."""
-    # Mock persisted states
-    mock_get = Mock()
-    mock_get.get.return_value = {
-        "skip-123": True,
-        "skip-456": False,
-    }
-    mock_values_list.return_value = mock_get
+    with patch(
+        "canvas_sdk.commands.commands.questionnaire.toggle_questions.Command.objects.values_list"
+    ) as mock_values_list:
+        # Mock persisted states
+        mock_get = Mock()
+        mock_get.get.return_value = {
+            "skip-123": True,
+            "skip-456": False,
+        }
+        mock_values_list.return_value = mock_get
 
-    assert command_with_uuid.is_question_enabled("123") is True
-    assert command_with_uuid.is_question_enabled("456") is False
-    assert command_with_uuid.is_question_enabled("789") is None
+        assert command_with_uuid.is_question_enabled("123") is True
+        assert command_with_uuid.is_question_enabled("456") is False
+        assert command_with_uuid.is_question_enabled("789") is None
 
 
-def test_set_question_enabled(command_without_uuid: TestCommand) -> None:
+def test_set_question_enabled(command_without_uuid: ToggleQuestionsMixin) -> None:
     """Test setting question enabled states."""
     # Enable a question
     command_without_uuid.set_question_enabled("123", True)
@@ -119,23 +128,23 @@ def test_set_question_enabled(command_without_uuid: TestCommand) -> None:
     assert command_without_uuid.is_question_enabled("456") is True
 
 
-@patch.object(Command.objects, "values_list")
-def test_runtime_changes_override_persisted(
-    mock_values_list: Mock, command_with_uuid: TestCommand
-) -> None:
+def test_runtime_changes_override_persisted(command_with_uuid: ToggleQuestionsMixin) -> None:
     """Test that runtime changes override persisted states."""
-    # Mock persisted state
-    mock_get = Mock()
-    mock_get.get.return_value = {"skip-123": True}  # Persisted as enabled
-    mock_values_list.return_value = mock_get
+    with patch(
+        "canvas_sdk.commands.commands.questionnaire.toggle_questions.Command.objects.values_list"
+    ) as mock_values_list:
+        # Mock persisted state
+        mock_get = Mock()
+        mock_get.get.return_value = {"skip-123": True}  # Persisted as enabled
+        mock_values_list.return_value = mock_get
 
-    # Runtime change to disabled
-    command_with_uuid.set_question_enabled("123", False)
-    assert command_with_uuid.is_question_enabled("123") is False
+        # Runtime change to disabled
+        command_with_uuid.set_question_enabled("123", False)
+        assert command_with_uuid.is_question_enabled("123") is False
 
-    # Verify toggles show runtime state
-    toggles = command_with_uuid.question_toggles
-    assert toggles["123"] is False
+        # Verify toggles show runtime state
+        toggles = command_with_uuid.question_toggles
+        assert toggles["123"] is False
 
 
 @patch(
@@ -143,7 +152,7 @@ def test_runtime_changes_override_persisted(
     new_callable=PropertyMock,
 )
 def test_values_includes_skip_prefix(
-    mock_parent_values: PropertyMock, command_without_uuid: TestCommand
+    mock_parent_values: PropertyMock, command_without_uuid: ToggleQuestionsMixin
 ) -> None:
     """Test that values property adds skip- prefix correctly."""
     # Mock parent class values to avoid DB access
@@ -166,34 +175,36 @@ def test_values_includes_skip_prefix(
     "canvas_sdk.commands.commands.questionnaire.QuestionnaireCommand.values",
     new_callable=PropertyMock,
 )
-@patch.object(Command.objects, "values_list")
 def test_values_merges_persisted_and_runtime(
-    mock_values_list: Mock, mock_parent_values: PropertyMock, command_with_uuid: TestCommand
+    mock_parent_values: PropertyMock, command_with_uuid: ToggleQuestionsMixin
 ) -> None:
     """Test that values merges persisted and runtime states correctly."""
     # Mock parent class values
-    mock_parent_values.return_value = {"questionnaire_id": QUESTIONNAIRE_ID}
+    with patch(
+        "canvas_sdk.commands.commands.questionnaire.toggle_questions.Command.objects.values_list"
+    ) as mock_values_list:
+        mock_parent_values.return_value = {"questionnaire_id": QUESTIONNAIRE_ID}
 
-    # Mock persisted states
-    mock_get = Mock()
-    mock_get.get.return_value = {
-        "skip-123": True,
-        "skip-456": False,
-    }
-    mock_values_list.return_value = mock_get
+        # Mock persisted states
+        mock_get = Mock()
+        mock_get.get.return_value = {
+            "skip-123": True,
+            "skip-456": False,
+        }
+        mock_values_list.return_value = mock_get
 
-    # Add runtime changes
-    command_with_uuid.set_question_enabled("456", True)  # Override persisted
-    command_with_uuid.set_question_enabled("789", False)  # New toggle
+        # Add runtime changes
+        command_with_uuid.set_question_enabled("456", True)  # Override persisted
+        command_with_uuid.set_question_enabled("789", False)  # New toggle
 
-    values = command_with_uuid.values
+        values = command_with_uuid.values
 
-    assert values["skip-123"] is True  # From persisted
-    assert values["skip-456"] is True  # Runtime override
-    assert values["skip-789"] is False  # New runtime
+        assert values["skip-123"] is True  # From persisted
+        assert values["skip-456"] is True  # Runtime override
+        assert values["skip-789"] is False  # New runtime
 
 
-def test_question_toggles_returns_copy(command_without_uuid: TestCommand) -> None:
+def test_question_toggles_returns_copy(command_without_uuid: ToggleQuestionsMixin) -> None:
     """Test that question_toggles returns a copy, not the internal dict."""
     command_without_uuid.set_question_enabled("123", True)
 
@@ -204,33 +215,33 @@ def test_question_toggles_returns_copy(command_without_uuid: TestCommand) -> Non
     assert command_without_uuid.is_question_enabled("456") is None
 
 
-@patch.object(Command.objects, "values_list")
-def test_ensure_toggles_loaded_called_once(
-    mock_values_list: Mock, command_with_uuid: TestCommand
-) -> None:
+def test_ensure_toggles_loaded_called_once(command_with_uuid: ToggleQuestionsMixin) -> None:
     """Test that database is only queried once, not on every access."""
-    mock_get = Mock()
-    mock_get.get.return_value = {"skip-123": True}
-    mock_values_list.return_value = mock_get
-
-    # Multiple accesses
-    command_with_uuid.is_question_enabled("123")
-    command_with_uuid.set_question_enabled("456", True)
-    _ = command_with_uuid.question_toggles
-
-    # Access values with mocked parent
     with patch(
-        "canvas_sdk.commands.commands.questionnaire.QuestionnaireCommand.values",
-        new_callable=PropertyMock,
-    ) as mock_parent_values:
-        mock_parent_values.return_value = {"questionnaire_id": QUESTIONNAIRE_ID}
-        _ = command_with_uuid.values
+        "canvas_sdk.commands.commands.questionnaire.toggle_questions.Command.objects.values_list"
+    ) as mock_values_list:
+        mock_get = Mock()
+        mock_get.get.return_value = {"skip-123": True}
+        mock_values_list.return_value = mock_get
 
-    # Database should only be queried once
-    assert mock_values_list.call_count == 1
+        # Multiple accesses
+        command_with_uuid.is_question_enabled("123")
+        command_with_uuid.set_question_enabled("456", True)
+        _ = command_with_uuid.question_toggles
+
+        # Access values with mocked parent
+        with patch(
+            "canvas_sdk.commands.commands.questionnaire.QuestionnaireCommand.values",
+            new_callable=PropertyMock,
+        ) as mock_parent_values:
+            mock_parent_values.return_value = {"questionnaire_id": QUESTIONNAIRE_ID}
+            _ = command_with_uuid.values
+
+        # Database should only be queried once
+        assert mock_values_list.call_count == 1
 
 
-def test_type_conversion_for_question_ids(command_without_uuid: TestCommand) -> None:
+def test_type_conversion_for_question_ids(command_without_uuid: ToggleQuestionsMixin) -> None:
     """Test that question IDs are consistently converted to strings."""
     command_without_uuid.set_question_enabled(123, True)
     command_without_uuid.set_question_enabled("456", False)
@@ -251,7 +262,7 @@ def test_type_conversion_for_question_ids(command_without_uuid: TestCommand) -> 
     new_callable=PropertyMock,
 )
 def test_values_with_no_toggles(
-    mock_parent_values: PropertyMock, command_without_uuid: TestCommand
+    mock_parent_values: PropertyMock, command_without_uuid: ToggleQuestionsMixin
 ) -> None:
     """Test values property when no toggles are set."""
     mock_parent_values.return_value = {"questionnaire_id": QUESTIONNAIRE_ID}
@@ -266,41 +277,43 @@ def test_values_with_no_toggles(
     "canvas_sdk.commands.commands.questionnaire.QuestionnaireCommand.values",
     new_callable=PropertyMock,
 )
-@patch.object(Command.objects, "values_list")
 def test_complex_scenario(
-    mock_values_list: Mock, mock_parent_values: PropertyMock, command_with_uuid: TestCommand
+    mock_parent_values: PropertyMock, command_with_uuid: ToggleQuestionsMixin
 ) -> None:
     """Test a complex scenario with multiple operations."""
-    # Mock parent values
-    mock_parent_values.return_value = {
-        "questionnaire_id": QUESTIONNAIRE_ID,
-        "questions": {"question-123": "response"},
-    }
+    with patch(
+        "canvas_sdk.commands.commands.questionnaire.toggle_questions.Command.objects.values_list"
+    ) as mock_values_list:
+        # Mock parent values
+        mock_parent_values.return_value = {
+            "questionnaire_id": QUESTIONNAIRE_ID,
+            "questions": {"question-123": "response"},
+        }
 
-    # Mock persisted states
-    mock_get = Mock()
-    mock_get.get.return_value = {
-        "skip-123": True,
-        "skip-456": False,
-        "skip-789": True,
-    }
-    mock_values_list.return_value = mock_get
+        # Mock persisted states
+        mock_get = Mock()
+        mock_get.get.return_value = {
+            "skip-123": True,
+            "skip-456": False,
+            "skip-789": True,
+        }
+        mock_values_list.return_value = mock_get
 
-    # Check initial state
-    assert command_with_uuid.is_question_enabled("123") is True
-    assert command_with_uuid.is_question_enabled("456") is False
+        # Check initial state
+        assert command_with_uuid.is_question_enabled("123") is True
+        assert command_with_uuid.is_question_enabled("456") is False
 
-    # Make changes
-    command_with_uuid.set_question_enabled("123", False)  # Disable previously enabled
-    command_with_uuid.set_question_enabled("999", True)  # Add new
+        # Make changes
+        command_with_uuid.set_question_enabled("123", False)  # Disable previously enabled
+        command_with_uuid.set_question_enabled("999", True)  # Add new
 
-    # Get final values
-    values = command_with_uuid.values
+        # Get final values
+        values = command_with_uuid.values
 
-    # Should have all parent values plus all skip states
-    assert values["questionnaire_id"] == QUESTIONNAIRE_ID
-    assert values["questions"] == {"question-123": "response"}
-    assert values["skip-123"] is False  # Changed
-    assert values["skip-456"] is False  # Unchanged
-    assert values["skip-789"] is True  # Unchanged
-    assert values["skip-999"] is True  # New
+        # Should have all parent values plus all skip states
+        assert values["questionnaire_id"] == QUESTIONNAIRE_ID
+        assert values["questions"] == {"question-123": "response"}
+        assert values["skip-123"] is False  # Changed
+        assert values["skip-456"] is False  # Unchanged
+        assert values["skip-789"] is True  # Unchanged
+        assert values["skip-999"] is True  # New


### PR DESCRIPTION
This pull request refactors the test files `test_toggle_questions_mixin.py` and `test_models.py` to improve type safety, enhance readability, and ensure consistent behavior across tests. The key changes include the use of `pytest` fixtures for test class creation, explicit type casting, and the removal of unnecessary `@patch` decorators.

### Improvements to test structure and type safety in `test_toggle_questions_mixin.py`:

* Introduced a `pytest.fixture` for creating the `TestCommand` class, ensuring consistent setup and preventing pytest from treating it as a test case.
* Updated all test functions to use explicit type annotations (`ToggleQuestionsMixin`) for improved type safety and readability. [[1]](diffhunk://#diff-b1de6d4853b19281ca8e34650ee982986d7429f0a7dfc6be7a53a9b569790417L68-R81) [[2]](diffhunk://#diff-b1de6d4853b19281ca8e34650ee982986d7429f0a7dfc6be7a53a9b569790417L83-R102) [[3]](diffhunk://#diff-b1de6d4853b19281ca8e34650ee982986d7429f0a7dfc6be7a53a9b569790417L107-R116) [[4]](diffhunk://#diff-b1de6d4853b19281ca8e34650ee982986d7429f0a7dfc6be7a53a9b569790417L122-R135) [[5]](diffhunk://#diff-b1de6d4853b19281ca8e34650ee982986d7429f0a7dfc6be7a53a9b569790417L146-R155) [[6]](diffhunk://#diff-b1de6d4853b19281ca8e34650ee982986d7429f0a7dfc6be7a53a9b569790417L169-R185) [[7]](diffhunk://#diff-b1de6d4853b19281ca8e34650ee982986d7429f0a7dfc6be7a53a9b569790417L196-R207) [[8]](diffhunk://#diff-b1de6d4853b19281ca8e34650ee982986d7429f0a7dfc6be7a53a9b569790417L207-R222) [[9]](diffhunk://#diff-b1de6d4853b19281ca8e34650ee982986d7429f0a7dfc6be7a53a9b569790417L233-R244) [[10]](diffhunk://#diff-b1de6d4853b19281ca8e34650ee982986d7429f0a7dfc6be7a53a9b569790417L254-R265) [[11]](diffhunk://#diff-b1de6d4853b19281ca8e34650ee982986d7429f0a7dfc6be7a53a9b569790417L269-R286)
* Replaced `@patch.object` decorators with inline `patch` context managers for mocking database queries, improving clarity and reducing boilerplate. [[1]](diffhunk://#diff-b1de6d4853b19281ca8e34650ee982986d7429f0a7dfc6be7a53a9b569790417L68-R81) [[2]](diffhunk://#diff-b1de6d4853b19281ca8e34650ee982986d7429f0a7dfc6be7a53a9b569790417L83-R102) [[3]](diffhunk://#diff-b1de6d4853b19281ca8e34650ee982986d7429f0a7dfc6be7a53a9b569790417L122-R135) [[4]](diffhunk://#diff-b1de6d4853b19281ca8e34650ee982986d7429f0a7dfc6be7a53a9b569790417L169-R185) [[5]](diffhunk://#diff-b1de6d4853b19281ca8e34650ee982986d7429f0a7dfc6be7a53a9b569790417L269-R286)

### Enhancements to `test_models.py`:

* Added a `pytest.fixture` for creating the `TestModel` class, simplifying test setup and ensuring consistent behavior. [[1]](diffhunk://#diff-fc7a077f29e79924e8a6a47e41cb0ae825ae64a2e5fc41c852e38c4cc92cf740R16-R19) [[2]](diffhunk://#diff-fc7a077f29e79924e8a6a47e41cb0ae825ae64a2e5fc41c852e38c4cc92cf740R28-R29)
* Updated test functions to accept the `TestModel` fixture as a parameter, ensuring type safety and reducing redundant code. [[1]](diffhunk://#diff-fc7a077f29e79924e8a6a47e41cb0ae825ae64a2e5fc41c852e38c4cc92cf740L60-R67) [[2]](diffhunk://#diff-fc7a077f29e79924e8a6a47e41cb0ae825ae64a2e5fc41c852e38c4cc92cf740L69-R78) [[3]](diffhunk://#diff-fc7a077f29e79924e8a6a47e41cb0ae825ae64a2e5fc41c852e38c4cc92cf740L91-R100)

<!-- ## Title Guidelines

A title always has a prefix and a subject.

### Prefix
Make sure the title is prefixed with one of the following:

| Prefix | When to use |
|--------|-------------|
| `feat:`     | New feature |
| `fix:`      | Bug fix |
| `docs:`     | Documentation only changes |
| `style:`    | Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc) |
| `refactor:` | Code changes that neither fixes a bug nor adds a feature |
| `perf:`     | Code change that improves performance |
| `test:`     | Adding missing or correcting existing tests |
| `chore:`    | Changes to the build process or auxiliary tools and libraries such as documentation generation, ci, etc |

### Subject

Ensure the subject contains succinct description of the change.
* Use the imperative, present tense: "change", not "changed" nor "changes"
* Don’t capitalize first letter
* No dot (.) at the end
-->
