### PR TITLE
fix: skip Sentry init when running in CI

### DIFF
--- a/plugin_runner/plugin_runner.py
+++ b/plugin_runner/plugin_runner.py
@@ -74,7 +74,7 @@ from settings import (
     SENTRY_DSN,
 )
 
-if SENTRY_DSN and os.getenv("CI") != "true":
+if SENTRY_DSN and os.getenv("CI", "").lower() != "true":
     # Lazy import for faster reload time in dev
     from sentry_sdk.integrations.executing import ExecutingIntegration
     from sentry_sdk.integrations.pure_eval import PureEvalIntegration

--- a/plugin_runner/plugin_runner.py
+++ b/plugin_runner/plugin_runner.py
@@ -74,7 +74,7 @@ from settings import (
     SENTRY_DSN,
 )
 
-if SENTRY_DSN:
+if SENTRY_DSN and os.getenv("CI") != "true":
     # Lazy import for faster reload time in dev
     from sentry_sdk.integrations.executing import ExecutingIntegration
     from sentry_sdk.integrations.pure_eval import PureEvalIntegration


### PR DESCRIPTION
## Summary

- Skip `sentry_sdk.init` in `plugin_runner.py` when GitHub Actions' standard `CI=true` env var is set.
- Stops the plugin runner from flooding Sentry when Redis is unreachable in CI workflows.
- Comparison is case-insensitive so workflows that override `CI: 'True'` (capital T) still match.

## Context

Sentry [HOME-APP-11Y5](https://canvas-medical.sentry.io/issues/HOME-APP-11Y5/) — `ConnectionError: Error -3 connecting to redis:6379. Temporary failure in name resolution.` — has accumulated **100,718 occurrences** since 2025-11-17 with **0 users impacted**. Every event is tagged `customer: ci` and `environment: development`, identifying it as pure CI noise.

Root cause: `synchronize_plugins_and_report_errors` (`plugin_runner.py:518-526`) catches every exception, captures it to Sentry, sleeps 0.5s, and retries forever — about 7,200 events per hour the runner is alive without Redis. Eight home-app workflows set `CUSTOMER_IDENTIFIER='ci'` and start the plugin runner; some don't define a Redis service, others have config bugs (`typescript-types-gen.yml` points at `localhost:6379`, `test-canvas-plugins.yml`'s redis service has no health check).

## Why suppress Sentry rather than skip the synchronizer thread

The synchronizer thread is required for the canvas integration tests (`test-canvas-plugins.yml`) to pass — those tests rely on plugin reload signals over Redis pubsub. Skipping the thread would break them. Suppressing Sentry init is the smallest change that stops the noise without altering behavior.

Real production deployments do not set `CI`, so behavior there is unchanged.

## Trade-off

This drops *all* Sentry events from CI plugin runner processes, not just the Redis pubsub failures. If a future test surfaces a real bug via the plugin runner, it won't show up in Sentry — it will still surface in the test run output and CI logs. Worth knowing; not blocking.

## Test plan

- [ ] Existing tests pass on the `build-and-test` workflow.
- [ ] Existing tests pass on `test-canvas-plugins.yml` (the synchronizer thread is unaffected, so reload behavior is unchanged).
- [ ] In a CI workflow that sets `SENTRY_DSN` and starts the plugin runner, confirm no new HOME-APP-11Y5 events appear after merge.
- [ ] Confirm production plugin runners (no `CI` env) continue to report to Sentry normally.

## Follow-ups (not in this PR)

- The retry shape (`while True: try: ... except: capture+sleep(0.5)`) is still a footgun for transient Redis blips in production. Worth a separate change to add backoff and rate-limit the Sentry capture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)