### PR TITLE
feat: add annotations and source_protocol to CategorizeDocument effect

### DIFF
--- a/canvas_sdk/effects/categorize_document.py
+++ b/canvas_sdk/effects/categorize_document.py
@@ -66,6 +66,19 @@ class DocumentType(TypedDict):
     template_type: str | None
 
 
+class AnnotationItem(TypedDict):
+    """
+    Annotation item with text and color for UI display.
+
+    Attributes:
+        text: The annotation label (e.g., "AI 97%", "Auto-detected")
+        color: Hex color code (e.g., "#FF0000" for red)
+    """
+
+    text: str
+    color: str
+
+
 VALID_REPORT_TYPES = frozenset(["CLINICAL", "ADMINISTRATIVE"])
 VALID_TEMPLATE_TYPES = frozenset(
     ["LabReportTemplate", "ImagingReportTemplate", "SpecialtyReportTemplate"]
@@ -97,6 +110,8 @@ class CategorizeDocument(_BaseEffect):
     document_id: str | int | None = None
     document_type: DocumentType | dict[str, Any] | None = None
     confidence_scores: ConfidenceScores | None = None
+    annotations: list[AnnotationItem] | None = None
+    source_protocol: str | None = None
 
     @model_validator(mode="before")
     @classmethod
@@ -138,6 +153,10 @@ class CategorizeDocument(_BaseEffect):
 
         if self.confidence_scores is not None:
             result["confidence_scores"] = self.confidence_scores
+        if self.annotations is not None:
+            result["annotations"] = self.annotations
+        if self.source_protocol is not None:
+            result["source_protocol"] = self.source_protocol
 
         return result
 
@@ -230,6 +249,7 @@ class CategorizeDocument(_BaseEffect):
 
 
 __exports__ = (
+    "AnnotationItem",
     "ConfidenceScores",
     "DocumentType",
     "DocumentTypeConfidenceScores",


### PR DESCRIPTION
Linked Issue
------------

https://canvasmedical.atlassian.net/browse/KOALA-3988

Linked PRs
------------

- home-app: https://github.com/canvas-medical/canvas/pull/18583

Description
-----------

Adds two optional fields to the `CategorizeDocument` effect to support document prefill functionality:

**Previous state:**
- `CategorizeDocument` effect only supported `document_id`, `document_type`, and `confidence_scores` fields
- No way to pass UI display annotations or identify the source plugin

**Current state:**
- Added `annotations` field: list of `AnnotationItem` objects with `text` and `color` attributes for UI display tags (e.g., `[{"text": "AI 97%", "color": "#00FF00"}]`)
- Added `source_protocol` field: string identifying the plugin that performed the categorization
- Added `AnnotationItem` TypedDict for type safety
- Both fields are optional and excluded from payload when `None`

**Files changed:**
- `canvas_sdk/effects/categorize_document.py` - Added `AnnotationItem`, `annotations`, and `source_protocol`
- `canvas_sdk/tests/effects/test_categorize_document.py` - Added tests for new fields
