### PR TITLE
Fix stale Django DB connection in execute_create_table_sql

### DIFF
--- a/plugin_runner/ddl.py
+++ b/plugin_runner/ddl.py
@@ -391,6 +391,9 @@ def execute_create_table_sql(create_sql: str) -> None:
     """
     from django.db import connection
 
+    if not IS_SQLITE:
+        connection.close()
+
     with connection.cursor() as cursor:
         if IS_SQLITE:
             for statement in create_sql.split(SQL_STATEMENT_DELIMITER):


### PR DESCRIPTION
## Summary

- During plugin installation with `custom_data` namespaces, `plugin_runner/namespace.py` opens and closes raw psycopg connections to the database. By the time `execute_create_table_sql()` in `plugin_runner/ddl.py` runs, Django's persistent connection object may be stale — the underlying TCP socket can be reaped. Django won't auto-reconnect unless `CONN_HEALTH_CHECKS = True`, and even then `ensure_connection()` only checks `self.connection is not None`, so a closed-but-not-None connection slips through.
- This causes `psycopg.OperationalError: the connection is closed` consistently when installing plugins that define `custom_data` models.
- The fix calls `connection.close()` before `connection.cursor()`, forcing Django to establish a fresh connection. This is gated behind `not IS_SQLITE` since the issue only affects long-lived PostgreSQL connections.

## Context

Discovered during UAT of the custom data feature.

## Test plan

- [ ] Install a plugin with `custom_data` namespace definitions and verify the CREATE TABLE statements execute without `OperationalError`
- [ ] Verify existing plugin installations (without custom_data) are unaffected
- [ ] Verify SQLite test path is unchanged (no `connection.close()` call)