### PR TITLE
fix: allow __annotations__ in sandbox

### DIFF
--- a/plugin_runner/sandbox.py
+++ b/plugin_runner/sandbox.py
@@ -60,6 +60,7 @@ except FileNotFoundError:
 
 
 SAFE_INTERNAL_DUNDER_READ_ATTRIBUTES = {
+    "__annotations__",
     "__class__",
     "__dict__",
     "__eq__",
@@ -69,6 +70,7 @@ SAFE_INTERNAL_DUNDER_READ_ATTRIBUTES = {
 
 
 SAFE_EXTERNAL_DUNDER_READ_ATTRIBUTES = {
+    "__annotations__",
     "__class__",
     "__dict__",
     "__eq__",

--- a/plugin_runner/tests/test_sandbox.py
+++ b/plugin_runner/tests/test_sandbox.py
@@ -772,6 +772,19 @@ def test_urllib() -> None:
                 vars(obj).get('note_uuid')
                 vars(obj).items()
             """,
+            "annotations_on_plugin_class": """
+                class MyClass:
+                    name: str
+                    age: int
+
+                assert MyClass.__annotations__ == {"name": str, "age": int}
+            """,
+            "annotations_on_external_class": """
+                from canvas_sdk.commands import StopMedicationCommand
+
+                annots = StopMedicationCommand.__annotations__
+                assert isinstance(annots, dict)
+            """,
         }
     ),
 )


### PR DESCRIPTION
This pull request updates the sandbox to allow safe access to the `__annotations__` attribute on both internal and external classes, and adds corresponding tests to ensure this attribute can be accessed as expected.

**Sandbox attribute access:**

* Added `__annotations__` to the `SAFE_INTERNAL_DUNDER_READ_ATTRIBUTES` set, allowing safe read access to this attribute on internal classes.
* Added `__annotations__` to the `SAFE_EXTERNAL_DUNDER_READ_ATTRIBUTES` set, allowing safe read access to this attribute on external classes.

**Testing:**

* Added tests to verify that the `__annotations__` attribute can be accessed on both plugin-defined and external classes.