### PR TITLE
feat: add PluginData JSONB storage API and example plugin

### DIFF
--- a/canvas_cli/utils/validators/manifest_schema.py
+++ b/canvas_cli/utils/validators/manifest_schema.py
@@ -5,6 +5,7 @@ manifest_schema = {
         "plugin_version": {"type": "string"},
         "name": {"type": "string"},
         "description": {"type": "string"},
+        "data_isolated": {"type": "boolean", "default": True},
         "variables": {
             "description": "Plugin variables. Each entry has a name, an optional sensitive flag (default false), and an optional default value. Sensitive variables are write-only.",
             "type": "array",

--- a/canvas_sdk/v1/data/__init__.py
+++ b/canvas_sdk/v1/data/__init__.py
@@ -151,6 +151,7 @@ from .patient_group import PatientGroup, PatientGroupMember
 from .payment_collection import PaymentCollection
 from .payor_specific_charge import PayorSpecificCharge
 from .plugin_command import PluginCommand
+from .plugin_data import PluginData
 from .posting import (
     BasePosting,
     BaseRemittanceAdvice,
@@ -369,6 +370,7 @@ __all__ = __exports__ = (
     "PayorSpecificCharge",
     "PaymentCollection",
     "PluginCommand",
+    "PluginData",
     "PracticeLocation",
     "PracticeLocationAddress",
     "PracticeLocationContactPoint",

--- a/canvas_sdk/v1/data/plugin_data.py
+++ b/canvas_sdk/v1/data/plugin_data.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+import json
+import threading
+import uuid
+from collections.abc import Generator
+from contextlib import contextmanager
+from typing import Any
+
+from django.db import connection, models
+
+
+class PluginDataManager(models.Manager["PluginData"]):
+    """Custom manager that enforces plugin isolation via RLS."""
+
+    _thread_local = threading.local()
+
+    @classmethod
+    def _get_current_plugin(cls) -> str | None:
+        """Get the current plugin context."""
+        return getattr(cls._thread_local, "current_plugin", None)
+
+    @classmethod
+    def _set_current_plugin(cls, plugin_name: str | None) -> None:
+        """Set the current plugin context."""
+        cls._thread_local.current_plugin = plugin_name
+
+    def _require_context(self) -> str:
+        """Get current plugin, raising if not set."""
+        plugin_name = self._get_current_plugin()
+        if not plugin_name:
+            raise RuntimeError("Plugin context not set.")
+        return plugin_name
+
+    def get_queryset(self) -> models.QuerySet[PluginData]:
+        """Return a queryset scoped to current plugin via RLS."""
+        self._require_context()
+        return super().get_queryset()
+
+    def upsert(self, key: str, data: dict[str, Any]) -> PluginData:
+        """
+        Insert or update a plugin data record with shallow merge.
+
+        On insert, stores the data as-is. On update, merges new keys into
+        existing data (top-level shallow merge via jsonb || operator).
+
+        Args:
+            key: Unique key within this plugin's namespace
+            data: JSON-serializable dictionary to store/merge
+
+        Returns:
+            The created or updated PluginData instance
+        """
+        plugin_name = self._require_context()
+
+        with connection.cursor() as cursor:
+            cursor.execute(
+                """
+                INSERT INTO plugin_io_plugindata (id, plugin_name, key, data, created, modified)
+                VALUES (%s, %s, %s, %s, NOW(), NOW())
+                ON CONFLICT (plugin_name, key)
+                DO UPDATE SET data = plugin_io_plugindata.data || EXCLUDED.data, modified = NOW()
+                RETURNING id, plugin_name, key, data, created, modified
+                """,
+                [str(uuid.uuid4()), plugin_name, key, json.dumps(data)],
+            )
+            row = cursor.fetchone()
+
+        # Parse JSON if returned as string (depends on psycopg version/config)
+        row_data = row[3]
+        if isinstance(row_data, str):
+            row_data = json.loads(row_data)
+
+        return PluginData(
+            id=row[0],
+            plugin_name=row[1],
+            key=row[2],
+            data=row_data,
+            created=row[4],
+            modified=row[5],
+        )
+
+
+class PluginData(models.Model):
+    """
+    JSONB-based storage for plugin-specific data.
+
+    This model provides persistent key-value storage with JSON document values.
+    Each plugin can only access its own data, enforced by PostgreSQL Row-Level Security.
+
+    Storing Data:
+        # upsert() merges new keys into existing data (shallow merge)
+        PluginData.objects.upsert("config", {"timeout": 30})
+        PluginData.objects.upsert("config", {"retries": 3})
+        # Result: {"timeout": 30, "retries": 3}
+
+        # Existing keys are updated
+        PluginData.objects.upsert("config", {"timeout": 60})
+        # Result: {"timeout": 60, "retries": 3}
+
+    Retrieving Data:
+        config = PluginData.objects.get(key="config")
+        print(config.data["timeout"])
+
+        if PluginData.objects.filter(key="config").exists():
+            ...
+
+    Querying by JSON Content:
+        # Filter by JSON field
+        episodes = PluginData.objects.filter(
+            key__startswith="episode:",
+            data__patient_id="patient-123"
+        )
+
+        # Query nested JSON
+        active = PluginData.objects.filter(data__status="active")
+
+    Full Replacement:
+        # Use save() when you need to replace all data or delete keys
+        config = PluginData.objects.get(key="config")
+        del config.data["retries"]
+        config.save()  # Replaces entire data field
+
+    Deleting Records:
+        PluginData.objects.filter(key="old-data").delete()
+    """
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4)
+    plugin_name = models.CharField(max_length=255)
+    key = models.CharField(max_length=255)
+    data = models.JSONField(default=dict)
+    created = models.DateTimeField(auto_now_add=True)
+    modified = models.DateTimeField(auto_now=True)
+
+    objects = PluginDataManager()
+
+    class Meta:
+        managed = False
+        db_table = "plugin_io_plugindata"
+
+    def __str__(self) -> str:
+        return f"{self.plugin_name}:{self.key}"
+
+    def save(self, *args: Any, **kwargs: Any) -> None:
+        """Save the record, setting plugin_name from context."""
+        plugin_name = PluginDataManager._get_current_plugin()
+        if not plugin_name:
+            raise RuntimeError("Plugin context not set.")
+        self.plugin_name = plugin_name
+        super().save(*args, **kwargs)
+
+    def delete(self, *args: Any, **kwargs: Any) -> tuple[int, dict[str, int]]:
+        """Delete the record."""
+        if not PluginDataManager._get_current_plugin():
+            raise RuntimeError("Plugin context not set.")
+        return super().delete(*args, **kwargs)
+
+
+@contextmanager
+def plugin_context(plugin_name: str) -> Generator[None, None, None]:
+    """
+    Context manager to set plugin context for PluginData operations.
+
+    Sets the thread-local context and PostgreSQL RLS session variable once.
+    RLS uses SET LOCAL (transaction-scoped) for security.
+
+    This is used internally by the plugin runner. Plugin developers should not
+    use this directly.
+
+    Args:
+        plugin_name: The unique identifier for the plugin
+    """
+    previous_plugin = PluginDataManager._get_current_plugin()
+    try:
+        PluginDataManager._set_current_plugin(plugin_name)
+        with connection.cursor() as cursor:
+            cursor.execute("SET app.current_plugin = %s", [plugin_name])
+        yield
+    finally:
+        PluginDataManager._set_current_plugin(previous_plugin)
+        if previous_plugin:
+            with connection.cursor() as cursor:
+                cursor.execute("SET app.current_plugin = %s", [previous_plugin])

--- a/example-plugins/staff-custom-data/pyproject.toml
+++ b/example-plugins/staff-custom-data/pyproject.toml
@@ -1,0 +1,16 @@
+[project]
+authors = [
+  {email = "engineering@canvasmedical.com", name = "Canvas Team"}
+]
+dependencies = [
+  "canvas[test-utils]"
+]
+description = "Some description of your project."
+license = "MIT"
+name = "staff-custom-data"
+readme = "staff_custom_data/README.md"
+requires-python = ">=3.11"
+version = "0.1.0"
+
+[tool.pytest.ini_options]
+python_files = ["*_tests.py", "test_*.py", "tests.py"]

--- a/example-plugins/staff-custom-data/staff_custom_data/CANVAS_MANIFEST.json
+++ b/example-plugins/staff-custom-data/staff_custom_data/CANVAS_MANIFEST.json
@@ -1,0 +1,25 @@
+{
+    "sdk_version": "0.1.4",
+    "plugin_version": "0.0.1",
+    "name": "staff_custom_data",
+    "description": "Edit the description in CANVAS_MANIFEST.json",
+    "data_isolated": true,
+    "components": {
+        "protocols": [
+            {
+                "class": "staff_custom_data.routes.staff_api:StaffDataAPI",
+                "description": "API for managing staff biography and specialties"
+            }
+        ],
+        "commands": [],
+        "content": [],
+        "effects": [],
+        "views": []
+    },
+    "secrets": [],
+    "tags": {},
+    "references": [],
+    "license": "",
+    "diagram": false,
+    "readme": "./README.md"
+}

--- a/example-plugins/staff-custom-data/staff_custom_data/README.md
+++ b/example-plugins/staff-custom-data/staff_custom_data/README.md
@@ -1,0 +1,156 @@
+staff-custom-data
+=================
+
+## Description
+
+A plugin for storing and managing extended staff profile data using the PluginData API. Demonstrates custom JSONB storage with filtering capabilities.
+
+## Data Model
+
+Staff data is stored per staff member with the following structure:
+
+```json
+{
+    "biography": "Markdown formatted biography text",
+    "specialties": ["Cardiology", "Internal Medicine"],
+    "languages": ["English", "Spanish"],
+    "years_of_experience": 15,
+    "accepting_new_patients": true
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `biography` | string | Staff member's bio (supports markdown) |
+| `specialties` | string[] | Medical specialties |
+| `languages` | string[] | Languages spoken |
+| `years_of_experience` | integer | Years in practice |
+| `accepting_new_patients` | boolean | Currently accepting new patients |
+
+## API Endpoints
+
+Base path: `/plugin-io/api/staff_custom_data`
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/staff/` | List all staff data (with filtering) |
+| GET | `/staff/{uuid}/` | Get data for a single staff member |
+| PUT | `/staff/{uuid}/` | Update staff data (partial updates supported) |
+
+## Filtering
+
+The list endpoint supports query parameters for filtering:
+
+| Parameter | Description | Example |
+|-----------|-------------|---------|
+| `specialty` | Filter by specialty (case-insensitive, partial match) | `?specialty=cardio` |
+| `language` | Filter by language spoken | `?language=spanish` |
+| `accepting_new_patients` | Filter by availability | `?accepting_new_patients=true` |
+| `min_experience` | Minimum years of experience | `?min_experience=10` |
+
+Filters can be combined: `?specialty=cardio&language=spanish&accepting_new_patients=true`
+
+## Usage Examples
+
+### Create/Update staff data (PUT)
+
+Updates are merged with existing data - you only need to send the fields you want to change.
+
+```bash
+curl -X PUT "https://your-instance/plugin-io/api/staff_custom_data/staff/abc-123-def/" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "biography": "## Dr. Smith\n\nBoard certified cardiologist with 15 years of experience.",
+    "specialties": ["Cardiology", "Internal Medicine"],
+    "languages": ["English", "Spanish"],
+    "years_of_experience": 15,
+    "accepting_new_patients": true
+  }'
+```
+
+**Response (200 OK):**
+```json
+{
+    "message": "Staff data updated",
+    "staff_uuid": "abc-123-def",
+    "biography": "## Dr. Smith\n\nBoard certified cardiologist with 15 years of experience.",
+    "specialties": ["Cardiology", "Internal Medicine"],
+    "languages": ["English", "Spanish"],
+    "years_of_experience": 15,
+    "accepting_new_patients": true
+}
+```
+
+### Partial update (PUT)
+
+Update only specific fields - other fields are preserved:
+
+```bash
+curl -X PUT "https://your-instance/plugin-io/api/staff_custom_data/staff/abc-123-def/" \
+  -H "Content-Type: application/json" \
+  -d '{"accepting_new_patients": false}'
+```
+
+### Get single staff data (GET)
+
+```bash
+curl "https://your-instance/plugin-io/api/staff_custom_data/staff/abc-123-def/"
+```
+
+**Response (200 OK):**
+```json
+{
+    "staff_uuid": "abc-123-def",
+    "biography": "## Dr. Smith\n\nBoard certified cardiologist with 15 years of experience.",
+    "specialties": ["Cardiology", "Internal Medicine"],
+    "languages": ["English", "Spanish"],
+    "years_of_experience": 15,
+    "accepting_new_patients": false
+}
+```
+
+### List all staff data (GET)
+
+```bash
+curl "https://your-instance/plugin-io/api/staff_custom_data/staff/"
+```
+
+**Response (200 OK):**
+```json
+{
+    "staff": [
+        {
+            "staff_uuid": "abc-123-def",
+            "biography": "## Dr. Smith\n\nBoard certified cardiologist.",
+            "specialties": ["Cardiology", "Internal Medicine"],
+            "languages": ["English", "Spanish"],
+            "years_of_experience": 15,
+            "accepting_new_patients": true
+        },
+        {
+            "staff_uuid": "xyz-789-ghi",
+            "biography": "## Dr. Jones\n\nFamily medicine specialist.",
+            "specialties": ["Family Medicine", "Pediatrics"],
+            "languages": ["English"],
+            "years_of_experience": 8,
+            "accepting_new_patients": true
+        }
+    ],
+    "count": 2
+}
+```
+
+### List with filters (GET)
+
+Find Spanish-speaking cardiologists with 10+ years experience who are accepting patients:
+
+```bash
+curl "https://your-instance/plugin-io/api/staff_custom_data/staff/?specialty=cardio&language=spanish&min_experience=10&accepting_new_patients=true"
+```
+
+## Data Storage
+
+This plugin uses the `PluginData` API for JSONB storage with:
+- Automatic plugin isolation (each plugin can only access its own data)
+- Shallow merge on updates (via PostgreSQL's `||` operator)
+- Row-Level Security enforcement at the database level

--- a/example-plugins/staff-custom-data/staff_custom_data/routes/__init__.py
+++ b/example-plugins/staff-custom-data/staff_custom_data/routes/__init__.py
@@ -1,0 +1,1 @@
+# Routes package for staff_custom_data plugin

--- a/example-plugins/staff-custom-data/staff_custom_data/routes/staff_api.py
+++ b/example-plugins/staff-custom-data/staff_custom_data/routes/staff_api.py
@@ -1,0 +1,180 @@
+from http import HTTPStatus
+
+from canvas_sdk.effects.simple_api import JSONResponse, Response
+from canvas_sdk.handlers.simple_api import Credentials, SimpleAPI, api
+from canvas_sdk.v1.data import PluginData
+from logger import log
+
+
+class StaffDataAPI(SimpleAPI):
+    """API for managing extended staff profile data.
+
+    Schema:
+        - biography: str - Staff member's bio
+        - specialties: list[str] - Medical specialties (e.g., ["Cardiology", "Internal Medicine"])
+        - languages: list[str] - Languages spoken (e.g., ["English", "Spanish"])
+        - years_of_experience: int - Years in practice
+        - accepting_new_patients: bool - Currently accepting new patients
+
+    Filtering (GET /staff/):
+        - specialty: Filter by specialty (case-sensitive, exact match)
+        - language: Filter by language (case-sensitive, exact match)
+        - accepting_new_patients: Filter by availability (true/false)
+        - min_experience: Minimum years of experience
+    """
+
+    PREFIX = "/staff"
+
+    def authenticate(self, credentials: Credentials) -> bool:
+        """Allow all requests (demo purposes)."""
+        return True
+
+    def _serialize_record(self, record: PluginData) -> dict:
+        """Convert a PluginData record to API response format."""
+        staff_uuid = record.key.replace("staff:", "")
+        return {
+            "staff_uuid": staff_uuid,
+            "biography": record.data.get("biography", ""),
+            "specialties": record.data.get("specialties", []),
+            "languages": record.data.get("languages", []),
+            "years_of_experience": record.data.get("years_of_experience"),
+            "accepting_new_patients": record.data.get("accepting_new_patients"),
+        }
+
+    @api.get("/")
+    def list_all(self) -> list[Response]:
+        """Get all staff data with optional filtering (all DB-level)."""
+        params = self.request.query_params
+
+        # Build ORM query and log string
+        filters = ['key__startswith="staff:"']
+        queryset = PluginData.objects.filter(key__startswith="staff:")
+
+        # Boolean filter
+        if accepting := params.get("accepting_new_patients"):
+            value = accepting.lower() == "true"
+            queryset = queryset.filter(data__accepting_new_patients=value)
+            filters.append(f"data__accepting_new_patients={value}")
+
+        # Integer comparison
+        if min_exp := params.get("min_experience"):
+            queryset = queryset.filter(data__years_of_experience__gte=int(min_exp))
+            filters.append(f"data__years_of_experience__gte={int(min_exp)}")
+
+        # Array contains (case-sensitive, exact match)
+        if specialty := params.get("specialty"):
+            queryset = queryset.filter(data__specialties__contains=[specialty])
+            filters.append(f'data__specialties__contains=["{specialty}"]')
+
+        if language := params.get("language"):
+            queryset = queryset.filter(data__languages__contains=[language])
+            filters.append(f'data__languages__contains=["{language}"]')
+
+        # Log ORM query for shell_plus
+        orm_query = f"PluginData.objects.filter({', '.join(filters)})"
+        log.info(f"\n{'=' * 60}\nORM QUERY:\n{orm_query}\n{'=' * 60}\n")
+
+        result = [self._serialize_record(record) for record in queryset]
+        return [JSONResponse({"staff": result, "count": len(result)})]
+
+    @api.get("/<uuid>/")
+    def get_one(self) -> list[Response]:
+        """Get data for a single staff member."""
+        staff_uuid = self.request.path_params.get("uuid")
+        record = PluginData.objects.filter(key=f"staff:{staff_uuid}").first()
+
+        if not record:
+            return [
+                JSONResponse(
+                    {"error": "Staff data not found"},
+                    status_code=HTTPStatus.NOT_FOUND,
+                )
+            ]
+
+        return [JSONResponse(self._serialize_record(record))]
+
+    @api.put("/<uuid>/")
+    def update(self) -> list[Response]:
+        """Update staff profile data (merges with existing data)."""
+        staff_uuid = self.request.path_params.get("uuid")
+
+        # Validate staff exists
+        # if not Staff.objects.filter(id=staff_uuid).exists():
+        #     return [JSONResponse(
+        #         {"error": "Staff member not found"},
+        #         status_code=HTTPStatus.NOT_FOUND,
+        #     )]
+
+        body = self.request.json()
+        data = {}
+
+        # Validate and collect fields
+        if "biography" in body:
+            if not isinstance(body["biography"], str):
+                return [
+                    JSONResponse(
+                        {"error": "biography must be a string"},
+                        status_code=HTTPStatus.BAD_REQUEST,
+                    )
+                ]
+            data["biography"] = body["biography"]
+
+        if "specialties" in body:
+            if not isinstance(body["specialties"], list):
+                return [
+                    JSONResponse(
+                        {"error": "specialties must be a list of strings"},
+                        status_code=HTTPStatus.BAD_REQUEST,
+                    )
+                ]
+            data["specialties"] = body["specialties"]
+
+        if "languages" in body:
+            if not isinstance(body["languages"], list):
+                return [
+                    JSONResponse(
+                        {"error": "languages must be a list of strings"},
+                        status_code=HTTPStatus.BAD_REQUEST,
+                    )
+                ]
+            data["languages"] = body["languages"]
+
+        if "years_of_experience" in body:
+            if not isinstance(body["years_of_experience"], int):
+                return [
+                    JSONResponse(
+                        {"error": "years_of_experience must be an integer"},
+                        status_code=HTTPStatus.BAD_REQUEST,
+                    )
+                ]
+            data["years_of_experience"] = body["years_of_experience"]
+
+        if "accepting_new_patients" in body:
+            if not isinstance(body["accepting_new_patients"], bool):
+                return [
+                    JSONResponse(
+                        {"error": "accepting_new_patients must be a boolean"},
+                        status_code=HTTPStatus.BAD_REQUEST,
+                    )
+                ]
+            data["accepting_new_patients"] = body["accepting_new_patients"]
+
+        if not data:
+            return [
+                JSONResponse(
+                    {"error": "No valid fields provided"},
+                    status_code=HTTPStatus.BAD_REQUEST,
+                )
+            ]
+
+        # Upsert merges with existing data
+        record = PluginData.objects.upsert(key=f"staff:{staff_uuid}", data=data)
+
+        return [
+            JSONResponse(
+                {
+                    "message": "Staff data updated",
+                    **self._serialize_record(record),
+                }
+            )
+        ]

--- a/example-plugins/staff-custom-data/tests/test_models.py
+++ b/example-plugins/staff-custom-data/tests/test_models.py
@@ -1,0 +1,62 @@
+# To run the tests, use the command `pytest` in the terminal or uv run pytest.
+# Each test is wrapped inside a transaction that is rolled back at the end of the test.
+# If you want to modify which files are used for testing, check the [tool.pytest.ini_options] section in pyproject.toml.
+# For more information on testing Canvas plugins, see: https://docs.canvasmedical.com/sdk/testing-utils/
+
+from unittest.mock import Mock
+
+from staff_custom_data.protocols.my_protocol import Protocol
+
+from canvas_sdk.effects import EffectType
+from canvas_sdk.events import EventType
+from canvas_sdk.test_utils.factories import PatientFactory
+from canvas_sdk.v1.data.discount import Discount
+
+
+# Test the protocol's compute method with mocked event data
+def test_protocol_responds_to_assess_command() -> None:
+    """Test that the protocol responds correctly to ASSESS_COMMAND__CONDITION_SELECTED events."""
+    # Create a mock event with the expected structure
+    mock_event = Mock()
+    mock_event.type = EventType.ASSESS_COMMAND__CONDITION_SELECTED
+    mock_event.context = {
+        "note": {
+            "uuid": "test-note-uuid-123",
+        }
+    }
+
+    # Instantiate the protocol with the mock event
+    protocol = Protocol(event=mock_event)
+
+    # Call compute and get the effects
+    effects = protocol.compute()
+
+    # Assert that effects were returned
+    assert len(effects) == 1
+
+    # Assert the effect has the correct type
+    assert effects[0].type == EffectType.LOG
+
+    # Assert the effect contains expected data
+    assert "test-note-uuid-123" in effects[0].payload
+    assert protocol.NARRATIVE_STRING in effects[0].payload
+
+
+# Test that the protocol class has the correct event type configured
+def test_protocol_event_configuration() -> None:
+    """Test that the protocol is configured to respond to the correct event type."""
+    assert EventType.Name(EventType.ASSESS_COMMAND__CONDITION_SELECTED) == Protocol.RESPONDS_TO
+
+
+# Example: You can use a factory to create a patient instance for testing purposes.
+def test_factory_example() -> None:
+    """Test that a patient can be created using the PatientFactory."""
+    patient = PatientFactory.create()
+    assert patient.id is not None
+
+
+# Example: If a factory is not available, you can create an instance manually with the data model directly.
+def test_model_example() -> None:
+    """Test that a Discount instance can be created."""
+    Discount.objects.create(name="10%", adjustment_group="30", adjustment_code="CO", discount=0.10)
+    assert Discount.objects.first().pk is not None

--- a/plugin_runner/allowed-module-imports.json
+++ b/plugin_runner/allowed-module-imports.json
@@ -1190,6 +1190,7 @@
     "PaymentCollection",
     "PayorSpecificCharge",
     "PluginCommand",
+    "PluginData",
     "PracticeLocation",
     "PracticeLocationAddress",
     "PracticeLocationContactPoint",

--- a/plugin_runner/plugin_runner.py
+++ b/plugin_runner/plugin_runner.py
@@ -48,6 +48,7 @@ from canvas_sdk.templates.utils import _engine_for_plugin
 from canvas_sdk.utils import metrics
 from canvas_sdk.utils.metrics import measured
 from canvas_sdk.v1.data.base import IS_SQLITE
+from canvas_sdk.v1.data.plugin_data import plugin_context
 from canvas_sdk.v1.plugin_database_context import plugin_database_context
 from logger import log
 from logger.logger import plugin_context
@@ -317,6 +318,7 @@ class PluginRunner(PluginRunnerServicer):
                             namespace_config["access_level"] if namespace_config else "read"
                         )
 
+                        # Automatically set plugin context for PluginData access
                         with (
                             metrics.measure(
                                 name=handler_name,
@@ -332,6 +334,7 @@ class PluginRunner(PluginRunnerServicer):
                                 namespace=db_namespace,
                                 access_level=db_access_level,
                             ),
+                            plugin_context(base_plugin_name),
                         ):
                             _effects = handler.compute()
                             if _effects is None:


### PR DESCRIPTION
This pull request introduces a new example plugin, `staff-custom-data`, which demonstrates how to use the new `PluginData` API for per-plugin, JSONB-based data storage with row-level security. It adds a reusable, isolated storage model to the SDK, exposes it for plugin use, and provides a working plugin with documentation, API endpoints, and tests. Additionally, the manifest schema is updated to support a `data_isolated` flag for plugins.

Key changes:

**1. Plugin Data Isolation Infrastructure**
- Introduced a new `PluginData` model and manager in `canvas_sdk.v1.data.plugin_data` for plugin-scoped, JSONB-backed key-value storage with PostgreSQL row-level security and shallow-merge upsert semantics. Includes a context manager for safe plugin context switching.
- Added `PluginData` to the SDK's public API (`canvas_sdk/v1/data/__init__.py`) and the plugin runner's allowed imports. [[1]](diffhunk://#diff-7b0c97fc42b6555943e206a71ce18b4e13f011b8a125f11e6983fffe154e3f5bR97) [[2]](diffhunk://#diff-7b0c97fc42b6555943e206a71ce18b4e13f011b8a125f11e6983fffe154e3f5bR241) [[3]](diffhunk://#diff-a40dcade76413e693e0a9fefc6afe070adb5765f6ca17ff86b3982eef6df5c32R801)

**2. Example Plugin: staff-custom-data**
- Added the `staff-custom-data` example plugin, including its manifest, Python package configuration, and a comprehensive README describing usage, data model, and API. [[1]](diffhunk://#diff-468db9d8cd6f09e6ce2baa0bb892fdcdd46a531ce9642e6ee290115064bca75cR1-R16) [[2]](diffhunk://#diff-9d09bf89cb5cca26c6f02dfe10c2861cb1496ae47ce033d8d9a69a47e8193968R1-R25) [[3]](diffhunk://#diff-f0f2a760cd63ad244f0b7c77640781480a48c3a490e7596372ddc4b672250f04R1-R156)
- Implemented a REST API (`staff_custom_data/routes/staff_api.py`) for storing and retrieving extended staff profile data using `PluginData`, with support for filtering and partial updates.
- Added a tests file with examples for protocol and model testing.
- Created an empty `routes/__init__.py` to mark the routes package.

**3. Manifest Schema Update**
- Updated the manifest schema validator to support a new boolean field `data_isolated`, defaulting to true, indicating if a plugin's data is isolated.

