### PR TITLE
chore: update codecov logic for ci/cd 

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -130,9 +130,9 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage-py3.11.xml,./coverage-py3.12.xml
-          flags: sdk-core,merged
+          flags: sdk-core
           fail_ci_if_error: true
-  
+
   discover-plugins:
     runs-on: ubuntu-latest
     outputs:


### PR DESCRIPTION
<!-- ## Title Guidelines

A title always has a prefix and a subject.

### Prefix
Make sure the title is prefixed with one of the following:

| Prefix | When to use |
|--------|-------------|
| `feat:`     | New feature |
| `fix:`      | Bug fix |
| `docs:`     | Documentation only changes |
| `style:`    | Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc) |
| `refactor:` | Code changes that neither fixes a bug nor adds a feature |
| `perf:`     | Code change that improves performance |
| `test:`     | Adding missing or correcting existing tests |
| `chore:`    | Changes to the build process or auxiliary tools and libraries such as documentation generation, ci, etc |

### Subject

Ensure the subject contains succinct description of the change.
* Use the imperative, present tense: "change", not "changed" nor "changes"
* Don’t capitalize first letter
* No dot (.) at the end
-->

## Fix Codecov race condition in matrix jobs

### Problem
Matrix jobs (Python 3.11 & 3.12) uploaded coverage to Codecov simultaneously, causing GitHub PR checks to show nondeterministic results (randomly displaying coverage from only one Python version).

### Solution
- **Matrix jobs**: Generate version-specific coverage files (`coverage-py3.11.xml`, `coverage-py3.12.xml`) and upload as artifacts (no direct Codecov upload)
- **New `upload-coverage` job**: Downloads artifacts and uploads to Codecov sequentially:
  - Per-version uploads with `py3.11` and `py3.12` flags (informational only)
  - Final merged upload with `sdk-core` flag (sets PR status)

### Result
- Single deterministic upload controls GitHub PR status
- Per-version coverage still visible in Codecov dashboard via flags
- Follows Codecov's recommended pattern for matrix builds
