### PR TITLE
fix: set size maximums for gRPC messages

### DIFF
--- a/plugin_runner/plugin_runner.py
+++ b/plugin_runner/plugin_runner.py
@@ -734,8 +734,9 @@ def main(specified_plugin_paths: list[str] | None = None) -> None:
     server = grpc.server(
         thread_pool=executor,
         options=(
-            # set max message length to 64mb
+            # set max message lengths to 64mb
             ("grpc.max_receive_message_length", 64 * 1024 * 1024),
+            ("grpc.max_send_message_length", 64 * 1024 * 1024),
         ),
     )
     server.add_insecure_port("127.0.0.1:" + port)

--- a/plugin_runner/plugin_runner.py
+++ b/plugin_runner/plugin_runner.py
@@ -731,7 +731,13 @@ def main(specified_plugin_paths: list[str] | None = None) -> None:
     port = "50051"
 
     executor = ThreadPoolExecutor(max_workers=settings.PLUGIN_RUNNER_MAX_WORKERS)
-    server = grpc.server(thread_pool=executor)
+    server = grpc.server(
+        thread_pool=executor,
+        options=(
+            # set max message length to 64mb
+            ("grpc.max_receive_message_length", 64 * 1024 * 1024),
+        ),
+    )
     server.add_insecure_port("127.0.0.1:" + port)
 
     add_PluginRunnerServicer_to_server(PluginRunner(), server)


### PR DESCRIPTION
https://canvasmedical.atlassian.net/browse/KOALA-3267

Some plugins send many effects, and the combined payloads exceed the default message size limit for gRPC. This PR increases the limit somewhat but does not allow unlimited payloads.