### PR TITLE
fix: change how we validate cpt_code and cvx_code in immunization statement command

### DIFF
--- a/canvas_sdk/commands/commands/immunization_statement.py
+++ b/canvas_sdk/commands/commands/immunization_statement.py
@@ -1,7 +1,5 @@
 from datetime import date
-from typing import Self
 
-from pydantic import model_validator
 from pydantic_core import InitErrorDetails
 
 from canvas_sdk.commands.base import _BaseCommand as BaseCommand
@@ -29,23 +27,23 @@ class ImmunizationStatementCommand(BaseCommand):
         # For Coding objects (dicts), check if it exists
         return True
 
-    @model_validator(mode="after")
-    def check_needed_together_fields(self) -> Self:
-        """Check that both 'cpt_code' and 'cvx_code' are set if one is provided."""
+    def _get_error_details(self, method: str) -> list[InitErrorDetails]:
+        errors = super()._get_error_details(method)
+
         has_cpt_code = self._has_value(self.cpt_code)
         has_cvx_code = self._has_value(self.cvx_code)
 
         if has_cpt_code ^ has_cvx_code:
-            raise ValueError(
-                "Both cpt_code and cvx_code must be provided if one is specified and cannot be empty."
+            value = self.cpt_code if has_cpt_code else self.cvx_code
+            errors.append(
+                self._create_error_detail(
+                    "value",
+                    "Both cpt_code and cvx_code must be provided if one is specified and cannot be empty.",
+                    value,
+                )
             )
 
-        return self
-
-    def _get_error_details(self, method: str) -> list[InitErrorDetails]:
-        errors = super()._get_error_details(method)
-
-        if self.unstructured and (self.cpt_code or self.cvx_code):
+        if self.unstructured and (has_cpt_code or has_cvx_code):
             message = "Unstructured codes cannot be used with CPT or CVX codes."
             errors.append(self._create_error_detail("value", message, self.cpt_code))
 

--- a/canvas_sdk/tests/commands/test_commands.py
+++ b/canvas_sdk/tests/commands/test_commands.py
@@ -392,6 +392,31 @@ def test_immunization_statement_values_are_set_correctly() -> None:
     assert data["approximate_date"] == "2024-01-15"
     assert data["comments"] == comments_value
 
+    # Test with values after instantiation
+    immunization_statement_command = ImmunizationStatementCommand(
+        note_uuid="test_uuid",
+        approximate_date=approximate_date_value,
+        comments=comments_value,
+    )
+    immunization_statement_command.cpt_code = cpt_coding
+    immunization_statement_command.cvx_code = cvx_coding
+
+    command = immunization_statement_command.originate()
+
+    payload = json.loads(command.payload)
+    data = payload["data"]
+
+    assert data["cpt_code"]["system"] == CodeSystems.CPT
+    assert data["cpt_code"]["code"] == "90471"
+    assert data["cpt_code"]["display"] == "Immunization administration"
+
+    assert data["cvx_code"]["system"] == CodeSystems.CVX
+    assert data["cvx_code"]["code"] == "207"
+    assert data["cvx_code"]["display"] == "COVID-19 vaccine"
+
+    assert data["approximate_date"] == "2024-01-15"
+    assert data["comments"] == comments_value
+
     # Test with unstructured code
     unstructured_coding = Coding(
         system=CodeSystems.UNSTRUCTURED,
@@ -405,6 +430,24 @@ def test_immunization_statement_values_are_set_correctly() -> None:
         approximate_date=approximate_date_value,
         comments=comments_value,
     ).originate()
+
+    payload = json.loads(command.payload)
+    data = payload["data"]
+
+    assert data["unstructured"]["system"] == CodeSystems.UNSTRUCTURED
+    assert data["unstructured"]["code"] == "flu shot"
+    assert data["unstructured"]["display"] == "Flu shot"
+    assert data["approximate_date"] == "2024-01-15"
+    assert data["comments"] == comments_value
+
+    # Test with value set after instantiation
+    immunization_statement_command = ImmunizationStatementCommand(
+        note_uuid="test_uuid",
+        approximate_date=approximate_date_value,
+        comments=comments_value,
+    )
+    immunization_statement_command.unstructured = unstructured_coding
+    command = immunization_statement_command.originate()
 
     payload = json.loads(command.payload)
     data = payload["data"]
@@ -430,9 +473,9 @@ def test_immunization_statement_cpt_and_cvx_required_together() -> None:
         ImmunizationStatementCommand(
             note_uuid="test_uuid",
             cpt_code=cpt_coding,
-        )
+        ).originate()
     assert (
-        "Value error, Both cpt_code and cvx_code must be provided if one is specified and cannot be empty"
+        "Both cpt_code and cvx_code must be provided if one is specified and cannot be empty"
         in str(exc_info.value)
     )
 
@@ -441,9 +484,9 @@ def test_immunization_statement_cpt_and_cvx_required_together() -> None:
         ImmunizationStatementCommand(
             note_uuid="test_uuid",
             cvx_code=cvx_coding,
-        )
+        ).originate()
     assert (
-        "Value error, Both cpt_code and cvx_code must be provided if one is specified and cannot be empty"
+        "Both cpt_code and cvx_code must be provided if one is specified and cannot be empty"
         in str(exc_info.value)
     )
 


### PR DESCRIPTION
INTERNAL TRACKING: https://canvasmedical.atlassian.net/browse/KOALA-3580

fixes: https://github.com/canvas-medical/canvas-plugins/discussions/1217

This pull request refactors validation logic in the `ImmunizationStatementCommand` to improve error reporting and updates related tests to ensure proper validation of CPT, CVX, and unstructured codes. The main changes involve replacing a model validator with enhanced error detail collection and expanding test coverage for value assignment after instantiation.

**Validation logic improvements:**

* Replaced the `@model_validator` in `immunization_statement.py` with a custom `_get_error_details` method to aggregate validation errors for CPT and CVX code requirements, enabling more informative error messages.
* Improved the check for unstructured codes to ensure they cannot be used together with CPT or CVX codes, now reporting errors through the new error detail mechanism.

**Test enhancements:**

* Added tests for setting `cpt_code`, `cvx_code`, and `unstructured` values after instantiation, confirming that payloads are correctly generated and validation is enforced. [[1]](diffhunk://#diff-b3cee4e0a3101fd24316292e304576519b8be8dc6df445ae1f501b65f8180b3aR395-R419) [[2]](diffhunk://#diff-b3cee4e0a3101fd24316292e304576519b8be8dc6df445ae1f501b65f8180b3aR443-R460)
* Updated tests to invoke `.originate()` when validating CPT and CVX code requirements, and verified that error messages match the new format. [[1]](diffhunk://#diff-b3cee4e0a3101fd24316292e304576519b8be8dc6df445ae1f501b65f8180b3aL433-R478) [[2]](diffhunk://#diff-b3cee4e0a3101fd24316292e304576519b8be8dc6df445ae1f501b65f8180b3aL444-R489)

**Type hint and import cleanup:**

* Removed unused imports and type hints, such as `Self` and `model_validator`, from `immunization_statement.py` for clarity.


<!-- ## Title Guidelines

A title always has a prefix and a subject.

### Prefix
Make sure the title is prefixed with one of the following:

| Prefix | When to use |
|--------|-------------|
| `feat:`     | New feature |
| `fix:`      | Bug fix |
| `docs:`     | Documentation only changes |
| `style:`    | Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc) |
| `refactor:` | Code changes that neither fixes a bug nor adds a feature |
| `perf:`     | Code change that improves performance |
| `test:`     | Adding missing or correcting existing tests |
| `chore:`    | Changes to the build process or auxiliary tools and libraries such as documentation generation, ci, etc |

### Subject

Ensure the subject contains succinct description of the change.
* Use the imperative, present tense: "change", not "changed" nor "changes"
* Don’t capitalize first letter
* No dot (.) at the end
-->
