### PR TITLE
fix: skip hidden dirs in unreferenced-handler scan

### DIFF
--- a/canvas_cli/apps/plugin/plugin.py
+++ b/canvas_cli/apps/plugin/plugin.py
@@ -4,6 +4,7 @@ import ast
 import base64
 import builtins
 import json
+import os
 import tarfile
 import tempfile
 from collections.abc import Iterable
@@ -527,67 +528,48 @@ def _find_unreferenced_handlers(plugin_path: Path, manifest_json: dict) -> built
             # Store just the class part (module.path:ClassName)
             referenced_classes.add(class_ref)
 
-    # Find all Python files in the plugin
+    # Walk the plugin tree, pruning directories we never want to descend into.
+    # Mirrors _build_package's dotfile-skip rule (.venv, .git, .tox, .eggs, ...)
+    # so the validator sees the same set of files that ship in the package.
     unreferenced = []
-    python_files = builtins.list(plugin_path.rglob("*.py"))
-
-    # Known base class names to look for in inheritance
     base_handler_names = {"BaseHandler", "BaseProtocol"}
 
-    for py_file in python_files:
-        # Skip test files, __pycache__, and __init__ files
-        # Check if file is in a test directory or is a test file itself
-        relative_parts = py_file.relative_to(plugin_path).parts
-        # Skip hidden directories/files (.venv, .git, .tox, .eggs, ...) — same
-        # rule _build_package uses when packaging the plugin.
-        if any(part.startswith(".") for part in relative_parts):
-            continue
-        if "__pycache__" in relative_parts or py_file.name == "__init__.py":
-            continue
-        if (
-            "tests" in relative_parts
-            or "test" in relative_parts
-            or py_file.stem.startswith("test_")
-        ):
-            continue
+    def _skip_dir(name: str) -> bool:
+        return name.startswith(".") or name in {"__pycache__", "tests", "test"}
 
-        # Parse the file using AST to avoid executing code
-        try:
-            tree = ast.parse(py_file.read_text())
+    for dirpath, dirnames, filenames in os.walk(plugin_path):
+        dirnames[:] = [d for d in dirnames if not _skip_dir(d)]
+        for filename in filenames:
+            if not filename.endswith(".py"):
+                continue
+            if filename == "__init__.py" or filename.startswith("test_"):
+                continue
+            py_file = Path(dirpath) / filename
 
-            # Find all class definitions
+            try:
+                tree = ast.parse(py_file.read_bytes())
+            except Exception:
+                print(f"Warning: Could not parse file '{py_file}'")
+                continue
+
             for node in ast.walk(tree):
-                if isinstance(node, ast.ClassDef):
-                    # Check if this class inherits from BaseHandler or BaseProtocol
-                    inherits_from_base = False
-                    for base in node.bases:
-                        # Handle direct inheritance: class Foo(BaseHandler)
-                        if isinstance(base, ast.Name) and base.id in base_handler_names:
-                            inherits_from_base = True
-                            break
-                        # Handle module-qualified inheritance: class Foo(handlers.BaseHandler)
-                        elif isinstance(base, ast.Attribute):
-                            if base.attr in base_handler_names:
-                                inherits_from_base = True
-                                break
+                if not isinstance(node, ast.ClassDef):
+                    continue
 
-                    if inherits_from_base:
-                        # Build the class reference string
-                        # Get relative path from plugin root
-                        relative_path = py_file.relative_to(plugin_path)
-                        module_path = str(relative_path.with_suffix("")).replace("/", ".")
-                        # Include package name prefix to match manifest format
-                        package_name = plugin_path.name
-                        class_ref = f"{package_name}.{module_path}:{node.name}"
+                inherits_from_base = any(
+                    (isinstance(base, ast.Name) and base.id in base_handler_names)
+                    or (isinstance(base, ast.Attribute) and base.attr in base_handler_names)
+                    for base in node.bases
+                )
+                if not inherits_from_base:
+                    continue
 
-                        # Check if it's referenced in the manifest
-                        if not any(class_ref in ref for ref in referenced_classes):
-                            unreferenced.append(class_ref)
+                relative_path = py_file.relative_to(plugin_path)
+                module_path = str(relative_path.with_suffix("")).replace("/", ".")
+                class_ref = f"{plugin_path.name}.{module_path}:{node.name}"
 
-        except Exception:
-            # Skip files that can't be parsed
-            print(f"Warning: Could not parse file '{py_file}'")
-            pass
+                if not any(class_ref in ref for ref in referenced_classes):
+                    unreferenced.append(class_ref)
 
     return unreferenced
 

--- a/canvas_cli/apps/plugin/plugin.py
+++ b/canvas_cli/apps/plugin/plugin.py
@@ -537,10 +537,18 @@ def _find_unreferenced_handlers(plugin_path: Path, manifest_json: dict) -> built
     for py_file in python_files:
         # Skip test files, __pycache__, and __init__ files
         # Check if file is in a test directory or is a test file itself
-        parts = py_file.parts
-        if "__pycache__" in str(py_file) or py_file.name == "__init__.py":
+        relative_parts = py_file.relative_to(plugin_path).parts
+        # Skip hidden directories/files (.venv, .git, .tox, .eggs, ...) — same
+        # rule _build_package uses when packaging the plugin.
+        if any(part.startswith(".") for part in relative_parts):
             continue
-        if "tests" in parts or "test" in parts or py_file.stem.startswith("test_"):
+        if "__pycache__" in relative_parts or py_file.name == "__init__.py":
+            continue
+        if (
+            "tests" in relative_parts
+            or "test" in relative_parts
+            or py_file.stem.startswith("test_")
+        ):
             continue
 
         # Parse the file using AST to avoid executing code

--- a/canvas_cli/apps/plugin/plugin.py
+++ b/canvas_cli/apps/plugin/plugin.py
@@ -4,6 +4,7 @@ import ast
 import base64
 import builtins
 import json
+import os
 import sys
 import tarfile
 import tempfile
@@ -558,67 +559,48 @@ def _find_unreferenced_handlers(plugin_path: Path, manifest_json: dict) -> built
             # Store just the class part (module.path:ClassName)
             referenced_classes.add(class_ref)
 
-    # Find all Python files in the plugin
+    # Walk the plugin tree, pruning directories we never want to descend into.
+    # Mirrors _build_package's dotfile-skip rule (.venv, .git, .tox, .eggs, ...)
+    # so the validator sees the same set of files that ship in the package.
     unreferenced = []
-    python_files = builtins.list(plugin_path.rglob("*.py"))
-
-    # Known base class names to look for in inheritance
     base_handler_names = {"BaseHandler", "BaseProtocol"}
 
-    for py_file in python_files:
-        # Skip test files, __pycache__, and __init__ files
-        # Check if file is in a test directory or is a test file itself
-        relative_parts = py_file.relative_to(plugin_path).parts
-        # Skip hidden directories/files (.venv, .git, .tox, .eggs, ...) — same
-        # rule _build_package uses when packaging the plugin.
-        if any(part.startswith(".") for part in relative_parts):
-            continue
-        if "__pycache__" in relative_parts or py_file.name == "__init__.py":
-            continue
-        if (
-            "tests" in relative_parts
-            or "test" in relative_parts
-            or py_file.stem.startswith("test_")
-        ):
-            continue
+    def _skip_dir(name: str) -> bool:
+        return name.startswith(".") or name in {"__pycache__", "tests", "test"}
 
-        # Parse the file using AST to avoid executing code
-        try:
-            tree = ast.parse(py_file.read_text())
+    for dirpath, dirnames, filenames in os.walk(plugin_path):
+        dirnames[:] = [d for d in dirnames if not _skip_dir(d)]
+        for filename in filenames:
+            if not filename.endswith(".py"):
+                continue
+            if filename == "__init__.py" or filename.startswith("test_"):
+                continue
+            py_file = Path(dirpath) / filename
 
-            # Find all class definitions
+            try:
+                tree = ast.parse(py_file.read_bytes())
+            except Exception:
+                print(f"Warning: Could not parse file '{py_file}'")
+                continue
+
             for node in ast.walk(tree):
-                if isinstance(node, ast.ClassDef):
-                    # Check if this class inherits from BaseHandler or BaseProtocol
-                    inherits_from_base = False
-                    for base in node.bases:
-                        # Handle direct inheritance: class Foo(BaseHandler)
-                        if isinstance(base, ast.Name) and base.id in base_handler_names:
-                            inherits_from_base = True
-                            break
-                        # Handle module-qualified inheritance: class Foo(handlers.BaseHandler)
-                        elif isinstance(base, ast.Attribute):
-                            if base.attr in base_handler_names:
-                                inherits_from_base = True
-                                break
+                if not isinstance(node, ast.ClassDef):
+                    continue
 
-                    if inherits_from_base:
-                        # Build the class reference string
-                        # Get relative path from plugin root
-                        relative_path = py_file.relative_to(plugin_path)
-                        module_path = str(relative_path.with_suffix("")).replace("/", ".")
-                        # Include package name prefix to match manifest format
-                        package_name = plugin_path.name
-                        class_ref = f"{package_name}.{module_path}:{node.name}"
+                inherits_from_base = any(
+                    (isinstance(base, ast.Name) and base.id in base_handler_names)
+                    or (isinstance(base, ast.Attribute) and base.attr in base_handler_names)
+                    for base in node.bases
+                )
+                if not inherits_from_base:
+                    continue
 
-                        # Check if it's referenced in the manifest
-                        if not any(class_ref in ref for ref in referenced_classes):
-                            unreferenced.append(class_ref)
+                relative_path = py_file.relative_to(plugin_path)
+                module_path = str(relative_path.with_suffix("")).replace("/", ".")
+                class_ref = f"{plugin_path.name}.{module_path}:{node.name}"
 
-        except Exception:
-            # Skip files that can't be parsed
-            print(f"Warning: Could not parse file '{py_file}'")
-            pass
+                if not any(class_ref in ref for ref in referenced_classes):
+                    unreferenced.append(class_ref)
 
     return unreferenced
 

--- a/canvas_cli/apps/plugin/plugin.py
+++ b/canvas_cli/apps/plugin/plugin.py
@@ -568,10 +568,18 @@ def _find_unreferenced_handlers(plugin_path: Path, manifest_json: dict) -> built
     for py_file in python_files:
         # Skip test files, __pycache__, and __init__ files
         # Check if file is in a test directory or is a test file itself
-        parts = py_file.parts
-        if "__pycache__" in str(py_file) or py_file.name == "__init__.py":
+        relative_parts = py_file.relative_to(plugin_path).parts
+        # Skip hidden directories/files (.venv, .git, .tox, .eggs, ...) — same
+        # rule _build_package uses when packaging the plugin.
+        if any(part.startswith(".") for part in relative_parts):
             continue
-        if "tests" in parts or "test" in parts or py_file.stem.startswith("test_"):
+        if "__pycache__" in relative_parts or py_file.name == "__init__.py":
+            continue
+        if (
+            "tests" in relative_parts
+            or "test" in relative_parts
+            or py_file.stem.startswith("test_")
+        ):
             continue
 
         # Parse the file using AST to avoid executing code

--- a/canvas_cli/apps/plugin/tests.py
+++ b/canvas_cli/apps/plugin/tests.py
@@ -867,6 +867,26 @@ class VendoredHandler(BaseHandler):
     assert unreferenced == []
 
 
+def test_find_unreferenced_handlers_skips_unparseable_files(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A file that can't be parsed by ast.parse must be skipped with a warning."""
+    plugin_dir = tmp_path / "test_plugin"
+    plugin_dir.mkdir()
+
+    manifest: dict[str, Any] = {"components": {"handlers": []}}
+
+    handlers_dir = plugin_dir / "handlers"
+    handlers_dir.mkdir()
+    broken = handlers_dir / "broken.py"
+    broken.write_text("class Foo(BaseHandler:\n    pass\n")
+
+    unreferenced = _find_unreferenced_handlers(plugin_dir, manifest)
+
+    assert unreferenced == []
+    assert f"Warning: Could not parse file '{broken}'" in capsys.readouterr().out
+
+
 def test_find_unreferenced_handlers_skips_imported_classes(tmp_path: Path) -> None:
     """Test that _find_unreferenced_handlers skips imported classes."""
     plugin_dir = tmp_path / "test_plugin"

--- a/canvas_cli/apps/plugin/tests.py
+++ b/canvas_cli/apps/plugin/tests.py
@@ -834,6 +834,39 @@ class HandlerInTestDir(BaseHandler):
     assert len(unreferenced) == 0
 
 
+def test_find_unreferenced_handlers_skips_hidden_dirs(tmp_path: Path) -> None:
+    """Handlers under hidden dirs (.venv, .tox, .git, ...) must not be reported.
+
+    Mirrors the dotfile-skip rule that _build_package already applies when
+    packaging a plugin: anything under a dot-prefixed directory is treated as
+    out-of-band (virtualenvs, VCS metadata, tool caches).
+    """
+    plugin_dir = tmp_path / "test_plugin"
+    plugin_dir.mkdir()
+
+    manifest: dict[str, Any] = {"components": {"handlers": []}}
+
+    handler_source = """
+from canvas_sdk.handlers import BaseHandler
+from canvas_sdk.effects import Effect
+
+class VendoredHandler(BaseHandler):
+    RESPONDS_TO = "test"
+
+    def compute(self) -> list[Effect]:
+        return []
+"""
+
+    for hidden in (".venv", ".tox", ".eggs"):
+        nested = plugin_dir / hidden / "lib" / "python3.14" / "site-packages" / "pkg"
+        nested.mkdir(parents=True)
+        (nested / "handler.py").write_text(handler_source)
+
+    unreferenced = _find_unreferenced_handlers(plugin_dir, manifest)
+
+    assert unreferenced == []
+
+
 def test_find_unreferenced_handlers_skips_imported_classes(tmp_path: Path) -> None:
     """Test that _find_unreferenced_handlers skips imported classes."""
     plugin_dir = tmp_path / "test_plugin"

--- a/canvas_cli/apps/plugin/tests.py
+++ b/canvas_cli/apps/plugin/tests.py
@@ -1231,6 +1231,39 @@ class HandlerInTestDir(BaseHandler):
     assert len(unreferenced) == 0
 
 
+def test_find_unreferenced_handlers_skips_hidden_dirs(tmp_path: Path) -> None:
+    """Handlers under hidden dirs (.venv, .tox, .git, ...) must not be reported.
+
+    Mirrors the dotfile-skip rule that _build_package already applies when
+    packaging a plugin: anything under a dot-prefixed directory is treated as
+    out-of-band (virtualenvs, VCS metadata, tool caches).
+    """
+    plugin_dir = tmp_path / "test_plugin"
+    plugin_dir.mkdir()
+
+    manifest: dict[str, Any] = {"components": {"handlers": []}}
+
+    handler_source = """
+from canvas_sdk.handlers import BaseHandler
+from canvas_sdk.effects import Effect
+
+class VendoredHandler(BaseHandler):
+    RESPONDS_TO = "test"
+
+    def compute(self) -> list[Effect]:
+        return []
+"""
+
+    for hidden in (".venv", ".tox", ".eggs"):
+        nested = plugin_dir / hidden / "lib" / "python3.14" / "site-packages" / "pkg"
+        nested.mkdir(parents=True)
+        (nested / "handler.py").write_text(handler_source)
+
+    unreferenced = _find_unreferenced_handlers(plugin_dir, manifest)
+
+    assert unreferenced == []
+
+
 def test_find_unreferenced_handlers_skips_imported_classes(tmp_path: Path) -> None:
     """Test that _find_unreferenced_handlers skips imported classes."""
     plugin_dir = tmp_path / "test_plugin"

--- a/canvas_cli/apps/plugin/tests.py
+++ b/canvas_cli/apps/plugin/tests.py
@@ -1264,6 +1264,43 @@ class VendoredHandler(BaseHandler):
     assert unreferenced == []
 
 
+def test_find_unreferenced_handlers_prunes_hidden_dirs_without_blinding_scan(
+    tmp_path: Path,
+) -> None:
+    """Hidden dirs are pruned *without* blinding the scan to real handlers.
+
+    Three handlers in one plugin: one vendored under ``.venv`` (must be
+    ignored), one referenced in the manifest (must not be reported), and one
+    genuine orphan (must be reported). Asserting the exact result distinguishes
+    "pruned the hidden dirs" from "scanned nothing at all" -- an ``== []``
+    assertion alone also passes when the scan never reaches the real files.
+    """
+    plugin_dir = tmp_path / "test_plugin"
+    handlers_dir = plugin_dir / "handlers"
+    handlers_dir.mkdir(parents=True)
+    (handlers_dir / "__init__.py").touch()
+
+    manifest: dict[str, Any] = {
+        "components": {"handlers": [{"class": "test_plugin.handlers.referenced:ReferencedHandler"}]}
+    }
+
+    def handler_source(name: str) -> str:
+        return (
+            "\nfrom canvas_sdk.handlers import BaseHandler\n\n\n"
+            f'class {name}(BaseHandler):\n    RESPONDS_TO = "test"\n'
+        )
+
+    vendored = plugin_dir / ".venv" / "lib" / "python3.14" / "site-packages" / "pkg"
+    vendored.mkdir(parents=True)
+    (vendored / "handler.py").write_text(handler_source("VendoredHandler"))
+    (handlers_dir / "referenced.py").write_text(handler_source("ReferencedHandler"))
+    (handlers_dir / "orphan.py").write_text(handler_source("OrphanHandler"))
+
+    unreferenced = _find_unreferenced_handlers(plugin_dir, manifest)
+
+    assert unreferenced == ["test_plugin.handlers.orphan:OrphanHandler"]
+
+
 def test_find_unreferenced_handlers_skips_unparseable_files(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:

--- a/canvas_cli/apps/plugin/tests.py
+++ b/canvas_cli/apps/plugin/tests.py
@@ -1264,6 +1264,26 @@ class VendoredHandler(BaseHandler):
     assert unreferenced == []
 
 
+def test_find_unreferenced_handlers_skips_unparseable_files(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A file that can't be parsed by ast.parse must be skipped with a warning."""
+    plugin_dir = tmp_path / "test_plugin"
+    plugin_dir.mkdir()
+
+    manifest: dict[str, Any] = {"components": {"handlers": []}}
+
+    handlers_dir = plugin_dir / "handlers"
+    handlers_dir.mkdir()
+    broken = handlers_dir / "broken.py"
+    broken.write_text("class Foo(BaseHandler:\n    pass\n")
+
+    unreferenced = _find_unreferenced_handlers(plugin_dir, manifest)
+
+    assert unreferenced == []
+    assert f"Warning: Could not parse file '{broken}'" in capsys.readouterr().out
+
+
 def test_find_unreferenced_handlers_skips_imported_classes(tmp_path: Path) -> None:
     """Test that _find_unreferenced_handlers skips imported classes."""
     plugin_dir = tmp_path / "test_plugin"


### PR DESCRIPTION
[KOALA-5326](https://canvasmedical.atlassian.net/browse/KOALA-5326)

## Summary

`canvas plugin validate`'s AST scan was walking into `.venv/` (and any other dot-prefixed directory inside the plugin path), so it would flag library-owned handler classes as "unreferenced" — Django's `ASGIHandler`/`WSGIHandler`, canvas_sdk's own base handlers, cookiecutter templates from `canvas_cli/templates`, and so on.

Fix: mirror the dotfile-skip rule `_build_package` already uses when packaging the plugin, so `_find_unreferenced_handlers` sees the same set of files that actually ship. No new excluded-dirs list to maintain.

Example output before the fix:

```
Warning: Found handler classes that are not referenced in the CANVAS_MANIFEST.json:
  - ..venv.lib.python3.14.site-packages.django.core.handlers.asgi:ASGIHandler
  - ..venv.lib.python3.14.site-packages.canvas_sdk.handlers.cron_task:CronTask
  ...
```

## Test plan

- [x] `uv run pytest canvas_cli/apps/plugin/tests.py -k find_unreferenced` (8 passed, including the new `_skips_hidden_dirs` case)

[KOALA-5326]: https://canvasmedical.atlassian.net/browse/KOALA-5326?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ