### PR TITLE
fix: return safe __class__ proxy for external module objects in sandbox

### DIFF
--- a/plugin_runner/sandbox.py
+++ b/plugin_runner/sandbox.py
@@ -11,7 +11,7 @@ from _ast import AnnAssign
 from collections.abc import Iterable, Sequence
 from functools import cached_property
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, TypedDict, cast
+from typing import TYPE_CHECKING, Any, NoReturn, TypedDict, cast
 
 from frozendict import frozendict
 from RestrictedPython import (
@@ -69,11 +69,31 @@ SAFE_INTERNAL_DUNDER_READ_ATTRIBUTES = {
 
 
 SAFE_EXTERNAL_DUNDER_READ_ATTRIBUTES = {
+    "__class__",
     "__dict__",
     "__eq__",
     "__init__",
     "__name__",
 }
+
+
+class _SafeClass:
+    """A read-only proxy for __class__ that only exposes __name__."""
+
+    __slots__ = ("__name__",)
+
+    def __init__(self, name: str) -> None:
+        object.__setattr__(self, "__name__", name)
+
+    def __getattr__(self, name: str) -> NoReturn:
+        raise AttributeError(f'Access to "{name}" on external __class__ is restricted')
+
+    def __setattr__(self, name: str, value: Any) -> NoReturn:
+        raise AttributeError("Cannot set attributes on external __class__")
+
+    def __repr__(self) -> str:
+        return f"<SafeClass '{self.__name__}'>"
+
 
 STANDARD_LIBRARY_MODULES = {
     "__future__": {
@@ -995,6 +1015,13 @@ class Sandbox:
             raise AttributeError(
                 f'"{module}.{name}" is an invalid attribute name (not in ALLOWED_MODULES)'
             )
+
+        # Prevent sandbox escape via __class__.__mro__, __subclasses__, etc.
+        if isinstance(_ob, _SafeClass) and name != "__name__":
+            raise AttributeError(f'Access to "{name}" on external __class__ is restricted')
+
+        if name == "__class__" and not self._same_module(module):
+            return _SafeClass(_ob.__class__.__name__)
 
         return getattr(_ob, name, default)
 

--- a/plugin_runner/tests/test_sandbox.py
+++ b/plugin_runner/tests/test_sandbox.py
@@ -737,13 +737,26 @@ def test_urllib() -> None:
     "code",
     params_from_dict(
         {
-            "class_name": """
+            "class_name_via_self": """
                 class Thing:
                     def __init__(self):
                         super().__init__()
                         print(f'name: {self.__class__.__name__}')
 
                 thing = Thing()
+            """,
+            "class_name_via_instance": """
+                class Thing:
+                    pass
+
+                thing = Thing()
+                assert thing.__class__.__name__ == "Thing"
+            """,
+            "class_name_via_external_instance": """
+                from canvas_sdk.commands import StopMedicationCommand
+
+                obj = StopMedicationCommand(note_uuid="123")
+                assert obj.__class__.__name__ == "StopMedicationCommand"
             """,
             "model_dict": """
                 from canvas_sdk.commands import StopMedicationCommand
@@ -768,6 +781,51 @@ def test_sandbox_allows_read_access_to_required_methods(code: str) -> None:
     """
     sandbox = _sandbox_from_code(code)
     sandbox.execute()
+
+
+@pytest.mark.parametrize(
+    "code",
+    params_from_dict(
+        {
+            "mro": """
+                from canvas_sdk.commands import StopMedicationCommand
+
+                obj = StopMedicationCommand(note_uuid="123")
+                obj.__class__.__mro__
+            """,
+            "subclasses": """
+                from canvas_sdk.commands import StopMedicationCommand
+
+                obj = StopMedicationCommand(note_uuid="123")
+                obj.__class__.__subclasses__()
+            """,
+            "setattr": """
+                from canvas_sdk.commands import StopMedicationCommand
+
+                obj = StopMedicationCommand(note_uuid="123")
+                obj.__class__.evil = "hacked"
+            """,
+            "dict": """
+                from canvas_sdk.commands import StopMedicationCommand
+
+                obj = StopMedicationCommand(note_uuid="123")
+                obj.__class__.__dict__
+            """,
+            "reinit": """
+                from canvas_sdk.commands import StopMedicationCommand
+
+                obj = StopMedicationCommand(note_uuid="123")
+                obj.__class__.__init__("evil")
+            """,
+        }
+    ),
+)
+def test_sandbox_denies_traversal_via_external_safe_class(code: str) -> None:
+    """The safe __class__ proxy should only expose __name__, nothing else."""
+    sandbox = _sandbox_from_code(source_code=code)
+
+    with pytest.raises(AttributeError):
+        sandbox.execute()
 
 
 def test_sandbox_allows_write_access_to_id() -> None:
@@ -945,12 +1003,6 @@ def test_type_is_inaccessible() -> None:
 
                 client = Http()
                 pvt = client._session
-            """,
-            "private_attr__class__": """
-                from canvas_sdk.utils import Http
-
-                client = Http()
-                pvt = client.__class__
             """,
             "ontologies_base_url": """
                 from canvas_sdk.utils.http import ontologies_http


### PR DESCRIPTION
[KOALA-4680](https://canvasmedical.atlassian.net/browse/KOALA-4680)

## Summary
- Plugins accessing `obj.__class__.__name__` on SDK objects (e.g. `canvas_sdk` commands) were blocked because `__class__` was not in the external dunder allowlist
- Rather than exposing the real type object (which would allow MRO traversal, `__subclasses__`, etc.), returns a `_SafeClass` proxy that only exposes `__name__`
- Three layers of defense: `_safe_getattr` gatekeeper restricts proxy to `__name__` only, `__slots__` eliminates instance `__dict__`, and `__getattr__`/`__setattr__` overrides catch remaining access

## Test plan
- [x] Added `class_name_via_instance` test — `__class__.__name__` on internally defined class instances
- [x] Added `class_name_via_external_instance` test — `__class__.__name__` on SDK command instances (the hyperscribe use case)
- [x] Added `test_sandbox_denies_traversal_via_external_safe_class` — verifies proxy blocks `__mro__`, `__subclasses__()`, `__setattr__`, `__dict__`, and `__init__` re-invocation
- [x] All 1557 sandbox tests pass

[KOALA-4680]: https://canvasmedical.atlassian.net/browse/KOALA-4680?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ