### PR TITLE
refactor: clean up data integration handler and confidence scores

### DIFF
--- a/canvas_sdk/effects/data_integration/__init__.py
+++ b/canvas_sdk/effects/data_integration/__init__.py
@@ -3,14 +3,10 @@ from .assign_document_reviewer import AssignDocumentReviewer as AssignDocumentRe
 from .assign_document_reviewer import Priority as Priority
 from .assign_document_reviewer import ReviewMode as ReviewMode
 from .junk_document import JunkDocument as JunkDocument
-from .junk_document import JunkDocumentConfidenceScores as JunkDocumentConfidenceScores
 from .link_document_to_patient import LinkDocumentToPatient as LinkDocumentToPatient
 from .prefill_document_fields import PrefillDocumentFieldData as PrefillDocumentFieldData
 from .prefill_document_fields import PrefillDocumentFields as PrefillDocumentFields
 from .prefill_document_fields import TemplateFields as TemplateFields
-from .remove_document_from_patient import (
-    RemoveDocumentConfidenceScores as RemoveDocumentConfidenceScores,
-)
 from .remove_document_from_patient import RemoveDocumentFromPatient as RemoveDocumentFromPatient
 
 __all__ = __exports__ = (
@@ -18,11 +14,9 @@ __all__ = __exports__ = (
     "AssignDocumentReviewer",
     "PrefillDocumentFieldData",
     "JunkDocument",
-    "JunkDocumentConfidenceScores",
     "LinkDocumentToPatient",
     "PrefillDocumentFields",
     "Priority",
-    "RemoveDocumentConfidenceScores",
     "RemoveDocumentFromPatient",
     "ReviewMode",
     "TemplateFields",

--- a/canvas_sdk/effects/data_integration/junk_document.py
+++ b/canvas_sdk/effects/data_integration/junk_document.py
@@ -1,28 +1,8 @@
-from typing import Annotated, Any
+from typing import Any
 
-from pydantic import Field, model_validator
 from pydantic_core import InitErrorDetails
-from typing_extensions import TypedDict
 
 from canvas_sdk.effects.base import EffectType, _BaseEffect
-
-
-class JunkDocumentConfidenceScores(TypedDict, total=False):
-    """
-    Confidence scores for the junk document decision.
-
-    All fields are optional. Values must be floats between 0.0 and 1.0,
-    representing the confidence level of the junk classification.
-
-    Attributes:
-        junk: Confidence score for the decision to junk a document (0.0-1.0).
-            Higher values indicate greater confidence that the document is junk/spam.
-    """
-
-    junk: Annotated[float, Field(ge=0.0, le=1.0)]
-
-
-CONFIDENCE_SCORE_KEYS = frozenset(JunkDocumentConfidenceScores.__annotations__.keys())
 
 
 class JunkDocument(_BaseEffect):
@@ -36,8 +16,6 @@ class JunkDocument(_BaseEffect):
     Attributes:
         document_id: The ID of the IntegrationTask document to mark as junk (required, non-empty).
             Accepts str or int; always serialized as string in the payload.
-        confidence_scores: Optional confidence scores for the junk classification.
-            See JunkDocumentConfidenceScores TypedDict for valid keys and value constraints.
     """
 
     class Meta:
@@ -45,36 +23,13 @@ class JunkDocument(_BaseEffect):
         apply_required_fields = ("document_id",)
 
     document_id: str | int | None = None
-    confidence_scores: JunkDocumentConfidenceScores | None = None
-
-    @model_validator(mode="before")
-    @classmethod
-    def validate_confidence_scores_keys(cls, data: Any) -> Any:
-        """Validate confidence_scores keys before Pydantic processes the TypedDict.
-
-        TypedDict in Pydantic silently drops unknown keys, so we validate
-        them here to provide a clear error message to users.
-        """
-        if isinstance(data, dict) and "confidence_scores" in data:
-            scores = data.get("confidence_scores")
-            if isinstance(scores, dict):
-                invalid_keys = set(scores.keys()) - CONFIDENCE_SCORE_KEYS
-                if invalid_keys:
-                    raise ValueError(
-                        f"confidence_scores contains invalid keys: {sorted(invalid_keys)}. "
-                        f"Valid keys are: {sorted(CONFIDENCE_SCORE_KEYS)}"
-                    )
-        return data
 
     @property
     def values(self) -> dict[str, Any]:
         """The effect's values to be sent in the payload."""
-        result: dict[str, Any] = {
+        return {
             "document_id": str(self.document_id).strip() if self.document_id is not None else None,
         }
-        if self.confidence_scores is not None:
-            result["confidence_scores"] = self.confidence_scores
-        return result
 
     def _get_error_details(self, method: Any) -> list[InitErrorDetails]:
         """Validate the effect fields and return any error details."""
@@ -93,4 +48,4 @@ class JunkDocument(_BaseEffect):
         return errors
 
 
-__exports__ = ("JunkDocumentConfidenceScores", "JunkDocument")
+__exports__ = ("JunkDocument",)

--- a/canvas_sdk/tests/effects/test_categorize_document.py
+++ b/canvas_sdk/tests/effects/test_categorize_document.py
@@ -8,7 +8,6 @@ from canvas_generated.messages.effects_pb2 import EffectType
 from canvas_sdk.effects.categorize_document import (
     AnnotationItem,
     CategorizeDocument,
-    ConfidenceScores,
     DocumentType,
 )
 
@@ -21,20 +20,6 @@ def valid_document_type() -> DocumentType:
         "name": "Lab Report",
         "report_type": "CLINICAL",
         "template_type": "LabReportTemplate",
-    }
-
-
-@pytest.fixture
-def valid_confidence_scores() -> ConfidenceScores:
-    """Valid confidence scores for testing."""
-    return {
-        "document_id": 0.90,
-        "document_type": {
-            "key": 0.90,
-            "name": 0.95,
-            "report_type": 0.85,
-            "template_type": 0.90,
-        },
     }
 
 
@@ -55,7 +40,6 @@ class TestCategorizeDocumentCreation:
         effect = CategorizeDocument(document_id="123", document_type=valid_document_type)
         assert effect.document_id == "123"
         assert effect.document_type == valid_document_type
-        assert effect.confidence_scores is None
 
     def test_creation_with_int_document_id(self, valid_document_type: DocumentType) -> None:
         """Test that document_id can be an int and is serialized as string."""
@@ -63,42 +47,34 @@ class TestCategorizeDocumentCreation:
         assert effect.document_id == 123
         assert effect.values["document_id"] == "123"
 
-    def test_creation_with_confidence_scores(
-        self, valid_document_type: DocumentType, valid_confidence_scores: ConfidenceScores
-    ) -> None:
-        """Test that CategorizeDocument can be created with confidence_scores."""
-        effect = CategorizeDocument(
-            document_id="456",
-            document_type=valid_document_type,
-            confidence_scores=valid_confidence_scores,
-        )
-        assert effect.confidence_scores == valid_confidence_scores
-
 
 class TestCategorizeDocumentValues:
     """Tests for the values property."""
 
-    def test_values_with_confidence_scores(
-        self, valid_document_type: DocumentType, valid_confidence_scores: ConfidenceScores
+    def test_values_with_all_fields(
+        self, valid_document_type: DocumentType, valid_annotations: list[AnnotationItem]
     ) -> None:
-        """Test that values property includes confidence_scores when provided."""
+        """Test that values property includes all fields when provided."""
         effect = CategorizeDocument(
             document_id=789,
             document_type=valid_document_type,
-            confidence_scores=valid_confidence_scores,
+            annotations=valid_annotations,
+            source_protocol="test_plugin",
         )
         values = effect.values
         assert values == {
             "document_id": "789",
             "document_type": valid_document_type,
-            "confidence_scores": valid_confidence_scores,
+            "annotations": valid_annotations,
+            "source_protocol": "test_plugin",
         }
 
-    def test_values_without_confidence_scores(self, valid_document_type: DocumentType) -> None:
-        """Test that values property excludes confidence_scores when not provided."""
+    def test_values_without_optional_fields(self, valid_document_type: DocumentType) -> None:
+        """Test that values property excludes optional fields when not provided."""
         effect = CategorizeDocument(document_id="999", document_type=valid_document_type)
         values = effect.values
-        assert "confidence_scores" not in values
+        assert "annotations" not in values
+        assert "source_protocol" not in values
         assert values == {
             "document_id": "999",
             "document_type": valid_document_type,
@@ -221,106 +197,6 @@ class TestDocumentTypeValidation:
         assert "document_type.template_type must be a string or null" in repr(exc_info.value)
 
 
-class TestConfidenceScoresValidation:
-    """Tests for confidence_scores field validation."""
-
-    def test_invalid_top_level_keys(self, valid_document_type: DocumentType) -> None:
-        """Test that invalid top-level confidence_scores keys raise ValueError."""
-        invalid_scores = {"invalid_key": 0.5, "document_id": 0.9}
-        with pytest.raises(ValueError, match="confidence_scores contains invalid keys"):
-            CategorizeDocument(
-                document_id="123",
-                document_type=valid_document_type,
-                confidence_scores=invalid_scores,  # type: ignore[arg-type]
-            )
-
-    def test_invalid_nested_keys(self, valid_document_type: DocumentType) -> None:
-        """Test that invalid nested confidence_scores keys raise ValueError."""
-        invalid_scores = {
-            "document_id": 0.9,
-            "document_type": {"invalid_key": 0.5, "key": 0.9},
-        }
-        with pytest.raises(
-            ValueError, match="confidence_scores.document_type contains invalid keys"
-        ):
-            CategorizeDocument(
-                document_id="123",
-                document_type=valid_document_type,
-                confidence_scores=invalid_scores,  # type: ignore[arg-type]
-            )
-
-    @pytest.mark.parametrize("value", [-0.1, 1.1])
-    def test_out_of_range_values(self, value: float, valid_document_type: DocumentType) -> None:
-        """Test that confidence_scores values outside 0.0-1.0 raise ValidationError."""
-        if value < 0:
-            invalid_scores: ConfidenceScores = {
-                "document_id": value,
-                "document_type": {
-                    "key": 0.9,
-                    "name": 0.95,
-                    "report_type": 0.85,
-                    "template_type": 0.9,
-                },
-            }
-        else:
-            invalid_scores = {
-                "document_id": 0.9,
-                "document_type": {
-                    "key": value,
-                    "name": 0.95,
-                    "report_type": 0.85,
-                    "template_type": 0.9,
-                },
-            }
-        with pytest.raises(ValidationError):
-            CategorizeDocument(
-                document_id="123",
-                document_type=valid_document_type,
-                confidence_scores=invalid_scores,
-            )
-
-    @pytest.mark.parametrize("value", [0.0, 1.0])
-    def test_boundary_values(self, value: float, valid_document_type: DocumentType) -> None:
-        """Test that confidence_scores boundary values (0.0, 1.0) are valid."""
-        confidence_scores: ConfidenceScores = {
-            "document_id": value,
-            "document_type": {
-                "key": value,
-                "name": value,
-                "report_type": value,
-                "template_type": value,
-            },
-        }
-        effect = CategorizeDocument(
-            document_id="123",
-            document_type=valid_document_type,
-            confidence_scores=confidence_scores,
-        )
-        applied = effect.apply()
-        assert applied.type == EffectType.CATEGORIZE_DOCUMENT
-
-    def test_confidence_scores_must_be_dict(self, valid_document_type: DocumentType) -> None:
-        """Test that confidence_scores must be a dict if provided."""
-        with pytest.raises(ValidationError):
-            CategorizeDocument(
-                document_id="123",
-                document_type=valid_document_type,
-                confidence_scores="not_a_dict",  # type: ignore[arg-type]
-            )
-
-    def test_partial_confidence_scores(self, valid_document_type: DocumentType) -> None:
-        """Test that confidence_scores can have only some keys."""
-        partial_scores: ConfidenceScores = {"document_id": 0.9}
-        effect = CategorizeDocument(
-            document_id="123", document_type=valid_document_type, confidence_scores=partial_scores
-        )
-        applied = effect.apply()
-        assert applied.type == EffectType.CATEGORIZE_DOCUMENT
-        values = effect.values
-        assert values["confidence_scores"]["document_id"] == 0.9
-        assert "document_type" not in values["confidence_scores"]
-
-
 class TestAnnotationsAndSourceProtocol:
     """Tests for annotations and source_protocol fields."""
 
@@ -383,20 +259,17 @@ class TestAnnotationsAndSourceProtocol:
     def test_all_fields_together(
         self,
         valid_document_type: DocumentType,
-        valid_confidence_scores: ConfidenceScores,
         valid_annotations: list[AnnotationItem],
     ) -> None:
         """Test that all fields work together."""
         effect = CategorizeDocument(
             document_id="test-uuid",
             document_type=valid_document_type,
-            confidence_scores=valid_confidence_scores,
             annotations=valid_annotations,
             source_protocol="llm_v1",
         )
         values = effect.values
         assert values["document_id"] == "test-uuid"
         assert values["document_type"] == valid_document_type
-        assert values["confidence_scores"] == valid_confidence_scores
         assert values["annotations"] == valid_annotations
         assert values["source_protocol"] == "llm_v1"

--- a/example-plugins/assign_document_reviewer_example/assign_document_reviewer_example/protocols/assign_reviewer_protocol.py
+++ b/example-plugins/assign_document_reviewer_example/assign_document_reviewer_example/protocols/assign_reviewer_protocol.py
@@ -57,21 +57,15 @@ class AssignDocumentReviewerProtocol(BaseProtocol):
             log.warning(f"No patient available for document {document_id}")
             return None
 
-        if not patient.birth_date:
-            log.warning(f"Patient {patient.id} has no birth_date")
-            return None
-
         try:
             effect = LinkDocumentToPatient(
                 document_id=str(document_id),
-                first_name=patient.first_name,
-                last_name=patient.last_name,
-                date_of_birth=patient.birth_date,
-                confidence_scores={
-                    "first_name": 0.95,
-                    "last_name": 0.95,
-                    "date_of_birth": 0.90,
-                },
+                patient_key=str(patient.id),
+                annotations=[
+                    {"text": "AI 95%", "color": "#00AA00"},
+                    {"text": "Auto-linked", "color": "#2196F3"},
+                ],
+                source_protocol="assign_document_reviewer_example",
             )
             log.info(
                 f"Linked document {document_id} to patient {patient.first_name} {patient.last_name}"
@@ -104,14 +98,11 @@ class AssignDocumentReviewerProtocol(BaseProtocol):
                     "report_type": doc_type["report_type"],
                     "template_type": doc_type.get("template_type"),
                 },
-                confidence_scores={
-                    "document_id": 0.95,
-                    "document_type": {
-                        "key": 0.92,
-                        "name": 0.92,
-                        "report_type": 0.88,
-                    },
-                },
+                annotations=[
+                    {"text": "AI 92%", "color": "#00AA00"},
+                    {"text": "Auto-categorized", "color": "#2196F3"},
+                ],
+                source_protocol="assign_document_reviewer_example",
             )
             log.info(f"Categorized document {document_id} as {doc_type['name']}")
             return effect.apply()

--- a/example-plugins/categorize_document_plugin/categorize_document_plugin/README.md
+++ b/example-plugins/categorize_document_plugin/categorize_document_plugin/README.md
@@ -1,30 +1,31 @@
-Categorize Document Plugin
+# Categorize Document Plugin
 
-Example plugin that demonstrates how to use the CATEGORIZE_DOCUMENT effect to categorize documents in the Data Integration queue into specific document types.
+Example plugin that demonstrates how to use the `CATEGORIZE_DOCUMENT` effect to categorize documents in the Data Integration queue into specific document types.
 
-Overview
+## Overview
 
-This plugin listens for DOCUMENT_RECEIVED events and automatically categorizes documents into specific document types. This is useful for automated document processing workflows where an LLM system or other classification logic identifies the document type from the document's content.
+This plugin listens for `DOCUMENT_RECEIVED` events and automatically categorizes documents into specific document types. This is useful for automated document processing workflows where an LLM system or other classification logic identifies the document type from the document's content.
 
-Features
+## Features
 
-- Listens to DOCUMENT_RECEIVED events
-- Emits CATEGORIZE_DOCUMENT effect to categorize documents
-- Uses exact UUID keys from available_document_types
-- Includes nested confidence scores for monitoring/debugging
+- Listens to `DOCUMENT_RECEIVED` events
+- Emits `CATEGORIZE_DOCUMENT` effect to categorize documents
+- Uses exact UUID keys from `available_document_types`
+- Includes annotations for UI display
 
-How It Works
+## How It Works
 
-When a document is received, the CategorizeDocumentHandler is triggered:
+When a document is received, the `CategorizeDocumentHandler` is triggered:
 
-1. Extracts the document ID from event.context["document"]["id"]
-2. Finds matching document type from event.context["available_document_types"]
-3. Emits CATEGORIZE_DOCUMENT effect with:
-   - document_id: The UUID from document.id
-   - document_type: Dict with key, name, report_type, template_type from available_document_types
-   - confidence_scores: Optional nested confidence scores for monitoring/debugging
+1. Extracts the document ID from `event.context["document"]["id"]`
+2. Finds matching document type from `event.context["available_document_types"]`
+3. Emits `CATEGORIZE_DOCUMENT` effect with:
+   - `document_id`: The UUID from document.id
+   - `document_type`: Dict with key, name, report_type, template_type from available_document_types
+   - `annotations`: List of annotation objects with text and color for UI display
+   - `source_protocol`: Plugin identifier for tracking
 
-Example Usage
+## Example Usage
 
 When a document is received:
 
@@ -44,27 +45,26 @@ When a document is received:
 }
 ```
 
-The plugin will emit:
+The plugin will emit a `CATEGORIZE_DOCUMENT` effect with the document type and annotations.
 
-```json
-{
-  "type": "CATEGORIZE_DOCUMENT",
-  "payload": "{\"document_id\": \"47fc2fac-d736-4cc0-bd98-ee476632e4a8\", \"document_type\": {\"key\": \"f605e084dcad4beca16c0f62e6586d76\", \"name\": \"Lab Report\", \"report_type\": \"CLINICAL\", \"template_type\": \"LabReportTemplate\"}, \"confidence_scores\": {\"document_id\": 0.90, \"document_type\": {\"key\": 0.90, \"name\": 0.95, \"report_type\": 0.85, \"template_type\": 0.90}}}"
-}
-```
+## Effect Fields
 
-**Note**: The payload is at the root level, not wrapped in a "data" key.
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| document_id | str | Yes | IntegrationTask UUID |
+| document_type | dict | Yes | Document type with key, name, report_type, template_type |
+| annotations | list[dict] | No | Display annotations with text and color |
+| source_protocol | str | No | Plugin identifier for tracking |
 
-Testing
+## Testing
 
 To test this plugin:
 
 1. Ensure the plugin is registered in your Canvas instance
-2. Send a DOCUMENT_RECEIVED event with a document
+2. Send a `DOCUMENT_RECEIVED` event with a document
 3. Verify the document is categorized with the appropriate document type
 
-Notes
+## Notes
 
-- All document_type fields must come from the same entry in available_document_types
-- The confidence score is for monitoring/debugging only, not used in categorization logic
+- All `document_type` fields must come from the same entry in `available_document_types`
 - This is a simple example - you can add custom logic to determine the document type

--- a/example-plugins/categorize_document_plugin/categorize_document_plugin/protocols/categorize_document_handler.py
+++ b/example-plugins/categorize_document_plugin/categorize_document_plugin/protocols/categorize_document_handler.py
@@ -1,18 +1,11 @@
-import json
-
 from canvas_sdk.effects.categorize_document import (
     AnnotationItem,
     CategorizeDocument,
-    ConfidenceScores,
     DocumentType,
-    DocumentTypeConfidenceScores,
 )
 from canvas_sdk.events import EventType
 from canvas_sdk.handlers import BaseHandler
 from logger import log
-
-# Log prefix for easy filtering in logs
-LOG_PREFIX = "PLUGIN_DEBUG:"
 
 
 class CategorizeDocumentHandler(BaseHandler):
@@ -26,27 +19,15 @@ class CategorizeDocumentHandler(BaseHandler):
 
     def compute(self) -> list:
         """Compute effects to categorize document."""
-        log.info(f"{LOG_PREFIX} Handler compute() called")
-        log.info(f"{LOG_PREFIX} Event context keys: {list(self.event.context.keys())}")
-
         document_id = self.event.context.get("document", {}).get("id")
-        log.info(f"{LOG_PREFIX} Extracted document_id: {document_id}")
 
         if not document_id:
-            log.warning(f"{LOG_PREFIX} Document ID not found in event context")
-            log.info(
-                f"{LOG_PREFIX} Event context document: {self.event.context.get('document', {})}"
-            )
+            log.warning("Document ID not found in event context")
             return []
 
         available_document_types = self.event.context.get("available_document_types", [])
-        log.info(f"{LOG_PREFIX} Available document types count: {len(available_document_types)}")
-        if available_document_types:
-            log.info(
-                f"{LOG_PREFIX} Sample document type structure: {json.dumps(available_document_types[0] if available_document_types else {}, indent=2)}"
-            )
 
-        log.info(f"{LOG_PREFIX} Searching for 'Lab Report' document type")
+        # Prefer "Lab Report" document type, fall back to first available
         lab_report_type = next(
             (dt for dt in available_document_types if dt.get("name") == "Lab Report"),
             None,
@@ -54,16 +35,10 @@ class CategorizeDocumentHandler(BaseHandler):
 
         if not lab_report_type:
             log.warning(
-                f"{LOG_PREFIX} Lab Report document type not found in available_document_types"
-            )
-            log.info(
-                f"{LOG_PREFIX} Available document type names: {[dt.get('name') for dt in available_document_types]}"
+                f"Lab Report document type not found. "
+                f"Available types: {[dt.get('name') for dt in available_document_types]}"
             )
             return []
-
-        log.info(
-            f"{LOG_PREFIX} Found Lab Report document type: {json.dumps(lab_report_type, indent=2)}"
-        )
 
         document_type: DocumentType = {
             "key": lab_report_type["key"],
@@ -71,46 +46,18 @@ class CategorizeDocumentHandler(BaseHandler):
             "report_type": lab_report_type["report_type"],
             "template_type": lab_report_type.get("template_type"),
         }
-        log.info(f"{LOG_PREFIX} Constructed document_type: {json.dumps(document_type, indent=2)}")
-
-        document_type_confidence: DocumentTypeConfidenceScores = {
-            "key": 0.90,
-            "name": 0.95,
-            "report_type": 0.85,
-            "template_type": 0.90,
-        }
-        confidence_scores: ConfidenceScores = {
-            "document_id": 0.90,
-            "document_type": document_type_confidence,
-        }
-        log.info(f"{LOG_PREFIX} Confidence scores: {json.dumps(confidence_scores, indent=2)}")
-
-        log.info(f"{LOG_PREFIX} Categorizing document {document_id} as {document_type['name']}")
 
         annotations: list[AnnotationItem] = [
             {"text": "AI 95%", "color": "#00AA00"},
             {"text": "Auto-detected", "color": "#2196F3"},
         ]
-        log.info(f"{LOG_PREFIX} Annotations: {json.dumps(annotations, indent=2)}")
 
         effect = CategorizeDocument(
             document_id=document_id,
             document_type=document_type,
-            confidence_scores=confidence_scores,
             annotations=annotations,
-            source_protocol="categorize_document_plugin_v1",
+            source_protocol="categorize_document_plugin",
         )
-        log.info(f"{LOG_PREFIX} Effect created successfully")
 
-        log.info(f"{LOG_PREFIX} Applying effect")
-        applied_effect = effect.apply()
-        log.info(f"{LOG_PREFIX} Effect applied successfully")
-
-        payload_data = json.loads(applied_effect.payload)
-        log.info(
-            f"{LOG_PREFIX} CATEGORIZE_DOCUMENT payload (formatted): {json.dumps(payload_data, indent=2)}"
-        )
-        log.info(f"{LOG_PREFIX} Effect payload (raw): {applied_effect.payload}")
-        log.info(f"{LOG_PREFIX} Returning {len([applied_effect])} effect(s)")
-
-        return [applied_effect]
+        log.info(f"Categorized document {document_id} as {document_type['name']}")
+        return [effect.apply()]

--- a/example-plugins/data_integration_example/data_integration_example/README.md
+++ b/example-plugins/data_integration_example/data_integration_example/README.md
@@ -108,24 +108,14 @@ Categorizes a document in the Data Integration queue into a specific document ty
 from canvas_sdk.effects.categorize_document import (
     CategorizeDocument,
     DocumentType,
-    ConfidenceScores,
     AnnotationItem,
 )
 
 document_type: DocumentType = {
     "key": "lab-report-key",
     "name": "Lab Report",
-    "report_type": "LAB",
-    "template_type": "lab_template",  # Optional
-}
-
-confidence_scores: ConfidenceScores = {
-    "document_id": 0.90,
-    "document_type": {
-        "key": 0.90,
-        "name": 0.95,
-        "report_type": 0.85,
-    },
+    "report_type": "CLINICAL",
+    "template_type": "LabReportTemplate",  # Optional
 }
 
 annotations: list[AnnotationItem] = [
@@ -136,9 +126,8 @@ annotations: list[AnnotationItem] = [
 effect = CategorizeDocument(
     document_id="12345",
     document_type=document_type,
-    confidence_scores=confidence_scores,
     annotations=annotations,
-    source_protocol="data_integration_example_v1",
+    source_protocol="data_integration_example",
 )
 ```
 
@@ -147,16 +136,15 @@ effect = CategorizeDocument(
 - `document_type` (DocumentType, required): The document type to assign, containing:
   - `key` (str): Unique key for the document type
   - `name` (str): Display name
-  - `report_type` (str): Report type code (e.g., "LAB", "RADIOLOGY")
-  - `template_type` (str, optional): Template type identifier
-- `confidence_scores` (ConfidenceScores, optional): Confidence scores for monitoring
+  - `report_type` (str): Report type ("CLINICAL" or "ADMINISTRATIVE")
+  - `template_type` (str, optional): Template type identifier ("LabReportTemplate", "ImagingReportTemplate", "SpecialtyReportTemplate", or null)
 - `annotations` (list[AnnotationItem], optional): Display annotations
 - `source_protocol` (str, optional): Protocol/plugin identifier
 
 **Behavior:**
 - Validates the document exists
 - Assigns the document type to the document
-- Stores confidence scores and annotations for display
+- Stores annotations for display in the UI
 
 ### 4. PrefillDocumentFields
 
@@ -243,12 +231,12 @@ This is an **example plugin** that demonstrates the structure and usage of Data 
 2. **Categorize Documents** (for `CategorizeDocument`):
    - Analyze the document content
    - Use an LLM or classification model to determine document type
-   - Return confidence scores for monitoring/debugging
+   - Add annotations to show confidence levels in the UI
 
 3. **Extract Fields** (for `PrefillDocumentFields`):
    - Use OCR or LLM to extract structured data from documents
    - Match extracted fields to template fields using LOINC codes or labels
-   - Include confidence scores at the field level
+   - Include annotations at the field level to show extraction confidence
 
 4. **Assign Reviewers** (for `AssignDocumentReviewer`):
    - Determine appropriate reviewer based on document type, specialty, or workload

--- a/example-plugins/link_document_to_patient/link_document_to_patient/handlers/link_document.py
+++ b/example-plugins/link_document_to_patient/link_document_to_patient/handlers/link_document.py
@@ -121,7 +121,7 @@ class LinkDocumentHandler(BaseHandler):
             "patient_key": str(patient.id),
             "annotations": [
                 {"text": "AI 95%", "color": "#00AA00"},
-                {"text": "DOB matched", "color": "#2196F3"},
+                {"text": "Auto-linked", "color": "#2196F3"},
             ],
             "source_protocol": "llm_v1",
         }


### PR DESCRIPTION
remove deprecated confidence_scores field from CategorizeDocument, JunkDocument, and RemoveDocumentFromPatient effects. These effects now use the standardized annotations list for UI display instead. 
