### PR TITLE
fix: prepend CUSTOMER_IDENTIFIER to presigned URL S3 keys

### DIFF
--- a/canvas_sdk/tests/data/test_utils.py
+++ b/canvas_sdk/tests/data/test_utils.py
@@ -102,11 +102,12 @@ def test_presigned_url_generates_valid_url(settings: SettingsWrapper) -> None:
     settings.AWS_SECRET_ACCESS_KEY = "test-secret-key"
     settings.MEDIA_S3_BUCKET_NAME = "test-bucket"
     settings.AWS_REGION = "us-west-2"
+    settings.CUSTOMER_IDENTIFIER = "test-customer"
 
     url = presigned_url("path/to/file.pdf")
 
     assert url.startswith("https://test-bucket.s3.us-west-2.amazonaws.com/")
-    assert "/path/to/file.pdf?" in url
+    assert "/test-customer/path/to/file.pdf?" in url
     assert "X-Amz-Algorithm=AWS4-HMAC-SHA256" in url
     assert "X-Amz-Credential=" in url
     assert "X-Amz-Date=" in url
@@ -121,6 +122,7 @@ def test_presigned_url_with_custom_expiry(settings: SettingsWrapper) -> None:
     settings.AWS_SECRET_ACCESS_KEY = "test-secret-key"
     settings.MEDIA_S3_BUCKET_NAME = "test-bucket"
     settings.AWS_REGION = "us-west-2"
+    settings.CUSTOMER_IDENTIFIER = "test-customer"
 
     url = presigned_url("path/to/file.pdf", expires_in=7200)
 
@@ -133,11 +135,12 @@ def test_presigned_url_removes_bucket_prefix(settings: SettingsWrapper) -> None:
     settings.AWS_SECRET_ACCESS_KEY = "test-secret-key"
     settings.MEDIA_S3_BUCKET_NAME = "test-bucket"
     settings.AWS_REGION = "us-west-2"
+    settings.CUSTOMER_IDENTIFIER = "test-customer"
 
     url = presigned_url("test-bucket/path/to/file.pdf")
 
-    # The bucket prefix should be removed, so path should be /path/to/file.pdf
-    assert "/path/to/file.pdf?" in url
+    # The bucket prefix should be removed, so path should be /test-customer/path/to/file.pdf
+    assert "/test-customer/path/to/file.pdf?" in url
     assert "/test-bucket/path/to/file.pdf?" not in url
 
 
@@ -147,6 +150,7 @@ def test_presigned_url_raises_error_without_credentials(settings: SettingsWrappe
     settings.AWS_SECRET_ACCESS_KEY = ""
     settings.MEDIA_S3_BUCKET_NAME = "test-bucket"
     settings.AWS_REGION = "us-west-2"
+    settings.CUSTOMER_IDENTIFIER = "test-customer"
 
     with pytest.raises(ValueError, match="AWS credentials not configured"):
         presigned_url("path/to/file.pdf")

--- a/canvas_sdk/v1/data/utils.py
+++ b/canvas_sdk/v1/data/utils.py
@@ -30,8 +30,13 @@ def presigned_url(s3_key: str, expires_in: int = 3600) -> str:
     if not access_key_id or not secret_access_key:
         raise ValueError("AWS credentials not configured")
 
+    customer_identifier = settings.CUSTOMER_IDENTIFIER
+
     # Clean the key - remove bucket prefix if present
     s3_key = s3_key.replace(f"{bucket}/", "")
+
+    # Prepend the customer identifier prefix
+    s3_key = f"{customer_identifier}/{s3_key}"
 
     service = "s3"
     host = f"{bucket}.s3.{region}.amazonaws.com"


### PR DESCRIPTION
[KOALA-4460](https://canvasmedical.atlassian.net/browse/KOALA-4460)

## Summary
- Model fields (`.document`, `.file`, `.image`) store relative S3 keys without the `CUSTOMER_IDENTIFIER` prefix
- The S3 storage backend (`MediaRootS3Boto3Storage`) adds the prefix at upload time via its `location` setting, but the DB only stores the relative path
- `presigned_url()` now prepends `settings.CUSTOMER_IDENTIFIER` to the key before signing, so the generated URL points to the correct object

## Test plan
- [x] Updated all `presigned_url` tests to set `CUSTOMER_IDENTIFIER` and assert the prefix appears in the signed URL
- [x] All existing tests pass

[KOALA-4460]: https://canvasmedical.atlassian.net/browse/KOALA-4460?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ