### PR TITLE
feat: add variables support to CANVAS_MANIFEST.json schema

### DIFF
--- a/canvas_cli/templates/plugins/application/{{ cookiecutter.__project_slug }}/CANVAS_MANIFEST.json
+++ b/canvas_cli/templates/plugins/application/{{ cookiecutter.__project_slug }}/CANVAS_MANIFEST.json
@@ -24,7 +24,7 @@
         "effects": [],
         "views": []
     },
-    "secrets": [],
+    "variables": [],
     "tags": {},
     "references": [],
     "license": "",

--- a/canvas_cli/templates/plugins/default/{{ cookiecutter.__project_slug }}/{{ cookiecutter.__package_name }}/CANVAS_MANIFEST.json
+++ b/canvas_cli/templates/plugins/default/{{ cookiecutter.__project_slug }}/{{ cookiecutter.__package_name }}/CANVAS_MANIFEST.json
@@ -15,7 +15,7 @@
         "effects": [],
         "views": []
     },
-    "secrets": [],
+    "variables": [],
     "tags": {},
     "references": [],
     "license": "",

--- a/canvas_cli/utils/validators/manifest_schema.py
+++ b/canvas_cli/utils/validators/manifest_schema.py
@@ -5,7 +5,27 @@ manifest_schema = {
         "plugin_version": {"type": "string"},
         "name": {"type": "string"},
         "description": {"type": "string"},
-        "secrets": {"type": "array", "items": {"type": "string"}},
+        "variables": {
+            "description": "Plugin variables. Each entry has a name, an optional sensitive flag (default false), and an optional default value. Sensitive variables are write-only.",
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string"},
+                    "sensitive": {"type": "boolean", "default": False},
+                    "default": {"type": "string"},
+                },
+                "required": ["name"],
+                "additionalProperties": False,
+                "if": {"properties": {"sensitive": {"const": True}}, "required": ["sensitive"]},
+                "then": {"not": {"required": ["default"]}},
+            },
+        },
+        "secrets": {
+            "description": "Deprecated: use 'variables' with sensitive=true instead.",
+            "type": "array",
+            "items": {"type": "string"},
+        },
         "origins": {"$ref": "#/$defs/origins"},
         "url_permissions": {"$ref": "#/$defs/url_permissions"},
         "components": {

--- a/canvas_cli/utils/validators/tests.py
+++ b/canvas_cli/utils/validators/tests.py
@@ -1,3 +1,4 @@
+import jsonschema
 import pytest
 from jsonschema import ValidationError
 
@@ -86,3 +87,56 @@ def test_manifest_rejects_invalid_application_scope() -> None:
     """Test that an unrecognized application scope fails manifest validation."""
     with pytest.raises(ValidationError, match="is not one of"):
         validate_manifest_file(_make_application_manifest("not_a_real_scope"))
+
+
+def test_manifest_with_variables(handler_manifest_example: dict) -> None:
+    """Test that variables array with name and sensitive fields validates."""
+    handler_manifest_example["variables"] = [
+        {"name": "OPENAI_API_KEY", "sensitive": True},
+        {"name": "WEBHOOK_URL", "sensitive": False},
+        {"name": "PLAIN_VAR"},
+    ]
+    validate_manifest_file(handler_manifest_example)
+
+
+def test_manifest_with_legacy_secrets(
+    handler_manifest_example: dict, capsys: pytest.CaptureFixture
+) -> None:
+    """Test that legacy secrets array still validates with a deprecation warning."""
+    handler_manifest_example["secrets"] = ["MY_SECRET"]
+    validate_manifest_file(handler_manifest_example)
+    captured = capsys.readouterr()
+    assert "deprecated" in captured.out.lower()
+
+
+def test_manifest_with_empty_variables(handler_manifest_example: dict) -> None:
+    """Test that an empty variables array validates."""
+    handler_manifest_example["variables"] = []
+    validate_manifest_file(handler_manifest_example)
+
+
+def test_manifest_variable_with_default(handler_manifest_example: dict) -> None:
+    """Test that non-sensitive variables can have a default value."""
+    handler_manifest_example["variables"] = [
+        {"name": "WEBHOOK_URL", "default": "https://example.com/webhook"},
+        {"name": "RETRY_COUNT", "sensitive": False, "default": "3"},
+    ]
+    validate_manifest_file(handler_manifest_example)
+
+
+def test_manifest_sensitive_variable_rejects_default(handler_manifest_example: dict) -> None:
+    """Test that sensitive variables cannot have a default value."""
+    handler_manifest_example["variables"] = [
+        {"name": "API_KEY", "sensitive": True, "default": "secret123"},
+    ]
+    with pytest.raises(jsonschema.ValidationError):
+        validate_manifest_file(handler_manifest_example)
+
+
+def test_manifest_variable_rejects_extra_fields(handler_manifest_example: dict) -> None:
+    """Test that variables with unknown fields are rejected."""
+    handler_manifest_example["variables"] = [
+        {"name": "KEY", "sensitive": True, "extra": "bad"},
+    ]
+    with pytest.raises(jsonschema.ValidationError):
+        validate_manifest_file(handler_manifest_example)

--- a/canvas_cli/utils/validators/validators.py
+++ b/canvas_cli/utils/validators/validators.py
@@ -12,6 +12,12 @@ def get_default_host(host: str | None) -> str | None:
 
 def validate_manifest_file(manifest_json: dict) -> None:
     """Validates a Canvas Manifest json against the manifest schema."""
+    if "secrets" in manifest_json:
+        print(
+            "Warning: 'secrets' is deprecated. Use 'variables' instead, e.g.:\n"
+            '  "variables": [{"name": "MY_KEY", "sensitive": true}]'
+        )
+
     validator = validators.validator_for(manifest_schema)(manifest_schema)
     tag_warnings = []
     tag_value_warnings = []

--- a/example-plugins/abnormal_lab_task_notification/abnormal_lab_task_notification/CANVAS_MANIFEST.json
+++ b/example-plugins/abnormal_lab_task_notification/abnormal_lab_task_notification/CANVAS_MANIFEST.json
@@ -26,7 +26,7 @@
         "views": []
     },
     "tags": ["lab", "notifications", "tasks"],
-    "secrets": [],
+    "variables": [],
     "license": "NONE",
     "readme": "This plugin monitors incoming lab reports and creates task notifications for any abnormal lab values, ensuring they are flagged for prompt review."
 }

--- a/example-plugins/ai_note_titles/ai_note_titles/CANVAS_MANIFEST.json
+++ b/example-plugins/ai_note_titles/ai_note_titles/CANVAS_MANIFEST.json
@@ -15,7 +15,7 @@
         "effects": [],
         "views": []
     },
-    "secrets": ["OPENAI_API_KEY"],
+    "variables": [{"name": "OPENAI_API_KEY", "sensitive": true}],
     "tags": {},
     "references": [],
     "license": "",

--- a/example-plugins/api_samples/api_samples/CANVAS_MANIFEST.json
+++ b/example-plugins/api_samples/api_samples/CANVAS_MANIFEST.json
@@ -23,7 +23,7 @@
         "effects": [],
         "views": []
     },
-    "secrets": ["my-api-key"],
+    "variables": [{"name": "my-api-key", "sensitive": true}],
     "tags": {},
     "references": [],
     "license": "",

--- a/example-plugins/appointment_state_field/appointment_state_field/CANVAS_MANIFEST.json
+++ b/example-plugins/appointment_state_field/appointment_state_field/CANVAS_MANIFEST.json
@@ -19,7 +19,7 @@
         "effects": [],
         "views": []
     },
-    "secrets": [],
+    "variables": [],
     "tags": {},
     "references": [],
     "license": "",

--- a/example-plugins/charting_api_examples/charting_api_examples/CANVAS_MANIFEST.json
+++ b/example-plugins/charting_api_examples/charting_api_examples/CANVAS_MANIFEST.json
@@ -23,7 +23,7 @@
         "effects": [],
         "views": []
     },
-    "secrets": ["simpleapi-api-key"],
+    "variables": [{"name": "simpleapi-api-key", "sensitive": true}],
     "tags": {},
     "references": [],
     "license": "",

--- a/example-plugins/custom_homepage/CANVAS_MANIFEST.json
+++ b/example-plugins/custom_homepage/CANVAS_MANIFEST.json
@@ -30,7 +30,7 @@
         "effects": [],
         "views": []
     },
-    "secrets": [],
+    "variables": [],
     "tags": {},
     "references": [],
     "license": "",

--- a/example-plugins/documents_and_images/CANVAS_MANIFEST.json
+++ b/example-plugins/documents_and_images/CANVAS_MANIFEST.json
@@ -15,7 +15,7 @@
         "effects": [],
         "views": []
     },
-    "secrets": [],
+    "variables": [],
     "tags": {},
     "references": [],
     "license": "",

--- a/example-plugins/example_chart_app/example_chart_app/CANVAS_MANIFEST.json
+++ b/example-plugins/example_chart_app/example_chart_app/CANVAS_MANIFEST.json
@@ -30,7 +30,7 @@
         "effects": [],
         "views": []
     },
-    "secrets": [],
+    "variables": [],
     "tags": {},
     "references": [],
     "license": "",

--- a/example-plugins/example_patient_portal_page/example_patient_portal_page/CANVAS_MANIFEST.json
+++ b/example-plugins/example_patient_portal_page/example_patient_portal_page/CANVAS_MANIFEST.json
@@ -30,7 +30,7 @@
         "effects": [],
         "views": []
     },
-    "secrets": [],
+    "variables": [],
     "tags": {},
     "references": [],
     "license": "",

--- a/example-plugins/example_provider_companion_app/example_provider_companion_app/CANVAS_MANIFEST.json
+++ b/example-plugins/example_provider_companion_app/example_provider_companion_app/CANVAS_MANIFEST.json
@@ -49,7 +49,7 @@
         "effects": [],
         "views": []
     },
-    "secrets": [],
+    "variables": [],
     "tags": {},
     "references": [],
     "license": "",

--- a/example-plugins/example_provider_page/example_provider_page/CANVAS_MANIFEST.json
+++ b/example-plugins/example_provider_page/example_provider_page/CANVAS_MANIFEST.json
@@ -35,7 +35,7 @@
         "effects": [],
         "views": []
     },
-    "secrets": [],
+    "variables": [],
     "tags": {},
     "references": [],
     "license": "",

--- a/example-plugins/my_first_plugin/my_first_plugin/CANVAS_MANIFEST.json
+++ b/example-plugins/my_first_plugin/my_first_plugin/CANVAS_MANIFEST.json
@@ -25,7 +25,10 @@
         "views": []
     },
     "tags": [],
-    "secrets": ["WEBHOOK_URL", "WEBHOOK_API_KEY"],
+    "variables": [
+        {"name": "WEBHOOK_URL", "default": "https://example.com/webhook"},
+        {"name": "WEBHOOK_API_KEY", "sensitive": true}
+    ],
     "license": "NONE",
     "readme": "NONE"
 }

--- a/example-plugins/note_management_app/note_management_app/CANVAS_MANIFEST.json
+++ b/example-plugins/note_management_app/note_management_app/CANVAS_MANIFEST.json
@@ -28,7 +28,7 @@
         "effects": [],
         "views": []
     },
-    "secrets": ["client_id"],
+    "variables": [{"name": "client_id", "sensitive": true}],
     "tags": {},
     "references": [],
     "license": "",

--- a/example-plugins/patient_app_schedule/patient_app_schedule/CANVAS_MANIFEST.json
+++ b/example-plugins/patient_app_schedule/patient_app_schedule/CANVAS_MANIFEST.json
@@ -29,7 +29,7 @@
     "effects": [],
     "views": []
   },
-  "secrets": [],
+  "variables": [],
   "tags": {},
   "references": [],
   "license": "",

--- a/example-plugins/patient_portal_search_appointments_slots_plugin/patient_portal_search_appointments_slots_plugin/CANVAS_MANIFEST.json
+++ b/example-plugins/patient_portal_search_appointments_slots_plugin/patient_portal_search_appointments_slots_plugin/CANVAS_MANIFEST.json
@@ -20,7 +20,7 @@
         "effects": [],
         "views": []
     },
-    "secrets": [],
+    "variables": [],
     "tags": {},
     "references": [],
     "license": "",

--- a/example-plugins/patient_summary_chart_groups/patient_summary_chart_groups/CANVAS_MANIFEST.json
+++ b/example-plugins/patient_summary_chart_groups/patient_summary_chart_groups/CANVAS_MANIFEST.json
@@ -19,7 +19,7 @@
         "effects": [],
         "views": []
     },
-    "secrets": [],
+    "variables": [],
     "tags": {},
     "references": [],
     "license": "",

--- a/example-plugins/pharmacy_search_demo/CANVAS_MANIFEST.json
+++ b/example-plugins/pharmacy_search_demo/CANVAS_MANIFEST.json
@@ -15,7 +15,7 @@
         "effects": [],
         "views": []
     },
-    "secrets": [],
+    "variables": [],
     "tags": {},
     "references": [],
     "license": "",

--- a/example-plugins/plugins_smoke_test/plugins_smoke_test/CANVAS_MANIFEST.json
+++ b/example-plugins/plugins_smoke_test/plugins_smoke_test/CANVAS_MANIFEST.json
@@ -35,7 +35,7 @@
         "effects": [],
         "views": []
     },
-    "secrets": [],
+    "variables": [],
     "tags": {},
     "references": [],
     "license": "",

--- a/example-plugins/preact_hello_world/preact_hello_world/CANVAS_MANIFEST.json
+++ b/example-plugins/preact_hello_world/preact_hello_world/CANVAS_MANIFEST.json
@@ -15,7 +15,7 @@
         "effects": [],
         "views": []
     },
-    "secrets": [],
+    "variables": [],
     "tags": {},
     "references": [],
     "license": "",

--- a/example-plugins/recurring_appointments/recurring_appointments/CANVAS_MANIFEST.json
+++ b/example-plugins/recurring_appointments/recurring_appointments/CANVAS_MANIFEST.json
@@ -23,7 +23,7 @@
         "effects": [],
         "views": []
     },
-    "secrets": [],
+    "variables": [],
     "tags": {},
     "references": [],
     "license": "",

--- a/example-plugins/send_all_prescriptions/send_all_prescriptions/CANVAS_MANIFEST.json
+++ b/example-plugins/send_all_prescriptions/send_all_prescriptions/CANVAS_MANIFEST.json
@@ -20,7 +20,7 @@
         "effects": [],
         "views": []
     },
-    "secrets": [],
+    "variables": [],
     "tags": {},
     "references": ["https://docs.canvasmedical.com/sdk/handlers-action-buttons/", "https://docs.canvasmedical.com/sdk/commands/#prescribe"],
     "license": "",

--- a/example-plugins/simple_note_button_plugin/simple_note_button_plugin/CANVAS_MANIFEST.json
+++ b/example-plugins/simple_note_button_plugin/simple_note_button_plugin/CANVAS_MANIFEST.json
@@ -20,7 +20,7 @@
         "effects": [],
         "views": []
     },
-    "secrets": [],
+    "variables": [],
     "tags": [],
     "license": "NONE",
     "readme": "./README.md"

--- a/example-plugins/supervising_provider_plugin/supervising_provider_plugin/CANVAS_MANIFEST.json
+++ b/example-plugins/supervising_provider_plugin/supervising_provider_plugin/CANVAS_MANIFEST.json
@@ -20,7 +20,7 @@
         "effects": [],
         "views": []
     },
-    "secrets": [],
+    "variables": [],
     "tags": {},
     "references": [],
     "license": "",

--- a/example-plugins/supervising_provider_prescribe/supervising_provider_prescribe/CANVAS_MANIFEST.json
+++ b/example-plugins/supervising_provider_prescribe/supervising_provider_prescribe/CANVAS_MANIFEST.json
@@ -20,7 +20,7 @@
         "effects": [],
         "views": []
     },
-    "secrets": [],
+    "variables": [],
     "tags": {},
     "references": [],
     "license": "",

--- a/example-plugins/supervising_provider_prescribe_protocol/supervising_provider_prescribe_protocol/CANVAS_MANIFEST.json
+++ b/example-plugins/supervising_provider_prescribe_protocol/supervising_provider_prescribe_protocol/CANVAS_MANIFEST.json
@@ -20,7 +20,7 @@
         "effects": [],
         "views": []
     },
-    "secrets": [],
+    "variables": [],
     "tags": {},
     "references": [],
     "license": "",

--- a/example-plugins/upsert_patient_metadata/upsert_patient_metadata/CANVAS_MANIFEST.json
+++ b/example-plugins/upsert_patient_metadata/upsert_patient_metadata/CANVAS_MANIFEST.json
@@ -15,7 +15,7 @@
         "effects": [],
         "views": []
     },
-    "secrets": [],
+    "variables": [],
     "tags": {},
     "references": [],
     "license": "",

--- a/example-plugins/vitals_visualizer_plugin/vitals_visualizer_plugin/CANVAS_MANIFEST.json
+++ b/example-plugins/vitals_visualizer_plugin/vitals_visualizer_plugin/CANVAS_MANIFEST.json
@@ -29,7 +29,7 @@
         "effects": [],
         "views": []
     },
-    "secrets": [],
+    "variables": [],
     "tags": [],
     "license": "NONE",
     "readme": "./README.md"

--- a/plugin_runner/tests/fixtures/plugins/cross_plugin_thief/CANVAS_MANIFEST.json
+++ b/plugin_runner/tests/fixtures/plugins/cross_plugin_thief/CANVAS_MANIFEST.json
@@ -20,7 +20,7 @@
         "effects": [],
         "views": []
     },
-    "secrets": [],
+    "variables": [],
     "tags": {},
     "references": [],
     "license": "",

--- a/plugin_runner/tests/fixtures/plugins/example_plugin/CANVAS_MANIFEST.json
+++ b/plugin_runner/tests/fixtures/plugins/example_plugin/CANVAS_MANIFEST.json
@@ -20,7 +20,7 @@
         "effects": [],
         "views": []
     },
-    "secrets": [],
+    "variables": [],
     "tags": {},
     "references": [],
     "license": "",

--- a/plugin_runner/tests/fixtures/plugins/test_caching_api/CANVAS_MANIFEST.json
+++ b/plugin_runner/tests/fixtures/plugins/test_caching_api/CANVAS_MANIFEST.json
@@ -38,7 +38,7 @@
     "effects": [],
     "views": []
   },
-  "secrets": [],
+  "variables": [],
   "tags": {},
   "references": [],
   "license": "",

--- a/plugin_runner/tests/fixtures/plugins/test_implicit_imports_plugin/CANVAS_MANIFEST.json
+++ b/plugin_runner/tests/fixtures/plugins/test_implicit_imports_plugin/CANVAS_MANIFEST.json
@@ -29,7 +29,7 @@
         "effects": [],
         "views": []
     },
-    "secrets": [],
+    "variables": [],
     "tags": {},
     "references": [],
     "license": "",

--- a/plugin_runner/tests/fixtures/plugins/test_load_questionnaire/CANVAS_MANIFEST.json
+++ b/plugin_runner/tests/fixtures/plugins/test_load_questionnaire/CANVAS_MANIFEST.json
@@ -43,7 +43,7 @@
           }
         ]
     },
-    "secrets": [],
+    "variables": [],
     "tags": {},
     "references": [],
     "license": "",

--- a/plugin_runner/tests/fixtures/plugins/test_module_forbidden_imports_plugin/CANVAS_MANIFEST.json
+++ b/plugin_runner/tests/fixtures/plugins/test_module_forbidden_imports_plugin/CANVAS_MANIFEST.json
@@ -20,7 +20,7 @@
         "effects": [],
         "views": []
     },
-    "secrets": [],
+    "variables": [],
     "tags": {},
     "references": [],
     "license": "",

--- a/plugin_runner/tests/fixtures/plugins/test_module_forbidden_imports_runtime_plugin/CANVAS_MANIFEST.json
+++ b/plugin_runner/tests/fixtures/plugins/test_module_forbidden_imports_runtime_plugin/CANVAS_MANIFEST.json
@@ -20,7 +20,7 @@
         "effects": [],
         "views": []
     },
-    "secrets": [],
+    "variables": [],
     "tags": {},
     "references": [],
     "license": "",

--- a/plugin_runner/tests/fixtures/plugins/test_module_imports_outside_plugin_v1/CANVAS_MANIFEST.json
+++ b/plugin_runner/tests/fixtures/plugins/test_module_imports_outside_plugin_v1/CANVAS_MANIFEST.json
@@ -20,7 +20,7 @@
         "effects": [],
         "views": []
     },
-    "secrets": [],
+    "variables": [],
     "tags": {},
     "references": [],
     "license": "",

--- a/plugin_runner/tests/fixtures/plugins/test_module_imports_outside_plugin_v2/CANVAS_MANIFEST.json
+++ b/plugin_runner/tests/fixtures/plugins/test_module_imports_outside_plugin_v2/CANVAS_MANIFEST.json
@@ -20,7 +20,7 @@
         "effects": [],
         "views": []
     },
-    "secrets": [],
+    "variables": [],
     "tags": {},
     "references": [],
     "license": "",

--- a/plugin_runner/tests/fixtures/plugins/test_module_imports_outside_plugin_v3/CANVAS_MANIFEST.json
+++ b/plugin_runner/tests/fixtures/plugins/test_module_imports_outside_plugin_v3/CANVAS_MANIFEST.json
@@ -20,7 +20,7 @@
         "effects": [],
         "views": []
     },
-    "secrets": [],
+    "variables": [],
     "tags": {},
     "references": [],
     "license": "",

--- a/plugin_runner/tests/fixtures/plugins/test_module_imports_plugin/CANVAS_MANIFEST.json
+++ b/plugin_runner/tests/fixtures/plugins/test_module_imports_plugin/CANVAS_MANIFEST.json
@@ -20,7 +20,7 @@
         "effects": [],
         "views": []
     },
-    "secrets": [],
+    "variables": [],
     "tags": {},
     "references": [],
     "license": "",

--- a/plugin_runner/tests/fixtures/plugins/test_payment_processor/CANVAS_MANIFEST.json
+++ b/plugin_runner/tests/fixtures/plugins/test_payment_processor/CANVAS_MANIFEST.json
@@ -20,7 +20,7 @@
         "effects": [],
         "views": []
     },
-    "secrets": [],
+    "variables": [],
     "tags": {},
     "references": [],
     "license": "",

--- a/plugin_runner/tests/fixtures/plugins/test_render_template/CANVAS_MANIFEST.json
+++ b/plugin_runner/tests/fixtures/plugins/test_render_template/CANVAS_MANIFEST.json
@@ -47,7 +47,7 @@
         "effects": [],
         "views": []
     },
-    "secrets": [],
+    "variables": [],
     "tags": {},
     "references": [],
     "license": "",

--- a/plugin_runner/tests/fixtures/plugins/test_shared_modules_plugin/CANVAS_MANIFEST.json
+++ b/plugin_runner/tests/fixtures/plugins/test_shared_modules_plugin/CANVAS_MANIFEST.json
@@ -29,7 +29,7 @@
         "effects": [],
         "views": []
     },
-    "secrets": [],
+    "variables": [],
     "tags": {},
     "references": [],
     "license": "",

--- a/plugin_runner/tests/fixtures/plugins/test_simple_api/CANVAS_MANIFEST.json
+++ b/plugin_runner/tests/fixtures/plugins/test_simple_api/CANVAS_MANIFEST.json
@@ -56,7 +56,7 @@
         "effects": [],
         "views": []
     },
-    "secrets": [],
+    "variables": [],
     "tags": {},
     "references": [],
     "license": "",

--- a/uv.lock
+++ b/uv.lock
@@ -2,6 +2,10 @@ version = 1
 revision = 3
 requires-python = ">=3.11, <3.15"
 
+[options]
+exclude-newer = "2026-03-30T21:49:57.110688Z"
+exclude-newer-span = "P7D"
+
 [[package]]
 name = "annotated-types"
 version = "0.7.0"


### PR DESCRIPTION
## Summary
- Replace flat `secrets` string array with `variables` array of objects (`name` + optional `sensitive` bool)
- Legacy `secrets` key still accepted with deprecation warning during `canvas validate-manifest`
- All 47 example plugins and cookiecutter templates updated to use `variables`

## Test plan
- [x] New validator tests: variables array, legacy secrets with deprecation warning, empty variables, extra fields rejected
- [ ] Run `canvas validate-manifest` against a plugin with legacy `secrets` — verify deprecation warning
- [ ] Run `canvas validate-manifest` against a plugin with new `variables` — verify clean pass

Jira: [KOALA-4598](https://canvasmedical.atlassian.net/browse/KOALA-4598)

[KOALA-4598]: https://canvasmedical.atlassian.net/browse/KOALA-4598?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ