### PR TITLE
feat: changes max_length of the StaffRole.name field

### DIFF
--- a/canvas_sdk/v1/data/staff.py
+++ b/canvas_sdk/v1/data/staff.py
@@ -223,7 +223,7 @@ class StaffRole(Model):
     internal_code = models.CharField(max_length=10)
     public_abbreviation = models.CharField(max_length=10, default="", blank=True)
     domain = models.CharField(max_length=3, choices=RoleDomain.choices, db_index=True)
-    name = models.CharField(max_length=50)
+    name = models.CharField(max_length=128)
     domain_privilege_level = models.IntegerField(default=0)
     permissions = models.JSONField(default=dict, blank=True, null=True)
     role_type = models.CharField(max_length=50, choices=RoleType.choices, blank=True)


### PR DESCRIPTION
This PR is to change the `StaffRole.name` database field to have a max_length of 128. This is in order to keep it in sync with the migration in [this PR](feature/jw-koala-4028) that adds a management command to add PDMP roles. 

https://canvasmedical.atlassian.net/browse/KOALA-4028

<!-- ## Title Guidelines

A title always has a prefix and a subject.

### Prefix
Make sure the title is prefixed with one of the following:

| Prefix | When to use |
|--------|-------------|
| `feat:`     | New feature |
| `fix:`      | Bug fix |
| `docs:`     | Documentation only changes |
| `style:`    | Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc) |
| `refactor:` | Code changes that neither fixes a bug nor adds a feature |
| `perf:`     | Code change that improves performance |
| `test:`     | Adding missing or correcting existing tests |
| `chore:`    | Changes to the build process or auxiliary tools and libraries such as documentation generation, ci, etc |

### Subject

Ensure the subject contains succinct description of the change.
* Use the imperative, present tense: "change", not "changed" nor "changes"
* Don’t capitalize first letter
* No dot (.) at the end
-->
