### PR TITLE
chore: remove data_access from patient_sync

### DIFF
--- a/example-plugins/api_samples/CANVAS_MANIFEST.json
+++ b/example-plugins/api_samples/CANVAS_MANIFEST.json
@@ -7,21 +7,11 @@
         "protocols": [
             {
                 "class": "api_samples.routes.hello_world:HelloWorldAPI",
-                "description": "Returns a json message",
-                "data_access": {
-                    "event": "",
-                    "read": [],
-                    "write": []
-                }
+                "description": "Returns a json message"
             },
             {
                 "class": "api_samples.routes.email_bounce:EmailBounceAPI",
-                "description": "Creates a task to confirm patient contact info",
-                "data_access": {
-                    "event": "",
-                    "read": [],
-                    "write": []
-                }
+                "description": "Creates a task to confirm patient contact info"
             }
         ],
         "commands": [],

--- a/example-plugins/charting_api_examples/CANVAS_MANIFEST.json
+++ b/example-plugins/charting_api_examples/CANVAS_MANIFEST.json
@@ -7,30 +7,15 @@
         "protocols": [
             {
                 "class": "charting_api_examples.routes.notes:NoteAPI",
-                "description": "Endpoints that showcase interactions with notes.",
-                "data_access": {
-                    "event": "",
-                    "read": [],
-                    "write": []
-                }
+                "description": "Endpoints that showcase interactions with notes."
             },
             {
                 "class": "charting_api_examples.routes.billing_line_items:BillingLineItemAPI",
-                "description": "Endpoints for interacting with billing line items on a note.",
-                "data_access": {
-                    "event": "",
-                    "read": [],
-                    "write": []
-                }
+                "description": "Endpoints for interacting with billing line items on a note."
             },
             {
                 "class": "charting_api_examples.routes.commands:CommandAPI",
-                "description": "Endpoints for interacting with commands on a note.",
-                "data_access": {
-                    "event": "",
-                    "read": [],
-                    "write": []
-                }
+                "description": "Endpoints for interacting with commands on a note."
             }
         ],
         "commands": [],

--- a/example-plugins/example_patient_portal_page/CANVAS_MANIFEST.json
+++ b/example-plugins/example_patient_portal_page/CANVAS_MANIFEST.json
@@ -22,12 +22,7 @@
         "protocols": [
             {
                 "class": "example_patient_portal_page.handlers.my_web_app:MyWebApp",
-                "description": "Serves the application",
-                "data_access": {
-                    "event": "",
-                    "read": [],
-                    "write": []
-                }
+                "description": "Serves the application"
             }
         ],
         "commands": [],

--- a/example-plugins/example_patient_sync/CANVAS_MANIFEST.json
+++ b/example-plugins/example_patient_sync/CANVAS_MANIFEST.json
@@ -7,21 +7,11 @@
         "protocols": [
             {
                 "class": "example_patient_sync.handlers.patient_sync:PatientSync",
-                "description": "Create or update patients in an external system based on Canvas events",
-                "data_access": {
-                    "event": "",
-                    "read": [],
-                    "write": []
-                }
+                "description": "Create or update patients in an external system based on Canvas events"
             },
             {
                 "class": "example_patient_sync.routes.patient_create_api:PatientCreateApi",
-                "description": "Create a patient in Canvas when a user is created in an external system",
-                "data_access": {
-                    "event": "",
-                    "read": [],
-                    "write": []
-                }
+                "description": "Create a patient in Canvas when a user is created in an external system"
             }
         ],
 

--- a/example-plugins/upsert_patient_metadata/CANVAS_MANIFEST.json
+++ b/example-plugins/upsert_patient_metadata/CANVAS_MANIFEST.json
@@ -7,12 +7,7 @@
         "protocols": [
             {
                 "class": "upsert_patient_metadata.protocols.my_protocol:Protocol",
-                "description": "A protocol that does xyz...",
-                "data_access": {
-                    "event": "",
-                    "read": [],
-                    "write": []
-                }
+                "description": "A protocol that does xyz..."
             }
         ],
         "commands": [],


### PR DESCRIPTION
This PR removes unused data_access fields from example plugin MANIFEST.json files
