### PR TITLE
feat: add --disable flag to sdk install command

### DIFF
--- a/canvas_cli/apps/plugin/plugin.py
+++ b/canvas_cli/apps/plugin/plugin.py
@@ -248,6 +248,9 @@ def install(
     secrets: builtins.list[str] = typer.Option(
         [], "--secret", callback=parse_secrets, help="Secrets to set, e.g. Key=value"
     ),
+    is_enabled: bool = typer.Option(
+        True, "--enable/--disable", help="Install the plugin in an enabled or disabled state"
+    ),
     host: str | None = typer.Option(
         callback=get_default_host,
         help="Canvas instance to connect to",
@@ -281,7 +284,7 @@ def install(
     print(f"Posting {built_package_path.absolute()} to {url}")
 
     try:
-        data = [("is_enabled", True)] + encoded_secrets
+        data = [("is_enabled", is_enabled)] + encoded_secrets
         with open(built_package_path, "rb") as package:
             r = requests.post(
                 url,
@@ -302,7 +305,7 @@ def install(
         package_name := _get_name_from_metadata(host, token, built_package_path)
     ):
         print(f"Plugin {package_name} already exists, updating instead...")
-        update(package_name, built_package_path, is_enabled=True, secrets=secrets, host=host)
+        update(package_name, built_package_path, is_enabled=is_enabled, secrets=secrets, host=host)
     else:
         print(f"Status code {r.status_code}: {r.text}")
         raise typer.Exit(1)

--- a/canvas_cli/apps/plugin/tests.py
+++ b/canvas_cli/apps/plugin/tests.py
@@ -452,6 +452,165 @@ def test_install_disabled(
     )
 
 
+@patch("canvas_cli.apps.plugin.plugin.update")
+@patch("canvas_cli.apps.plugin.plugin._get_name_from_metadata")
+@patch("builtins.print")
+@patch("builtins.open", new_callable=mock_open, read_data=b"fake package data")
+@patch("requests.post")
+@patch("canvas_cli.apps.plugin.plugin.plugin_url")
+@patch("canvas_cli.apps.plugin.plugin._build_package")
+@patch("canvas_cli.apps.plugin.plugin.validate_manifest")
+@patch("canvas_cli.apps.plugin.plugin.get_or_request_api_token")
+@patch("pathlib.Path.is_dir")
+@patch("pathlib.Path.exists")
+def test_install_conflict_calls_update(
+    mock_exists: Mock,
+    mock_is_dir: Mock,
+    mock_get_token: Mock,
+    mock_validate: Mock,
+    mock_build: Mock,
+    mock_plugin_url: Mock,
+    mock_post: Mock,
+    mock_open_file: Mock,
+    mock_print: Mock,
+    mock_get_name: Mock,
+    mock_update: Mock,
+) -> None:
+    """When the install endpoint returns 409, fall back to calling `update` with the package name."""
+    mock_exists.return_value = True
+    mock_is_dir.return_value = True
+    mock_get_token.return_value = "test-token"
+    mock_validate.return_value = None
+
+    built_path = Path("/tmp/built-plugin.zip")
+    mock_build.return_value = built_path
+    mock_plugin_url.return_value = "https://example.canvasmedical.com/api/plugins"
+
+    mock_response = Mock()
+    mock_response.status_code = requests.codes.conflict
+    mock_post.return_value = mock_response
+
+    mock_get_name.return_value = "existing-plugin"
+
+    host = "https://example.canvasmedical.com"
+    secrets = ["API_KEY=secret123"]
+
+    install(plugin_name=Path("/fake/plugin"), secrets=secrets, is_enabled=True, host=host)
+
+    mock_get_name.assert_called_once_with(host, "test-token", built_path)
+    mock_update.assert_called_once_with(
+        "existing-plugin",
+        built_path,
+        is_enabled=True,
+        secrets=secrets,
+        host=host,
+    )
+    mock_print.assert_any_call("Plugin existing-plugin already exists, updating instead...")
+
+
+@patch("canvas_cli.apps.plugin.plugin.update")
+@patch("canvas_cli.apps.plugin.plugin._get_name_from_metadata")
+@patch("builtins.print")
+@patch("builtins.open", new_callable=mock_open, read_data=b"fake package data")
+@patch("requests.post")
+@patch("canvas_cli.apps.plugin.plugin.plugin_url")
+@patch("canvas_cli.apps.plugin.plugin._build_package")
+@patch("canvas_cli.apps.plugin.plugin.validate_manifest")
+@patch("canvas_cli.apps.plugin.plugin.get_or_request_api_token")
+@patch("pathlib.Path.is_dir")
+@patch("pathlib.Path.exists")
+def test_install_error_status_exits(
+    mock_exists: Mock,
+    mock_is_dir: Mock,
+    mock_get_token: Mock,
+    mock_validate: Mock,
+    mock_build: Mock,
+    mock_plugin_url: Mock,
+    mock_post: Mock,
+    mock_open_file: Mock,
+    mock_print: Mock,
+    mock_get_name: Mock,
+    mock_update: Mock,
+) -> None:
+    """When the install endpoint returns an unexpected error status, print details and exit."""
+    mock_exists.return_value = True
+    mock_is_dir.return_value = True
+    mock_get_token.return_value = "test-token"
+    mock_validate.return_value = None
+
+    mock_build.return_value = Path("/tmp/built-plugin.zip")
+    mock_plugin_url.return_value = "https://example.canvasmedical.com/api/plugins"
+
+    mock_response = Mock()
+    mock_response.status_code = requests.codes.bad_request
+    mock_response.text = "bad request body"
+    mock_post.return_value = mock_response
+
+    with pytest.raises(typer.Exit):
+        install(
+            plugin_name=Path("/fake/plugin"),
+            secrets=[],
+            is_enabled=True,
+            host="https://example.canvasmedical.com",
+        )
+
+    mock_get_name.assert_not_called()
+    mock_update.assert_not_called()
+    mock_print.assert_any_call(f"Status code {requests.codes.bad_request}: bad request body")
+
+
+@patch("canvas_cli.apps.plugin.plugin.update")
+@patch("canvas_cli.apps.plugin.plugin._get_name_from_metadata")
+@patch("builtins.print")
+@patch("builtins.open", new_callable=mock_open, read_data=b"fake package data")
+@patch("requests.post")
+@patch("canvas_cli.apps.plugin.plugin.plugin_url")
+@patch("canvas_cli.apps.plugin.plugin._build_package")
+@patch("canvas_cli.apps.plugin.plugin.validate_manifest")
+@patch("canvas_cli.apps.plugin.plugin.get_or_request_api_token")
+@patch("pathlib.Path.is_dir")
+@patch("pathlib.Path.exists")
+def test_install_conflict_without_package_name_exits(
+    mock_exists: Mock,
+    mock_is_dir: Mock,
+    mock_get_token: Mock,
+    mock_validate: Mock,
+    mock_build: Mock,
+    mock_plugin_url: Mock,
+    mock_post: Mock,
+    mock_open_file: Mock,
+    mock_print: Mock,
+    mock_get_name: Mock,
+    mock_update: Mock,
+) -> None:
+    """When the install endpoint returns 409 but the package name can't be extracted, exit."""
+    mock_exists.return_value = True
+    mock_is_dir.return_value = True
+    mock_get_token.return_value = "test-token"
+    mock_validate.return_value = None
+
+    mock_build.return_value = Path("/tmp/built-plugin.zip")
+    mock_plugin_url.return_value = "https://example.canvasmedical.com/api/plugins"
+
+    mock_response = Mock()
+    mock_response.status_code = requests.codes.conflict
+    mock_response.text = "conflict"
+    mock_post.return_value = mock_response
+
+    mock_get_name.return_value = None
+
+    with pytest.raises(typer.Exit):
+        install(
+            plugin_name=Path("/fake/plugin"),
+            secrets=[],
+            is_enabled=True,
+            host="https://example.canvasmedical.com",
+        )
+
+    mock_update.assert_not_called()
+    mock_print.assert_any_call(f"Status code {requests.codes.conflict}: conflict")
+
+
 @patch("builtins.print")
 @patch("builtins.open", new_callable=mock_open, read_data=b"fake package data")
 @patch("requests.patch")

--- a/canvas_cli/apps/plugin/tests.py
+++ b/canvas_cli/apps/plugin/tests.py
@@ -333,7 +333,7 @@ def test_install_success_no_secrets(
     plugin_path = Path("/fake/plugin")
     host = "https://example.canvasmesdical.com"
 
-    install(plugin_name=plugin_path, secrets=[], host=host)
+    install(plugin_name=plugin_path, secrets=[], is_enabled=True, host=host)
 
     mock_validate.assert_called_once_with(plugin_path)
     mock_build.assert_called_once_with(plugin_path)
@@ -390,7 +390,7 @@ def test_install_success_with_secrets(
     host = "https://example.canvasmedical.com"
     secrets = ["API_KEY=secret123", "DB_PASSWORD=mypassword"]
 
-    install(plugin_name=plugin_path, secrets=secrets, host=host)
+    install(plugin_name=plugin_path, secrets=secrets, is_enabled=True, host=host)
 
     expected_encoded_secrets = [
         ("secret", base64.b64encode(b"API_KEY=secret123").decode()),
@@ -401,6 +401,52 @@ def test_install_success_with_secrets(
     mock_post.assert_called_once_with(
         "https://example.canvasmedical.com/api/plugins",
         data=expected_data,
+        files={"package": mock_open_file.return_value.__enter__.return_value},
+        headers={"Authorization": "Bearer test-token"},
+    )
+
+
+@patch("builtins.open", new_callable=mock_open, read_data=b"fake package data")
+@patch("requests.post")
+@patch("canvas_cli.apps.plugin.plugin.plugin_url")
+@patch("canvas_cli.apps.plugin.plugin._build_package")
+@patch("canvas_cli.apps.plugin.plugin.validate_manifest")
+@patch("canvas_cli.apps.plugin.plugin.get_or_request_api_token")
+@patch("pathlib.Path.is_dir")
+@patch("pathlib.Path.exists")
+def test_install_disabled(
+    mock_exists: Mock,
+    mock_is_dir: Mock,
+    mock_get_token: Mock,
+    mock_validate: Mock,
+    mock_build: Mock,
+    mock_plugin_url: Mock,
+    mock_post: Mock,
+    mock_open_file: Mock,
+) -> None:
+    """Test installing a plugin in the disabled state."""
+    mock_exists.return_value = True
+    mock_is_dir.return_value = True
+    mock_get_token.return_value = "test-token"
+    mock_validate.return_value = None
+
+    mock_build.return_value = Path("/tmp/built-plugin.zip")
+    mock_plugin_url.return_value = "https://example.canvasmedical.com/api/plugins"
+
+    mock_response = Mock()
+    mock_response.status_code = requests.codes.created
+    mock_post.return_value = mock_response
+
+    install(
+        plugin_name=Path("/fake/plugin"),
+        secrets=[],
+        is_enabled=False,
+        host="https://example.canvasmedical.com",
+    )
+
+    mock_post.assert_called_once_with(
+        "https://example.canvasmedical.com/api/plugins",
+        data=[("is_enabled", False)],
         files={"package": mock_open_file.return_value.__enter__.return_value},
         headers={"Authorization": "Bearer test-token"},
     )


### PR DESCRIPTION
<!-- ## Title Guidelines

A title always has a prefix and a subject.

### Prefix
Make sure the title is prefixed with one of the following:

| Prefix | When to use |
|--------|-------------|
| `feat:`     | New feature |
| `fix:`      | Bug fix |
| `docs:`     | Documentation only changes |
| `style:`    | Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc) |
| `refactor:` | Code changes that neither fixes a bug nor adds a feature |
| `perf:`     | Code change that improves performance |
| `test:`     | Adding missing or correcting existing tests |
| `chore:`    | Changes to the build process or auxiliary tools and libraries such as documentation generation, ci, etc |

### Subject

Ensure the subject contains succinct description of the change.
* Use the imperative, present tense: "change", not "changed" nor "changes"
* Don’t capitalize first letter
* No dot (.) at the end
-->
https://canvasmedical.atlassian.net/browse/KOALA-5350

This pr adds a new flat `--disable` to the canvas install command that allows a plugin to be installed in a disabled state. 

example usage: 
`canvas install candid --disable`

default behavior is with enabled, so `canvas install candid` will install in enabled state. 
can also explicitly say --enabled like so `canvas install candid --enable`