### PR TITLE
chore(tests): add codecov config

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,9 @@
+ignore:
+  - "canvas_cli/templates"
+  - "canvas_sdk/tests"
+  - "**/test_*.py"
+  - "**/tests.py"
+  - "**/conftest.py"
+  - "example-plugins/"
+  - "import_tracing/"
+  - "protobufs/"


### PR DESCRIPTION
This pull request updates the `.codecov.yml` configuration to improve the accuracy of code coverage reporting by ignoring test files, templates, and several directories that should not be included in coverage metrics.

Coverage reporting configuration:

* Updated `.codecov.yml` to ignore files and directories such as `canvas_cli/templates`, `canvas_sdk/tests`, files matching `test_*.py`, `tests.py`, `conftest.py`, and the directories `example-plugins/`, `import_tracing/`, and `protobufs/`.