### PR TITLE
feat: staff license

### DIFF
--- a/canvas_sdk/v1/data/__init__.py
+++ b/canvas_sdk/v1/data/__init__.py
@@ -83,7 +83,7 @@ from .questionnaire import (
 from .reason_for_visit import ReasonForVisitSettingCoding
 from .referral import Referral, ReferralReport
 from .service_provider import ServiceProvider
-from .staff import Staff, StaffAddress, StaffContactPoint, StaffPhoto, StaffRole
+from .staff import Staff, StaffAddress, StaffContactPoint, StaffLicense, StaffPhoto, StaffRole
 from .task import Task, TaskComment, TaskLabel, TaskTaskLabel
 from .team import Team, TeamContactPoint
 from .user import CanvasUser
@@ -183,6 +183,7 @@ __all__ = __exports__ = (
     "ServiceProvider",
     "Staff",
     "StaffAddress",
+    "StaffLicense",
     "StaffPhoto",
     "StaffRole",
     "StaffContactPoint",

--- a/canvas_sdk/v1/data/staff.py
+++ b/canvas_sdk/v1/data/staff.py
@@ -211,4 +211,39 @@ class StaffRole(Model):
     role_type = models.CharField(max_length=50, choices=RoleType.choices, blank=True)
 
 
-__exports__ = ("Staff", "StaffContactPoint", "StaffAddress", "StaffPhoto", "StaffRole")
+class StaffLicense(IdentifiableModel):
+    """StaffLicense."""
+
+    class Meta:
+        db_table = "canvas_sdk_data_api_stafflicense_001"
+
+    class LicenseType(TextChoices):
+        CLIA = "CLIA", "CLIA"
+        DEA = "DEA", "DEA"
+        PTAN = "PTAN", "PTAN"
+        STATE_LICENSE = "STATE", "State license"
+        TAXONOMY = "TAXONOMY", "Taxonomy"
+        SPI = "SPI", "SPI"
+        OTHER = "OTHER", "Other"
+
+    staff = models.ForeignKey(Staff, on_delete=models.CASCADE, related_name="licenses")
+    issuing_authority_long_name = models.CharField(max_length=200, null=True, blank=True)
+    issuing_authority_url = models.URLField(blank=True, null=True)
+    license_or_certification_identifier = models.CharField(max_length=50, db_index=True)
+    issuance_date = models.DateField()
+    expiration_date = models.DateField(db_index=True)
+    license_type = models.CharField(
+        max_length=50, choices=LicenseType.choices, null=True, db_index=True, blank=True
+    )
+    primary = models.BooleanField(default=False)
+    state = models.CharField(max_length=2, blank=True, null=True)
+
+
+__exports__ = (
+    "Staff",
+    "StaffContactPoint",
+    "StaffAddress",
+    "StaffPhoto",
+    "StaffRole",
+    "StaffLicense",
+)

--- a/canvas_sdk/v1/data/staff.py
+++ b/canvas_sdk/v1/data/staff.py
@@ -241,9 +241,9 @@ class StaffLicense(IdentifiableModel):
 
 __exports__ = (
     "Staff",
-    "StaffContactPoint",
     "StaffAddress",
+    "StaffContactPoint",
+    "StaffLicense",
     "StaffPhoto",
     "StaffRole",
-    "StaffLicense",
 )

--- a/canvas_sdk/v1/data/staff.py
+++ b/canvas_sdk/v1/data/staff.py
@@ -229,11 +229,11 @@ class StaffLicense(IdentifiableModel):
     staff = models.ForeignKey(Staff, on_delete=models.CASCADE, related_name="licenses")
     issuing_authority_long_name = models.CharField(max_length=200, null=True, blank=True)
     issuing_authority_url = models.URLField(blank=True, null=True)
-    license_or_certification_identifier = models.CharField(max_length=50, db_index=True)
+    license_or_certification_identifier = models.CharField(max_length=50)
     issuance_date = models.DateField()
-    expiration_date = models.DateField(db_index=True)
+    expiration_date = models.DateField()
     license_type = models.CharField(
-        max_length=50, choices=LicenseType.choices, null=True, db_index=True, blank=True
+        max_length=50, choices=LicenseType.choices, null=True, blank=True
     )
     primary = models.BooleanField(default=False)
     state = models.CharField(max_length=2, blank=True, null=True)

--- a/plugin_runner/allowed-module-imports.json
+++ b/plugin_runner/allowed-module-imports.json
@@ -601,6 +601,7 @@
     "Staff",
     "StaffAddress",
     "StaffContactPoint",
+    "StaffLicense",
     "StaffPhoto",
     "StaffRole",
     "Task",
@@ -847,6 +848,7 @@
     "Staff",
     "StaffAddress",
     "StaffContactPoint",
+    "StaffLicense",
     "StaffPhoto",
     "StaffRole"
   ],


### PR DESCRIPTION
INTERNAL TRACKING: https://canvasmedical.atlassian.net/browse/KOALA-3310


This pull request introduces a new `StaffLicense` model to the codebase, which represents licenses and certifications associated with staff members. 

**Addition of Staff License Model:**

* Added a new `StaffLicense` model to `canvas_sdk/v1/data/staff.py`, including fields for license details, issuing authority, dates, and type, and linked to the `Staff` model.

**Exports and Imports:**

* Updated `canvas_sdk/v1/data/__init__.py` to import and export `StaffLicense` so it is available throughout the SDK. [[1]](diffhunk://#diff-7b0c97fc42b6555943e206a71ce18b4e13f011b8a125f11e6983fffe154e3f5bL86-R86) [[2]](diffhunk://#diff-7b0c97fc42b6555943e206a71ce18b4e13f011b8a125f11e6983fffe154e3f5bR186)

**Plugin and Module Configuration:**

* Added `StaffLicense` to the allowed imports in `plugin_runner/allowed-module-imports.json`, enabling its use in plugins and other modules. [[1]](diffhunk://#diff-a40dcade76413e693e0a9fefc6afe070adb5765f6ca17ff86b3982eef6df5c32R604) [[2]](diffhunk://#diff-a40dcade76413e693e0a9fefc6afe070adb5765f6ca17ff86b3982eef6df5c32R851)

<!-- ## Title Guidelines

A title always has a prefix and a subject.

### Prefix
Make sure the title is prefixed with one of the following:

| Prefix | When to use |
|--------|-------------|
| `feat:`     | New feature |
| `fix:`      | Bug fix |
| `docs:`     | Documentation only changes |
| `style:`    | Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc) |
| `refactor:` | Code changes that neither fixes a bug nor adds a feature |
| `perf:`     | Code change that improves performance |
| `test:`     | Adding missing or correcting existing tests |
| `chore:`    | Changes to the build process or auxiliary tools and libraries such as documentation generation, ci, etc |

### Subject

Ensure the subject contains succinct description of the change.
* Use the imperative, present tense: "change", not "changed" nor "changes"
* Don’t capitalize first letter
* No dot (.) at the end
-->
