### PR TITLE
fix: prevent an issue where the prescribe command effects send compound medication values where not desired

### DIFF
--- a/canvas_sdk/commands/commands/prescribe.py
+++ b/canvas_sdk/commands/commands/prescribe.py
@@ -170,6 +170,9 @@ class PrescribeCommand(_SendableCommandMixin, _BaseCommand):
             if isinstance(compound_data, CompoundMedicationData):
                 values["compound_medication_values"] = compound_data.to_dict()
 
+        if values.get("fdb_code") is not None and values.get("compound_medication_values") == {}:
+            del values["compound_medication_values"]
+
         return values
 
     def originate(self, line_number: int = -1) -> Effect:

--- a/canvas_sdk/tests/commands/test_prescribe_compound_medication.py
+++ b/canvas_sdk/tests/commands/test_prescribe_compound_medication.py
@@ -357,6 +357,21 @@ def test_prescribe_compound_medication_values_property(
     assert compound_med_values["active"] is True
 
 
+def test_prescribe_compound_medication_values_property_is_ommitted_if_fdb_code_is_present(
+    mock_db_queries: dict[str, MagicMock],
+) -> None:
+    """Test that the values property does not return data for compound medications when an fdb_code is provided."""
+    prescribe_cmd = PrescribeCommand(
+        note_uuid=str(uuid4()),
+        fdb_code="abc123",
+        sig="Take one tablet by mouth daily",
+    )
+
+    values = prescribe_cmd.values
+    assert "compound_medication_values" not in values
+    assert values["fdb_code"] == "abc123"
+
+
 def test_prescribe_compound_medication_edit_command(
     mock_db_queries: dict[str, MagicMock],
 ) -> None:


### PR DESCRIPTION
Without this change, when setting an fdb_code on a prescribe command, the medication represented by that fdb_code would be set to the command's prescribe attribute, but then the compound_medication_values (defaulted to an empty dict instead of None) would overwrite the command's prescribe attribute to None.