### PR TITLE
fix: filter private attrs from __dict__ and vars() on external objects and allow underscore key access on plugin-owned types

### DIFF
--- a/plugin_runner/sandbox.py
+++ b/plugin_runner/sandbox.py
@@ -112,6 +112,52 @@ SAFE_EXTERNAL_DUNDER_READ_ATTRIBUTES = {
 }
 
 
+def _is_private(key: str) -> bool:
+    return isinstance(key, str) and key.startswith("_")
+
+
+class _FilteredDict:
+    """A read-only view of a dict that hides underscore-prefixed keys."""
+
+    __slots__ = ("_wrapped",)
+
+    def __init__(self, wrapped: dict[str, Any]) -> None:
+        self._wrapped = wrapped
+
+    def __getitem__(self, key: str) -> Any:
+        if _is_private(key):
+            raise KeyError(key)
+        return self._wrapped[key]
+
+    def __contains__(self, key: object) -> bool:
+        if isinstance(key, str) and _is_private(key):
+            return False
+        return key in self._wrapped
+
+    def __iter__(self) -> Any:
+        return (k for k in self._wrapped if not _is_private(k))
+
+    def __len__(self) -> int:
+        return len([k for k in self._wrapped if not _is_private(k)])
+
+    def __repr__(self) -> str:
+        return repr(dict(self.items()))
+
+    def get(self, key: str, default: Any = None) -> Any:
+        if _is_private(key):
+            return default
+        return self._wrapped.get(key, default)
+
+    def keys(self) -> Any:
+        return (k for k in self._wrapped if not _is_private(k))
+
+    def values(self) -> Any:
+        return (v for k, v in self._wrapped.items() if not _is_private(k))
+
+    def items(self) -> Any:
+        return ((k, v) for k, v in self._wrapped.items() if not _is_private(k))
+
+
 class _SafeClass:
     """A read-only proxy for __class__ that only exposes __name__."""
 
@@ -932,7 +978,7 @@ class Sandbox:
                 "staticmethod": builtins.staticmethod,
                 "sum": builtins.sum,
                 "super": builtins.super,
-                "vars": builtins.vars,
+                "vars": self._safe_vars,
                 "extract_exc_frames": _extract_exc_frames,
             },
             "__is_plugin__": True,
@@ -1081,8 +1127,13 @@ class Sandbox:
             (name and name.split(".")[0] in self.imported_names["names"])
             # deny if it's anything callable
             or callable(value)
-            # deny writes to dictionary underscore keys
-            or (isinstance(_ob, dict) and isinstance(attribute, str) and attribute.startswith("_"))
+            # deny writes to dictionary underscore keys on external non-builtin types
+            or (
+                isinstance(_ob, dict)
+                and isinstance(attribute, str)
+                and attribute.startswith("_")
+                and module_name != "builtins"
+            )
         ):
             # Deprecated: allow plugins to override _MAX_REQUEST_TIMEOUT_SECONDS on
             # Http instances. This will be removed in a future release.
@@ -1110,12 +1161,42 @@ class Sandbox:
 
         return isinstance(_ob, Http)
 
+    def _safe_vars(self, obj: Any) -> dict[str, Any] | _FilteredDict:
+        """Restricted vars() that filters private attributes on external objects."""
+        if isinstance(obj, types.ModuleType):
+            module = obj.__name__
+        elif isinstance(obj, type):
+            module = obj.__module__
+        else:
+            module = obj.__class__.__module__
+
+        raw = builtins.vars(obj)
+
+        if not self._same_module(module) and isinstance(raw, dict):
+            return _FilteredDict(raw)
+
+        return raw
+
     def _safe_getitem(self, ob: Any, index: Any) -> Any:
         """
-        Prevent access to several classes of items.
+        Prevent access to underscore-prefixed item keys on external objects.
+
+        Built-in containers (dict, list, etc.) and plugin-defined types are
+        allowed to hold underscore keys because they are data structures
+        owned by the plugin.
         """
         if isinstance(index, str) and index.startswith("_"):
-            raise AttributeError(f'"{index}" is an invalid item name because it starts with "_"')
+            if isinstance(ob, types.ModuleType):
+                module = ob.__name__
+            elif isinstance(ob, type):
+                module = ob.__module__
+            else:
+                module = ob.__class__.__module__
+
+            if module != "builtins" and not self._same_module(module):
+                raise AttributeError(
+                    f'"{index}" is an invalid item name because it starts with "_"'
+                )
 
         return ob[index]
 
@@ -1191,6 +1272,12 @@ class Sandbox:
         if name == "__traceback__":
             tb = getattr(_ob, "__traceback__", None)
             return _SafeTraceback(tb) if tb is not None else None
+
+        if name == "__dict__" and not self._same_module(module):
+            raw = getattr(_ob, name, default)
+            if isinstance(raw, dict):
+                return _FilteredDict(raw)
+            return raw
 
         return getattr(_ob, name, default)
 

--- a/plugin_runner/tests/test_sandbox.py
+++ b/plugin_runner/tests/test_sandbox.py
@@ -990,6 +990,213 @@ def test_sandbox_allows_access_to_private_attributes_same_module() -> None:
     sandbox.execute()
 
 
+@pytest.mark.parametrize(
+    "code",
+    params_from_dict(
+        {
+            "read_underscore_key_from_dict": """
+                d = {"_key": "value"}
+                result = d["_key"]
+                assert result == "value"
+            """,
+            "read_underscore_key_from_typed_dict": """
+                from typing import TypedDict
+
+                class MyConfig(TypedDict):
+                    _internal: str
+                    public: str
+
+                config: MyConfig = {"_internal": "secret", "public": "visible"}
+                result = config["_internal"]
+                assert result == "secret"
+            """,
+            "read_underscore_key_from_dict_in_method": """
+                class MyClass:
+                    def compute(self):
+                        d = {"_internal": 42}
+                        return d["_internal"]
+
+                result = MyClass().compute()
+                assert result == 42
+            """,
+        }
+    ),
+)
+def test_sandbox_allows_underscore_item_access_on_plugin_objects(code: str) -> None:
+    """Test that underscore key access is allowed on objects defined within the plugin."""
+    sandbox = _sandbox_from_code(code)
+    sandbox.execute()
+
+
+@pytest.mark.parametrize(
+    "code",
+    params_from_dict(
+        {
+            "write_underscore_key_to_dict": """
+                d = {}
+                d["_key"] = "value"
+                assert d["_key"] == "value"
+            """,
+            "update_underscore_key_in_dict": """
+                d = {"_key": "old"}
+                d["_key"] = "new"
+                assert d["_key"] == "new"
+            """,
+            "write_underscore_key_in_method": """
+                class MyClass:
+                    def build(self):
+                        d = {}
+                        d["_internal"] = 42
+                        return d["_internal"]
+
+                assert MyClass().build() == 42
+            """,
+        }
+    ),
+)
+def test_sandbox_allows_underscore_item_write_on_plugin_dicts(code: str) -> None:
+    """Test that writing underscore keys to plugin-created dicts is allowed."""
+    sandbox = _sandbox_from_code(code)
+    sandbox.execute()
+
+
+@pytest.mark.parametrize(
+    "code",
+    params_from_dict(
+        {
+            "dict_get_returns_none": """
+                from canvas_sdk.utils.http import ontologies_http
+
+                d = ontologies_http.__dict__
+                assert d.get("_session") is None
+            """,
+            "dict_iteration_excludes_private_keys": """
+                from canvas_sdk.utils.http import ontologies_http
+
+                d = ontologies_http.__dict__
+                private_keys = [k for k in d if k.startswith("_")]
+                assert len(private_keys) == 0, f"leaked keys: {private_keys}"
+            """,
+            "vars_get_returns_none": """
+                from canvas_sdk.utils.http import ontologies_http
+
+                d = vars(ontologies_http)
+                assert d.get("_session") is None
+            """,
+            "vars_iteration_excludes_private_keys": """
+                from canvas_sdk.utils.http import ontologies_http
+
+                d = vars(ontologies_http)
+                private_keys = [k for k in d if k.startswith("_")]
+                assert len(private_keys) == 0, f"leaked keys: {private_keys}"
+            """,
+            "dict_write_blocked": """
+                from canvas_sdk.utils.http import ontologies_http
+
+                d = ontologies_http.__dict__
+                try:
+                    d["_evil"] = "injected"
+                    assert False, "write should have been blocked"
+                except TypeError:
+                    pass
+            """,
+            "vars_write_blocked": """
+                from canvas_sdk.utils.http import ontologies_http
+
+                d = vars(ontologies_http)
+                try:
+                    d["_evil"] = "injected"
+                    assert False, "write should have been blocked"
+                except TypeError:
+                    pass
+            """,
+            "dict_values_excludes_private": """
+                from canvas_sdk.utils.http import ontologies_http
+
+                d = ontologies_http.__dict__
+                for v in d.values():
+                    assert not hasattr(v, 'headers'), "session object leaked via values()"
+            """,
+            "dict_items_excludes_private": """
+                from canvas_sdk.utils.http import ontologies_http
+
+                d = ontologies_http.__dict__
+                for k, v in d.items():
+                    assert not k.startswith("_"), f"private key leaked: {k}"
+            """,
+            "dict_contains_private_key_false": """
+                from canvas_sdk.utils.http import ontologies_http
+
+                d = ontologies_http.__dict__
+                assert "_session" not in d
+            """,
+            "dict_len_excludes_private": """
+                from canvas_sdk.utils.http import ontologies_http
+
+                d = ontologies_http.__dict__
+                all_keys = vars(ontologies_http)
+                assert len(d) == len(all_keys)
+                assert "_session" not in d
+            """,
+            "dict_underlying_not_accessible_via_wrapped": """
+                from canvas_sdk.utils.http import ontologies_http
+
+                d = ontologies_http.__dict__
+                try:
+                    d._wrapped
+                    assert False, "_wrapped should not be accessible"
+                except AttributeError:
+                    pass
+            """,
+            "vars_underlying_not_accessible_via_wrapped": """
+                from canvas_sdk.utils.http import ontologies_http
+
+                d = vars(ontologies_http)
+                try:
+                    d._wrapped
+                    assert False, "_wrapped should not be accessible"
+                except AttributeError:
+                    pass
+            """,
+        }
+    ),
+)
+def test_sandbox_filters_private_attrs_from_external_dict_and_vars(code: str) -> None:
+    """Test that __dict__ and vars() on external objects exclude underscore-prefixed keys."""
+    sandbox = _sandbox_from_code(code)
+    sandbox.execute()
+
+
+@pytest.mark.parametrize(
+    "code",
+    params_from_dict(
+        {
+            "plugin_dict_unfiltered": """
+                class MyClass:
+                    _private = 42
+
+                obj = MyClass()
+                d = obj.__dict__
+                assert "_private" not in d or True  # __dict__ may or may not have class attrs
+            """,
+            "plugin_vars_unfiltered": """
+                class MyClass:
+                    def __init__(self):
+                        self._private = 42
+
+                obj = MyClass()
+                d = vars(obj)
+                assert d["_private"] == 42
+            """,
+        }
+    ),
+)
+def test_sandbox_allows_unfiltered_dict_and_vars_on_plugin_objects(code: str) -> None:
+    """Test that __dict__ and vars() on plugin-defined objects include private attributes."""
+    sandbox = _sandbox_from_code(code)
+    sandbox.execute()
+
+
 def test_urllib() -> None:
     """Test that urllib.parse (and modules like it) work, but only with the allowed attributes."""
     sandbox = _sandbox_from_code("""
@@ -1357,7 +1564,7 @@ def test_sandbox_denies_access_to_private_attributes_of_external_modules(code: s
     """Test that private attribute/method access is not allowed for external modules."""
     sandbox = _sandbox_from_code(source_code=code)
 
-    with pytest.raises(AttributeError):
+    with pytest.raises((AttributeError, KeyError)):
         sandbox.execute()
 
 

--- a/plugin_runner/tests/test_sandbox.py
+++ b/plugin_runner/tests/test_sandbox.py
@@ -22,6 +22,7 @@ from plugin_runner.generate_allowed_imports import CANVAS_TOP_LEVEL_MODULES, fin
 from plugin_runner.sandbox import (
     ALLOWED_MODULES,
     Sandbox,
+    _FilteredDict,
     sandbox_from_module,
 )
 
@@ -1193,6 +1194,81 @@ def test_sandbox_filters_private_attrs_from_external_dict_and_vars(code: str) ->
 )
 def test_sandbox_allows_unfiltered_dict_and_vars_on_plugin_objects(code: str) -> None:
     """Test that __dict__ and vars() on plugin-defined objects include private attributes."""
+    sandbox = _sandbox_from_code(code)
+    sandbox.execute()
+
+
+def test_filtered_dict_hides_private_keys() -> None:
+    """_FilteredDict is a read-only view that excludes underscore-prefixed keys."""
+    view = _FilteredDict({"public": 1, "_private": 2})
+
+    assert view["public"] == 1
+    with pytest.raises(KeyError):
+        view["_private"]
+
+    assert "public" in view
+    assert "_private" not in view
+    assert 1 not in view
+
+    assert view.get("public") == 1
+    assert view.get("_private") is None
+    assert view.get("_private", "fallback") == "fallback"
+
+    assert list(view) == ["public"]
+    assert list(view.keys()) == ["public"]
+    assert list(view.values()) == [1]
+    assert list(view.items()) == [("public", 1)]
+    assert len(view) == 1
+
+    assert repr(view) == "{'public': 1}"
+
+
+@pytest.mark.parametrize(
+    "code",
+    params_from_dict(
+        {
+            "vars_on_external_module_filters_private": """
+                import json
+
+                d = vars(json)
+                assert "loads" in d
+                assert "__name__" not in d
+            """,
+            "vars_on_external_class": """
+                from canvas_sdk.utils import Http
+
+                d = vars(Http)
+                assert "_session" not in d
+            """,
+            "subscript_private_key_on_external_module": """
+                import json
+
+                try:
+                    json["_private"]
+                    assert False, "underscore item access should be blocked"
+                except (AttributeError, KeyError):
+                    pass
+            """,
+            "subscript_private_key_on_external_class": """
+                from canvas_sdk.utils import Http
+
+                try:
+                    Http["_session"]
+                    assert False, "underscore item access should be blocked"
+                except (AttributeError, KeyError):
+                    pass
+            """,
+            "dict_on_external_class_hides_private": """
+                from canvas_sdk.utils import Http
+
+                d = Http.__dict__
+                assert "_session" not in d
+            """,
+        }
+    ),
+)
+def test_sandbox_filters_private_attrs_on_external_modules_and_classes(code: str) -> None:
+    """Test that vars()/__dict__/item access on external modules and classes hide private keys."""
     sandbox = _sandbox_from_code(code)
     sandbox.execute()
 


### PR DESCRIPTION
  - Introduced `_FilteredDict`, a read-only proxy that hides underscore-prefixed keys from `__dict__` and `vars()` on external (non-plugin) objects. This closes existing data leak vectors (`.get()`, iteration, `.items()`,           
  `.values()`) that previously exposed private attributes like `_session` on SDK objects                                                                                                                                                
  - Updated `_safe_getattr` to return `_FilteredDict` when accessing `__dict__` on external objects                                                                                                                                     
  - Added `_safe_vars` to replace the unguarded `builtins.vars`, applying the same filtering for external objects while leaving plugin objects unfiltered                                                                               
  - Updated `_safe_getitem` to allow underscore key access on builtin containers (`dict`, `list`, etc.) and plugin-defined types, unblocking legitimate use cases like `TypedDict` fields and plugin-created dicts with underscore keys 
  - Updated `_safe_write` to allow underscore key writes to builtin dicts, since `__dict__`/`vars()` now return a proxy that blocks writes at the proxy level (`TypeError`) 


solves: https://canvas-medical.sentry.io/issues/7365359303/
