### PR TITLE
chore: add support for multi-branch releases

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -2,11 +2,11 @@ name: Build and Test
 
 on:
   pull_request:
-    branches: ["main"]
+    branches: ["main", "release/*"]
   workflow_call:
   workflow_dispatch:
   push:
-    branches: ["main"]
+    branches: ["main", "release/*"]
 
 jobs:
   build-and-test:

--- a/.github/workflows/publish-and-release.yml
+++ b/.github/workflows/publish-and-release.yml
@@ -30,6 +30,21 @@ jobs:
       - uses: ./.github/actions/install-python-and-uv
       - uses: ./.github/actions/install-canvas
 
+      - name: Verify patch-only bump on release branches
+        if: startsWith(github.ref_name, 'release/')
+        run: |
+          LAST_VERSION=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+          NEXT_VERSION=$(uv run semantic-release --strict version --print)
+          LAST_MAJOR=$(echo "$LAST_VERSION" | cut -d. -f1)
+          LAST_MINOR=$(echo "$LAST_VERSION" | cut -d. -f2)
+          NEXT_MAJOR=$(echo "$NEXT_VERSION" | cut -d. -f1)
+          NEXT_MINOR=$(echo "$NEXT_VERSION" | cut -d. -f2)
+          if [[ "$LAST_MAJOR" != "$NEXT_MAJOR" || "$LAST_MINOR" != "$NEXT_MINOR" ]]; then
+            echo "::error::Release branches only allow patch bumps. Got $LAST_VERSION -> $NEXT_VERSION"
+            exit 1
+          fi
+          echo "Patch bump verified: $LAST_VERSION -> $NEXT_VERSION"
+
       - name: Python Semantic Release
         id: release
         env:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,6 +86,38 @@ Here’s the format to use:
 
 ---
 
+## Hotfix Release Process
+
+To release a patch fix for a previous version without including unreleased features from `main`:
+
+1. **Create a release branch** from the version tag:
+   ```bash
+   git checkout -b release/0.122.x 0.122.0
+   git push origin release/0.122.x
+   ```
+
+2. **Cherry-pick the fix** onto the release branch:
+   ```bash
+   git cherry-pick <commit-sha>
+   git push origin release/0.122.x
+   ```
+
+3. **Trigger the release** from GitHub Actions:
+   - Go to Actions > "Semantic Release" workflow
+   - Click "Run workflow"
+   - Select branch `release/0.122.x`
+   - Optionally run with dry-run first to verify
+
+4. The workflow forces a patch bump on release branches, so it will produce `0.122.1` regardless of commit type.
+
+**Notes:**
+- Use the naming convention `release/X.Y.x` (e.g., `release/0.122.x`)
+- Multiple patches can be released from the same branch (0.122.1, 0.122.2, etc.)
+- Always merge the fix to `main` as well to ensure it's included in future releases
+- Only use a release branch when `main` has unreleased features you want to exclude. If `main` has no pending features, just release from `main` directly.
+
+---
+
 ## Code of Conduct
 
 This project adheres to a [Code of Conduct](./CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code and maintain a respectful and collaborative environment.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -193,10 +193,17 @@ uv build
 """
 commit_message = "chore: v{version}\n\nSee the changelog for changes."
 commit_version_number = true
-match = "main"
 tag_format = "{version}"
 version_source = "tag"
 version_toml = ["pyproject.toml:project.version"]
+
+[tool.semantic_release.branches.hotfix]
+match = "release/.*"
+prerelease = false
+
+[tool.semantic_release.branches.main]
+match = "main"
+prerelease = false
 
 [tool.uv]
 required-version = ">=0.8.0"


### PR DESCRIPTION
###   Summary

  - Add support for hotfix/patch releases from release/* branches without including unreleased features from main
  - Configure python-semantic-release with a hotfix branch group matching release/.*
  - Enable CI (build-and-test) to run on release/* branches
  - Document the hotfix release process in CONTRIBUTING.md

###   How it works

  When a bug fix needs to be released without including new features on main:

  1. Create a release/X.Y.x branch from the version tag (e.g., git checkout -b release/0.121.x 0.121.4)
  2. Cherry-pick the fix onto the branch
  3. Trigger the "Semantic Release" workflow selecting the release branch
  4. PSR detects only tags reachable from that branch, computes the correct patch version (e.g., 0.121.5)

###   Key decisions

  - No --patch flag: PSR's --force-level bypasses branch-aware tag filtering and reads all tags globally, which causes it to bump from the wrong version. The normal algorithm correctly filters tags by branch reachability.
  - Branch group config: Added [tool.semantic_release.branches.hotfix] with match = "release/.*" so PSR recognizes release branches as valid release groups.