### PR TITLE
feat: allow originate and commit with a single effect

### DIFF
--- a/canvas_sdk/commands/base.py
+++ b/canvas_sdk/commands/base.py
@@ -114,7 +114,7 @@ class _BaseCommand(TrackableFieldsModel):
             if name not in base_properties
         }
 
-    def originate(self, line_number: int = -1) -> Effect:
+    def originate(self, line_number: int = -1, commit: bool = False) -> Effect:
         """Originate a new command in the note body."""
         self._validate_before_effect("originate")
         return Effect(
@@ -125,6 +125,7 @@ class _BaseCommand(TrackableFieldsModel):
                     "note": self.note_uuid,
                     "data": self.values,
                     "line_number": line_number,
+                    "commit": commit,
                 }
             ),
         )

--- a/canvas_sdk/commands/commands/prescribe.py
+++ b/canvas_sdk/commands/commands/prescribe.py
@@ -174,7 +174,7 @@ class PrescribeCommand(_ReviewableCommandMixin, _SendableCommandMixin, _BaseComm
 
         return values
 
-    def originate(self, line_number: int = -1) -> Effect:
+    def originate(self, line_number: int = -1, commit: bool = False) -> Effect:
         """Originate a new command in the note body with explicit compound medication processing."""
         self._validate_before_effect("originate")
 

--- a/canvas_sdk/tests/commands/test_base_command.py
+++ b/canvas_sdk/tests/commands/test_base_command.py
@@ -97,6 +97,23 @@ def test_originate_successfully_returns_originate_effect(
         "note": dummy_command_instance.note_uuid,
         "data": dummy_command_instance.values,
         "line_number": -1,
+        "commit": False,
+    }
+
+
+def test_originate_with_commit_true(
+    dummy_command_instance: DummyCommand,
+) -> None:
+    """Test that originate(commit=True) includes commit flag in payload."""
+    effect = dummy_command_instance.originate(commit=True)
+
+    assert effect.type == EffectType.ORIGINATE_PLAN_COMMAND
+    assert json.loads(effect.payload) == {
+        "command": dummy_command_instance.command_uuid,
+        "note": dummy_command_instance.note_uuid,
+        "data": dummy_command_instance.values,
+        "line_number": -1,
+        "commit": True,
     }
 
 

--- a/canvas_sdk/tests/commands/test_compound_medication.py
+++ b/canvas_sdk/tests/commands/test_compound_medication.py
@@ -611,6 +611,26 @@ def test_originate_prescribe_output_mutually_exclusive_fields(
 
 @pytest.mark.parametrize(
     "prescription",
+    ("valid_regular_prescription_data",),
+    indirect=True,
+    ids=["regular_medication"],
+)
+def test_originate_prescribe_ignores_commit_flag(
+    mock_db_queries: dict[str, MagicMock], prescription: dict[str, Any]
+) -> None:
+    """Test that originate(commit=True) does not include commit in prescribe payload.
+
+    Prescribe does not support COMMIT, so the flag must not be forwarded.
+    """
+    prescribe_cmd = PrescribeCommand(**prescription)
+    effect = prescribe_cmd.originate(commit=True)
+    payload = json.loads(effect.payload)
+
+    assert "commit" not in payload
+
+
+@pytest.mark.parametrize(
+    "prescription",
     ("valid_regular_prescription_data", "valid_compound_medication_prescription_data"),
     indirect=True,
     ids=["regular_medication", "compound_medication"],


### PR DESCRIPTION
Internal tracking: [KOALA-4679](https://canvasmedical.atlassian.net/browse/KOALA-4679)

This pull request updates the command origination logic to support an explicit `commit` parameter, allowing for more control when originating commands. The changes ensure that both the base command and the specialized prescribe command can now indicate whether a command should be immediately committed.

Enhancements to command origination:

* Updated the `originate` method in `canvas_sdk/commands/base.py` to accept an optional `commit` boolean parameter and include it in the effect payload. [[1]](diffhunk://#diff-0365185fb98923e73ca31dd40505267268b09dffee4d4052eabd22f3dc6fe623L117-R117) [[2]](diffhunk://#diff-0365185fb98923e73ca31dd40505267268b09dffee4d4052eabd22f3dc6fe623R128)
* Updated the `originate` method in `canvas_sdk/commands/commands/prescribe.py` to match the new signature, supporting the `commit` parameter for consistency and explicit control.


[KOALA-4679]: https://canvasmedical.atlassian.net/browse/KOALA-4679?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ