### PR TITLE
fix: change the PatientMetadata.value attribute type

### DIFF
--- a/canvas_sdk/tests/v1/data/test_patient.py
+++ b/canvas_sdk/tests/v1/data/test_patient.py
@@ -1,0 +1,15 @@
+import pytest
+
+from canvas_sdk.v1.data.patient import PatientMetadata
+
+
+@pytest.mark.django_db
+def test_patient_metadata_supports_large_values() -> None:
+    """Test that PatientMetadata.value can store and retrieve up to 1000 characters."""
+    large_value = "a" * 1000
+    metadata = PatientMetadata.objects.create(key="test_key", value=large_value)
+
+    metadata.refresh_from_db()
+
+    assert metadata.value == large_value
+    assert len(metadata.value) == 1000

--- a/canvas_sdk/v1/data/patient.py
+++ b/canvas_sdk/v1/data/patient.py
@@ -286,7 +286,7 @@ class PatientMetadata(IdentifiableModel):
         "v1.Patient", on_delete=models.CASCADE, related_name="metadata", null=True
     )
     key = models.CharField(max_length=32)
-    value = models.CharField(max_length=256)
+    value = models.TextField()
 
 
 class PatientFacilityAddress(PatientAddress):


### PR DESCRIPTION
https://canvasmedical.atlassian.net/browse/KOALA-4240

This reflects the removal of length limitations in the database. The full length is already available in use, this just makes the model match reality.