### PR TITLE
fix: improvements to backward compatibility for note applications

### DIFF
--- a/canvas_sdk/handlers/application.py
+++ b/canvas_sdk/handlers/application.py
@@ -107,6 +107,10 @@ class NoteApplication(EmbeddedApplication):
         """Delegate to handle() for backward compatibility with old plugins."""
         # If a subclass overrides handle(), call it for backward compat.
         # New plugins should override on_open() directly.
+        context_patient = self.event.context.get("patient")
+        if context_patient and (patient_id := context_patient.get("id")):
+            self.event.target.id = patient_id
+
         return self.handle()
 
     @deprecation.deprecated(

--- a/canvas_sdk/tests/handlers/test_note_application.py
+++ b/canvas_sdk/tests/handlers/test_note_application.py
@@ -77,6 +77,17 @@ class AlwaysVisibleNoteApplication(NoteApplication):
         return []
 
 
+class OldPatientAwareNoteApplication(NoteApplication):
+    """An old NoteApplication that reads the patient from self.event.target inside handle()."""
+
+    NAME = "Old Patient App"
+    IDENTIFIER = "test_plugin__old_patient_app"
+
+    def handle(self) -> list[Effect]:
+        """Include self.event.target.id in the URL to verify what the old plugin sees."""
+        return [LaunchModalEffect(url=f"https://example.com/{self.event.target.id}").apply()]
+
+
 class NoIdentifierNoteApplication(NoteApplication):
     """A NoteApplication without an explicit IDENTIFIER."""
 
@@ -209,6 +220,45 @@ def test_on_context_change_returns_empty_by_default(target: str) -> None:
     event = _make_event(EventType.APPLICATION__ON_CONTEXT_CHANGE, target=target)
     app = NewNoteApplication(event)
     assert app.compute() == []
+
+
+def test_on_open_backfills_patient_target_before_handle() -> None:
+    """Verify on_open sets event.target.id from patient context before delegating to handle()."""
+    event = _make_event(
+        EventType.APPLICATION__ON_OPEN,
+        target="test_plugin__old_patient_app",
+        context={"patient": {"id": "patient-uuid-123"}},
+    )
+    app = OldPatientAwareNoteApplication(event)
+    result = app.compute()
+
+    payload = json.loads(result[0].payload)
+    assert payload["data"]["url"] == "https://example.com/patient-uuid-123"
+
+
+def test_on_open_does_not_modify_target_without_patient_context() -> None:
+    """Verify on_open leaves event.target.id unchanged when no patient is in context."""
+    event = _make_event(
+        EventType.APPLICATION__ON_OPEN,
+        target="test_plugin__old_patient_app",
+    )
+    app = OldPatientAwareNoteApplication(event)
+    app.compute()
+
+    assert app.event.target.id == "test_plugin__old_patient_app"
+
+
+def test_on_open_does_not_modify_target_when_patient_has_no_id() -> None:
+    """Verify on_open leaves event.target.id unchanged when patient context has no id key."""
+    event = _make_event(
+        EventType.APPLICATION__ON_OPEN,
+        target="test_plugin__old_patient_app",
+        context={"patient": {}},
+    )
+    app = OldPatientAwareNoteApplication(event)
+    app.compute()
+
+    assert app.event.target.id == "test_plugin__old_patient_app"
 
 
 def test_handle_emits_deprecation_warning() -> None:


### PR DESCRIPTION
https://canvasmedical.atlassian.net/browse/KOALA-4387

This pull request updates the behavior of the `on_open` method in `NoteApplication` to ensure backward compatibility with older plugins that expect the patient ID to be set on `event.target.id`. It also adds comprehensive tests to verify this behavior and edge cases.

**Backward compatibility improvements:**

* Updated `on_open` in `canvas_sdk/handlers/application.py` to set `event.target.id` from the patient ID in the event context, if present, before delegating to `handle()`. This ensures that older plugins relying on this pattern continue to function correctly.

**Testing enhancements:**

* Added `OldPatientAwareNoteApplication` test class to simulate legacy plugin behavior and verify the new compatibility logic.
* Added tests to ensure `on_open` correctly sets or leaves `event.target.id` based on the presence and structure of patient context:
  - Verifies correct patient ID assignment when present.
  - Ensures no modification when patient context is missing or lacks an ID.


<!-- ## Title Guidelines

A title always has a prefix and a subject.

### Prefix
Make sure the title is prefixed with one of the following:

| Prefix | When to use |
|--------|-------------|
| `feat:`     | New feature |
| `fix:`      | Bug fix |
| `docs:`     | Documentation only changes |
| `style:`    | Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc) |
| `refactor:` | Code changes that neither fixes a bug nor adds a feature |
| `perf:`     | Code change that improves performance |
| `test:`     | Adding missing or correcting existing tests |
| `chore:`    | Changes to the build process or auxiliary tools and libraries such as documentation generation, ci, etc |

### Subject

Ensure the subject contains succinct description of the change.
* Use the imperative, present tense: "change", not "changed" nor "changes"
* Don’t capitalize first letter
* No dot (.) at the end
-->
