### PR TITLE
fix: rename example plugin methods

### DIFF
--- a/example-plugins/example_chart_app/applications/my_application.py
+++ b/example-plugins/example_chart_app/applications/my_application.py
@@ -26,7 +26,7 @@ class MyChartApplication(Application):
 
 class MyApi(StaffSessionAuthMixin, SimpleAPI):
     @api.get("/custom-ui")
-    def ical_links(self) -> list[Response | Effect]:
+    def custom_ui(self) -> list[Response | Effect]:
         logged_in_staff = Staff.objects.get(id=self.request.headers["canvas-logged-in-user-id"])
 
         context = {

--- a/example-plugins/plugins_smoke_test/applications/my_application.py
+++ b/example-plugins/plugins_smoke_test/applications/my_application.py
@@ -25,7 +25,7 @@ class MyGlobalApplication(Application):
 
 class SmokeTestApi(StaffSessionAuthMixin, SimpleAPI):
     @api.get("/global")
-    def ical_links(self) -> list[Response | Effect]:
+    def smoke_test_ui(self) -> list[Response | Effect]:
         logged_in_staff = Staff.objects.get(id=self.request.headers["canvas-logged-in-user-id"])
 
         context = {


### PR DESCRIPTION
A few example plugins stemmed from the same base plugin, and I forgot to rename the method that only makes sense in the context of the plugin they were copied from.