### PR TITLE
fix: clear template loader cache on plugin updates

### DIFF
--- a/plugin_runner/plugin_runner.py
+++ b/plugin_runner/plugin_runner.py
@@ -42,6 +42,7 @@ from canvas_sdk.effects.simple_api import Response
 from canvas_sdk.events import Event, EventRequest, EventResponse, EventType
 from canvas_sdk.handlers.simple_api.websocket import DenyConnection
 from canvas_sdk.protocols import ClinicalQualityMeasure
+from canvas_sdk.templates.utils import _engine_for_plugin
 from canvas_sdk.utils import metrics
 from canvas_sdk.utils.metrics import measured
 from logger import log
@@ -419,6 +420,9 @@ def synchronize_plugins(run_once: bool = False) -> None:
         if "action" not in data:
             continue
 
+        # clear the template engine cache so that any template changes
+        # from plugins are picked up
+        _engine_for_plugin.cache_clear()
         plugin_name = data.get("plugin", None)
         try:
             if data["action"] == "reload":


### PR DESCRIPTION
https://canvasmedical.atlassian.net/browse/KOALA-3536

This pull request makes a targeted improvement to the plugin synchronization process by ensuring that template changes from plugins are correctly recognized. The key change is to clear the template engine cache before processing plugin actions, which guarantees that any updates to plugin templates are picked up immediately.

**Plugin Template Handling:**

* Added an import for `_engine_for_plugin` from `canvas_sdk.templates.utils` in `plugin_runner.py` to access the template engine cache.
* Added a call to `_engine_for_plugin.cache_clear()` at the start of each plugin action in `synchronize_plugins`, ensuring that template changes from plugins are recognized without requiring a restart.

<!-- ## Title Guidelines

A title always has a prefix and a subject.

### Prefix
Make sure the title is prefixed with one of the following:

| Prefix | When to use |
|--------|-------------|
| `feat:`     | New feature |
| `fix:`      | Bug fix |
| `docs:`     | Documentation only changes |
| `style:`    | Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc) |
| `refactor:` | Code changes that neither fixes a bug nor adds a feature |
| `perf:`     | Code change that improves performance |
| `test:`     | Adding missing or correcting existing tests |
| `chore:`    | Changes to the build process or auxiliary tools and libraries such as documentation generation, ci, etc |

### Subject

Ensure the subject contains succinct description of the change.
* Use the imperative, present tense: "change", not "changed" nor "changes"
* Don’t capitalize first letter
* No dot (.) at the end
-->
