### PR TITLE
feat: allow command.upsert_metadata to be chained with command.originate

### DIFF
--- a/canvas_sdk/effects/command_metadata/base.py
+++ b/canvas_sdk/effects/command_metadata/base.py
@@ -1,7 +1,4 @@
-from typing import Any
-
 from canvas_sdk.effects.metadata import BaseMetadata
-from canvas_sdk.v1.data import Command
 
 
 class _CommandMetadata(BaseMetadata):
@@ -12,20 +9,6 @@ class _CommandMetadata(BaseMetadata):
 
     command_id: str
     schema_key: str
-
-    def _get_error_details(self, method: Any) -> list:
-        errors = super()._get_error_details(method)
-
-        if not Command.objects.filter(id=self.command_id, schema_key=self.schema_key).exists():
-            errors.append(
-                self._create_error_detail(
-                    "command_id",
-                    f"{self.schema_key} with id: {self.command_id} does not exist.",
-                    self.command_id,
-                )
-            )
-
-        return errors
 
 
 __exports__ = ()

--- a/canvas_sdk/tests/effects/command_metadata/test_command_metadata.py
+++ b/canvas_sdk/tests/effects/command_metadata/test_command_metadata.py
@@ -1,9 +1,6 @@
 import json
-from collections.abc import Generator
-from unittest.mock import MagicMock, patch
 
 import pytest
-from pydantic_core import ValidationError
 
 from canvas_generated.messages.effects_pb2 import EffectType
 from canvas_sdk.commands.base import _BaseCommand
@@ -14,25 +11,7 @@ class _TestCommand(_BaseCommand):
         key = "testCommand"
 
 
-@pytest.fixture
-def mock_command_exists() -> Generator[MagicMock]:
-    """Mock Command.objects to simulate an existing command."""
-    with patch("canvas_sdk.effects.command_metadata.base.Command.objects") as mock_command:
-        mock_command.filter.return_value.exists.return_value = True
-        yield mock_command
-
-
-@pytest.fixture
-def mock_command_not_exists() -> Generator[MagicMock]:
-    """Mock Command.objects to simulate a non-existing command."""
-    with patch("canvas_sdk.effects.command_metadata.base.Command.objects") as mock_command:
-        mock_command.filter.return_value.exists.return_value = False
-        yield mock_command
-
-
-def test_upsert_metadata_creates_effect_with_correct_type(
-    mock_command_exists: MagicMock,
-) -> None:
+def test_upsert_metadata_creates_effect_with_correct_type() -> None:
     """Test that upsert_metadata creates an Effect with the correct type."""
     cmd = _TestCommand(command_uuid="test-command-id")
     effect = cmd.upsert_metadata(key="test_key", value="test_value")
@@ -40,9 +19,7 @@ def test_upsert_metadata_creates_effect_with_correct_type(
     assert effect.type == EffectType.UPSERT_COMMAND_METADATA
 
 
-def test_upsert_metadata_creates_effect_with_correct_payload(
-    mock_command_exists: MagicMock,
-) -> None:
+def test_upsert_metadata_creates_effect_with_correct_payload() -> None:
     """Test that upsert_metadata creates an Effect with the correct payload structure."""
     cmd = _TestCommand(command_uuid="test-command-id")
     effect = cmd.upsert_metadata(key="test_key", value="test_value")
@@ -56,41 +33,6 @@ def test_upsert_metadata_creates_effect_with_correct_payload(
             "value": "test_value",
         }
     }
-
-
-def test_upsert_metadata_validates_command_exists_with_schema_key(
-    mock_command_exists: MagicMock,
-) -> None:
-    """Test that upsert_metadata validates command existence using both command_id and schema_key."""
-    cmd = _TestCommand(command_uuid="test-command-id")
-    cmd.upsert_metadata(key="test_key", value="test_value")
-
-    mock_command_exists.filter.assert_called_once_with(
-        id="test-command-id", schema_key="testCommand"
-    )
-
-
-def test_upsert_metadata_fails_when_command_does_not_exist(
-    mock_command_not_exists: MagicMock,
-) -> None:
-    """Test that upsert_metadata validates the command exists."""
-    cmd = _TestCommand(command_uuid="nonexistent-command-id")
-
-    with pytest.raises(ValidationError) as exc_info:
-        cmd.upsert_metadata(key="test_key", value="test_value")
-
-    errors = exc_info.value.errors()
-    assert len(errors) == 1
-    assert "nonexistent-command-id" in errors[0]["msg"]
-    assert "testCommand" in errors[0]["msg"]
-
-
-def test_upsert_metadata_passes_when_command_exists(mock_command_exists: MagicMock) -> None:
-    """Test that upsert_metadata succeeds when the command exists."""
-    cmd = _TestCommand(command_uuid="existing-command-id")
-
-    effect = cmd.upsert_metadata(key="test_key", value="test_value")
-    assert effect is not None
 
 
 def test_upsert_metadata_fails_without_command_uuid() -> None:


### PR DESCRIPTION
Internal tracking: [KOALA-4833](https://canvasmedical.atlassian.net/browse/KOALA-4833)

This pull request removes the validation logic that checked for the existence of a command in the database when upserting command metadata. As a result, related tests that mocked or validated this behavior have also been removed, simplifying both the implementation and the test suite.

[KOALA-4833]: https://canvasmedical.atlassian.net/browse/KOALA-4833?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ