### PR TITLE
fix: add socket_keepalive to Redis clients

### DIFF
--- a/plugin_runner/plugin_runner.py
+++ b/plugin_runner/plugin_runner.py
@@ -616,6 +616,7 @@ def get_client() -> tuple[redis.Redis, redis.client.PubSub]:
         retry=Retry(backoff=ExponentialBackoff(), retries=10),
         retry_on_error=[ConnectionError, TimeoutError, ConnectionResetError],
         health_check_interval=1,
+        socket_keepalive=True,
     )
     pubsub = client.pubsub()
 

--- a/pubsub/pubsub.py
+++ b/pubsub/pubsub.py
@@ -33,6 +33,7 @@ class PubSubBase:
                 retry=Retry(backoff=ExponentialBackoff(), retries=10),
                 retry_on_error=[ConnectionError, TimeoutError, ConnectionResetError],
                 health_check_interval=1,
+                socket_keepalive=True,
             )
 
         return None

--- a/uv.lock
+++ b/uv.lock
@@ -2,6 +2,10 @@ version = 1
 revision = 3
 requires-python = ">=3.11, <3.15"
 
+[options]
+exclude-newer = "2026-03-24T18:43:19.88065Z"
+exclude-newer-span = "P7D"
+
 [[package]]
 name = "annotated-types"
 version = "0.7.0"


### PR DESCRIPTION
[KOALA-4710](https://canvasmedical.atlassian.net/browse/KOALA-4710)

## Summary
- Add `socket_keepalive=True` to both Redis clients (`plugin_runner/plugin_runner.py` and `pubsub/pubsub.py`) so the OS sends TCP keepalive probes to detect dead connections before the application tries to use them
- These clients already had `health_check_interval=1` and retry with exponential backoff — this closes the remaining gap

Companion to canvas-medical/canvas#18866 which makes the same improvements in home-app.

## Test plan
- [ ] Monitor Redis `ConnectionError` rates in Elastic/Sentry after deploy

[KOALA-4710]: https://canvasmedical.atlassian.net/browse/KOALA-4710?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ