### PR TITLE
feat: add ability to set note related_data via existing note effects

### DIFF
--- a/canvas_sdk/effects/note/note.py
+++ b/canvas_sdk/effects/note/note.py
@@ -27,6 +27,7 @@ class Note(NoteOrAppointmentABC):
     datetime_of_service: datetime.datetime | None = None
     patient_id: str | None = None
     title: str | None = None
+    related_data: dict | None = None
 
     def _get_error_details(self, method: Any) -> list[InitErrorDetails]:
         """


### PR DESCRIPTION
Allows setting arbitrary key-value pairs on the note through the existing `related_data` attribute.