### PR TITLE
fix: unload plugin handlers before reloading a specific plugin

### DIFF
--- a/plugin_runner/plugin_runner.py
+++ b/plugin_runner/plugin_runner.py
@@ -429,6 +429,7 @@ def synchronize_plugins(run_once: bool = False) -> None:
                         log.info(
                             f'synchronize_plugins: installing/reloading plugin "{plugin_name}" for action=reload'
                         )
+                        unload_plugin(plugin_name)
                         install_plugin(plugin_name, attributes=plugin)
                         plugin_dir = pathlib.Path(PLUGIN_DIRECTORY) / plugin_name
                         load_plugin(plugin_dir.resolve())

--- a/plugin_runner/tests/test_plugin_runner.py
+++ b/plugin_runner/tests/test_plugin_runner.py
@@ -372,6 +372,7 @@ def test_synchronize_plugins_installs_and_loads_enabled_plugin() -> None:
         patch("plugin_runner.plugin_runner.enabled_plugins") as mock_enabled_plugins,
         patch("plugin_runner.plugin_runner.install_plugin") as mock_install_plugin,
         patch("plugin_runner.plugin_runner.load_or_reload_plugin") as mock_load_or_reload_plugin,
+        patch("plugin_runner.plugin_runner.unload_plugin") as mock_unload_plugin,
         patch("plugin_runner.plugin_runner.install_plugins") as mock_install_plugins,
         patch("plugin_runner.plugin_runner.load_plugins") as mock_load_plugins,
     ):
@@ -391,6 +392,7 @@ def test_synchronize_plugins_installs_and_loads_enabled_plugin() -> None:
 
         expected_path = (Path(PLUGIN_DIRECTORY) / plugin_name).resolve()
         mock_load_or_reload_plugin.assert_called_once_with(expected_path)
+        mock_unload_plugin.assert_called_once_with(plugin_name)
 
         mock_install_plugins.assert_not_called()
         mock_load_plugins.assert_not_called()


### PR DESCRIPTION
[KOALA-3498](https://canvasmedical.atlassian.net/browse/KOALA-3498)

This pull request improves the plugin synchronization process by ensuring that plugins are properly unloaded before being reinstalled and reloaded. It also updates the corresponding test to verify this new behavior.

Plugin reload logic:

* Added a call to `unload_plugin(plugin_name)` before reinstalling and reloading a plugin in the `synchronize_plugins` function to ensure the plugin is cleanly reset.

Testing improvements:

* Updated the `test_synchronize_plugins_installs_and_loads_enabled_plugin` test to mock the `unload_plugin` function and assert that it is called with the correct plugin name. [[1]](diffhunk://#diff-51b062e877aa4bbfd4d1b480a461c654bc6758c7e3b17de16f907c009e7207e4R375) [[2]](diffhunk://#diff-51b062e877aa4bbfd4d1b480a461c654bc6758c7e3b17de16f907c009e7207e4R395)

[KOALA-3498]: https://canvasmedical.atlassian.net/browse/KOALA-3498?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ