### PR TITLE
feat(cli): add local database support to the run-plugin cli command

### DIFF
--- a/canvas_cli/apps/run_plugins/run_plugins.py
+++ b/canvas_cli/apps/run_plugins/run_plugins.py
@@ -1,16 +1,102 @@
+from collections.abc import Generator
+from contextlib import contextmanager
+from pathlib import Path
+
+import django.db
+import typer
+from django.core.management import call_command
+
+import settings
 from plugin_runner.plugin_runner import main as run_server
 
 
-def run_plugin(plugin_directory: str) -> None:
+@contextmanager
+def _patch_default_db_connection() -> Generator[None, None, None]:
+    """
+    Temporarily patch the 'default' Django DB connection to allow db writes.
+    """
+    original_default = django.db.connections["default"]
+    try:
+        temp_handler = django.db.utils.ConnectionHandler(
+            {"default": settings.SQLITE_WRITE_MODE_DATABASE}
+        )
+        django.db.connections["default"] = temp_handler["default"]
+        yield
+    finally:
+        django.db.connections["default"] = original_default
+
+
+def _run_db_seed_file(path: Path) -> None:
+    """Run the database setup file to initialize the database."""
+    code = path.read_text()
+    exec_globals = {"__name__": "__main__"}
+    exec(code, exec_globals)
+
+
+def _reset_db(seed_file: Path | None = None) -> None:
+    """Reset the database."""
+    settings.SQLITE_DB_PATH.unlink(missing_ok=True)
+
+    with _patch_default_db_connection():
+        call_command("migrate", run_syncdb=True, verbosity=0)
+        if seed_file:
+            _run_db_seed_file(seed_file)
+
+
+def run_plugin(
+    plugin_directory: str = typer.Argument(..., help="Path to the plugin directory to run."),
+    db_seed_file: Path | None = typer.Option(
+        help="Path to the database seed file to use.",
+        default=None,
+    ),
+    reset_db: bool = typer.Option(
+        help="Reset the database before running the plugin.", default=False
+    ),
+) -> None:
     """
     Run the specified plugin for local development.
     """
-    return run_plugins([plugin_directory])
+    _run_plugins([plugin_directory], db_seed_file=db_seed_file, reset_db=reset_db)
 
 
-def run_plugins(plugin_directories: list[str]) -> None:
+def run_plugins(
+    plugin_directories: list[str],
+    db_seed_file: Path | None = typer.Option(
+        help="Path to the database seed file to use.",
+        default=None,
+    ),
+    reset_db: bool = typer.Option(
+        help="Reset the database before running the plugin(s).", default=False
+    ),
+) -> None:
     """
     Run the specified plugins for local development.
     """
+    _run_plugins(plugin_directories, db_seed_file=db_seed_file, reset_db=reset_db)
+
+
+def _run_plugins(
+    plugin_directories: list[str], db_seed_file: Path | None = None, reset_db: bool = False
+) -> None:
+    """
+    Run the specified plugins for local development.
+    """
+    if db_seed_file:
+        if not db_seed_file.exists():
+            raise typer.BadParameter(f"Database setup file not found: {db_seed_file.resolve()}")
+        if not db_seed_file.is_file():
+            raise typer.BadParameter(
+                f"Database setup file is not a regular file: {db_seed_file.resolve()}"
+            )
+        if not db_seed_file.suffix == ".py":
+            raise typer.BadParameter("Database setup file must be a Python script (.py)")
+
+    if settings.CANVAS_SDK_DB_BACKEND != "sqlite3":
+        raise typer.BadParameter(
+            "Database backend must be 'sqlite3' for local plugin development. Please unset 'DATABASE_URL' env var."
+        )
+
+    if db_seed_file or reset_db:
+        _reset_db(seed_file=db_seed_file)
+
     run_server(plugin_directories)
-    return

--- a/canvas_cli/apps/run_plugins/tests.py
+++ b/canvas_cli/apps/run_plugins/tests.py
@@ -1,0 +1,118 @@
+from pathlib import Path
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+import typer
+from typer.testing import CliRunner
+
+from canvas_cli.apps.run_plugins.run_plugins import (
+    _patch_default_db_connection,
+    _reset_db,
+    _run_plugins,
+)
+
+
+@patch("django.db.connections")
+@patch("django.db.utils.ConnectionHandler")
+def test_patches_connection_successfully(mock_handler_class: Mock, mock_connections: Mock) -> None:
+    """Test that the context manager patches the connection correctly."""
+    original_connection = MagicMock()
+    mock_connections.__getitem__.return_value = original_connection
+    mock_temp_handler = MagicMock()
+    mock_new_connection = MagicMock()
+    mock_temp_handler.__getitem__.return_value = mock_new_connection
+    mock_handler_class.return_value = mock_temp_handler
+
+    with _patch_default_db_connection():
+        assert mock_connections.__setitem__.called
+
+    mock_connections.__setitem__.assert_called_with("default", original_connection)
+
+
+@patch("django.db.connections")
+@patch("django.db.utils.ConnectionHandler")
+def test_restores_connection_on_exception(mock_handler_class: Mock, mock_connections: Mock) -> None:
+    """Test that the original connection is restored even if an exception occurs."""
+    original_connection = MagicMock()
+    mock_connections.__getitem__.return_value = original_connection
+
+    mock_new_connection = MagicMock()
+    mock_temp_handler = MagicMock()
+    mock_temp_handler.__getitem__.return_value = mock_new_connection
+    mock_handler_class.return_value = mock_temp_handler
+
+    with pytest.raises(ValueError), _patch_default_db_connection():
+        raise ValueError("Test exception")
+
+    mock_connections.__setitem__.assert_called_with("default", original_connection)
+
+
+@patch("canvas_cli.apps.run_plugins.run_plugins._run_db_seed_file")
+@patch("canvas_cli.apps.run_plugins.run_plugins.call_command")
+@patch("canvas_cli.apps.run_plugins.run_plugins._patch_default_db_connection")
+@patch("canvas_cli.apps.run_plugins.run_plugins.settings")
+def test_resets_database_without_seed_file(
+    mock_settings: Mock, mock_patch_db: Mock, mock_call_command: Mock, mock_run_db_setup: Mock
+) -> None:
+    """Test that _reset_db resets the database without a seed file."""
+    mock_db_path = Mock()
+    mock_settings.SQLITE_DB_PATH = mock_db_path
+
+    _reset_db()
+
+    mock_db_path.unlink.assert_called_once_with(missing_ok=True)
+    mock_patch_db.assert_called_once()
+    mock_call_command.assert_called_once_with("migrate", run_syncdb=True, verbosity=0)
+    mock_run_db_setup.assert_not_called()
+
+
+@patch("canvas_cli.apps.run_plugins.run_plugins._run_db_seed_file")
+@patch("canvas_cli.apps.run_plugins.run_plugins.call_command")
+@patch("canvas_cli.apps.run_plugins.run_plugins._patch_default_db_connection")
+@patch("canvas_cli.apps.run_plugins.run_plugins.settings")
+def test_resets_database_with_seed_file(
+    mock_settings: Mock, mock_patch_db: Mock, mock_call_command: Mock, mock_run_db_setup: Mock
+) -> None:
+    """Test that _reset_db resets the database and runs seed file."""
+    mock_db_path = Mock()
+    mock_settings.SQLITE_DB_PATH = mock_db_path
+    seed_file = Mock(spec=Path)
+
+    _reset_db(seed_file=seed_file)
+
+    mock_db_path.unlink.assert_called_once_with(missing_ok=True)
+    mock_patch_db.assert_called_once()
+    mock_call_command.assert_called_once_with("migrate", run_syncdb=True, verbosity=0)
+    mock_run_db_setup.assert_called_once_with(seed_file)
+
+
+@pytest.mark.parametrize(
+    "file,exists,is_file,expected_message",
+    [
+        (Path("/path/to/nonexistent.py"), False, True, "Database setup file not found"),
+        (Path("/path/to/directory"), True, False, "Database setup file is not a regular file"),
+        (Path("/path/to/setup.txt"), True, True, "Database setup file must be a Python script"),
+    ],
+    ids=("non-existent", "dir", "non-python-file"),
+)
+def test_raises_error_db_seed_file(
+    cli_runner: CliRunner, file: Path, exists: bool, is_file: bool, expected_message: str
+) -> None:
+    """Test that error is raised for database setup file."""
+    db_seed_file = MagicMock(spec=Path)
+    db_seed_file.exists.return_value = exists
+    db_seed_file.is_file.return_value = is_file
+    db_seed_file.suffix.return_value = file.suffix
+    db_seed_file.resolve.return_value = file
+
+    with pytest.raises(typer.BadParameter, match=expected_message):
+        _run_plugins(["some_dir"], db_seed_file=db_seed_file)
+
+
+@patch("canvas_cli.apps.run_plugins.run_plugins.settings")
+def test_raises_error_on_db_backend_not_supported(mock_settings: Mock) -> None:
+    """Test that an error is raised when an unsupported database backend is specified."""
+    mock_settings.CANVAS_SDK_DB_BACKEND = "postgres"
+
+    with pytest.raises(typer.BadParameter, match="Database backend must be 'sqlite3'"):
+        _run_plugins(["some_dir"], db_seed_file=None, reset_db=False)

--- a/settings.py
+++ b/settings.py
@@ -108,17 +108,20 @@ if CANVAS_SDK_DB_BACKEND == "postgres":
     DATABASES = {"default": db_config}
 
 elif CANVAS_SDK_DB_BACKEND == "sqlite3":
+    SQLITE_DB_PATH = BASE_DIR / "canvas_db.sqlite3"
+    SQLITE_WRITE_MODE_DATABASE = {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": str(SQLITE_DB_PATH),
+    }
+
     DATABASES = {
         "default": {
             "ENGINE": "django.db.backends.sqlite3",
-            "NAME": f"file:{str(BASE_DIR / 'db.sqlite3')}?mode=ro",
+            "NAME": f"file:{str(SQLITE_DB_PATH)}?mode=ro",
             "OPTIONS": {"uri": True},
-        },
-        "default-write": {
-            "ENGINE": "django.db.backends.sqlite3",
-            "NAME": str(BASE_DIR / "db.sqlite3"),
-        },
+        }
     }
+
 
 else:
     raise ImproperlyConfigured(

--- a/settings.py
+++ b/settings.py
@@ -117,7 +117,7 @@ elif CANVAS_SDK_DB_BACKEND == "sqlite3":
     DATABASES = {
         "default": {
             "ENGINE": "django.db.backends.sqlite3",
-            "NAME": f"file:{str(SQLITE_DB_PATH)}?mode=ro",
+            "NAME": f"file:{SQLITE_DB_PATH}?mode=ro",
             "OPTIONS": {"uri": True},
         }
     }


### PR DESCRIPTION
[KOALA-3037](https://canvasmedical.atlassian.net/browse/KOALA-3037)

This pull request introduces significant enhancements to the `canvas_cli` application to improve local plugin development workflows. The changes include adding database reset and seeding capabilities, refining database connection handling, and updating associated tests and configurations. 

### Enhancements to database handling:
* Introduced `_patch_default_db_connection` context manager to temporarily allow database writes by patching the default Django DB connection.
* Added `_reset_db` function to reset the SQLite database, with optional support for running a seed file to initialize the database.

### Updates to plugin execution:
* Refactored `run_plugin` and `run_plugins` to include options for resetting the database and specifying a database setup file. These options are validated to ensure proper usage.

### Configuration changes:
* Updated `settings.py` to define `SQLITE_DB_PATH` and `SQLITE_WRITE_MODE_DATABASE` for managing SQLite databases in both read-only and write modes.

### Testing improvements:
* Added unit tests to verify database connection patching, database reset functionality, and validation of database seed file. Tests also ensure proper error handling for unsupported database backends and invalid setup files.


### Example



```
canvas run-plugin my_plugin dir --db-seed-file seedfile.py
```

where `seedfile.py` could be something like:

```python
   from canvas_sdk.v1.data.discount import Discount

   Discount.objects.create(name="10%",adjustment_group="30",adjustment_code="CO",discount=0.10)

```


[KOALA-3037]: https://canvasmedical.atlassian.net/browse/KOALA-3037?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ