### PR TITLE
feat(payments): passing additional context to charge

### DIFF
--- a/plugin_runner/tests/fixtures/plugins/test_payment_processor/protocols/my_protocol.py
+++ b/plugin_runner/tests/fixtures/plugins/test_payment_processor/protocols/my_protocol.py
@@ -48,7 +48,9 @@ class CustomPaymentProcessor(CardPaymentProcessor):
             )
         ]
 
-    def add_payment_method(self, token: str, patient: Patient) -> AddPaymentMethodResponse:
+    def add_payment_method(
+        self, token: str, patient: Patient, **kwargs: Any
+    ) -> AddPaymentMethodResponse:
         """Add a payment method for the patient using the provided token."""
         return AddPaymentMethodResponse(success=True)
 


### PR DESCRIPTION
[KOALA-4016](https://canvasmedical.atlassian.net/browse/KOALA-4016)

depends on: https://github.com/canvas-medical/canvas/pull/18600

This pull request enhances the card payment processor to support passing additional context to the charge method, improves robustness in handling this context, and adds comprehensive tests to ensure correct behavior. The main changes are grouped into improvements to the payment processor logic and enhancements to test coverage.

**Payment processor logic improvements:**

* Updated the `_charge` method in `card.py` to parse the `additional_context` field from the event context, attempting to decode it as JSON and falling back to a dictionary if necessary, before passing it as keyword arguments to the `charge` method.
* Modified the `charge` method signature (and its abstract base) to accept arbitrary keyword arguments (`**kwargs: Any`) for additional context, and updated the docstring accordingly.

**Test coverage enhancements:**

* Added a parameterized test `test_charge_additional_context` to verify that different forms of `additional_context` are correctly parsed and passed as keyword arguments to `charge`.
* Updated the `DummyCardProcessor.charge` method signature in the test suite to match the new interface with `**kwargs: Any`.
* Imported `Any` in the test file to support the updated method signatures.

Other:

* Imported `json` and `Any` in `card.py` to support the new parsing logic and typing.

[KOALA-4016]: https://canvasmedical.atlassian.net/browse/KOALA-4016?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ