### PR TITLE
fix: include sensitive in PluginSecret raw INSERT (KOALA-5442)

### DIFF
--- a/plugin_runner/namespace.py
+++ b/plugin_runner/namespace.py
@@ -428,11 +428,11 @@ def store_namespace_keys_as_plugin_secrets(plugin_name: str, keys: dict[str, str
         for key_name, key_value in keys.items():
             cursor.execute(
                 """
-                INSERT INTO plugin_io_pluginsecret (plugin_id, key, value)
-                VALUES (%s, %s, %s)
+                INSERT INTO plugin_io_pluginsecret (plugin_id, key, value, sensitive)
+                VALUES (%s, %s, %s, %s)
                 ON CONFLICT (plugin_id, key) DO UPDATE SET value = %s
                 """,
-                (plugin_id, key_name, key_value, key_value),
+                (plugin_id, key_name, key_value, False, key_value),
             )
 
         conn.commit()

--- a/plugin_runner/tests/test_namespace_schema.py
+++ b/plugin_runner/tests/test_namespace_schema.py
@@ -557,9 +557,10 @@ class TestStoreNamespaceKeysAsPluginSecrets:
         assert inserted_params["namespace_read_access_key"] == "read-uuid"
         assert inserted_params["namespace_read_write_access_key"] == "write-uuid"
 
-        # All inserts use the same plugin_id
+        # All inserts use the same plugin_id and sensitive=False
         for call in insert_calls:
             assert call[0][1][0] == 42
+            assert call[0][1][3] is False
 
     @patch("builtins.open", new_callable=mock_open, read_data="{}")
     @patch("plugin_runner.namespace.Path")


### PR DESCRIPTION
## Summary

Plugin installs crashed for any plugin that creates a new namespace because `store_namespace_keys_as_plugin_secrets` issued a raw INSERT into `plugin_io_pluginsecret` that didn't set the `sensitive` column. The column is `NOT NULL` with no database-level default (the Django model's `default=False` only applies through the ORM), so the INSERT failed with a NOT NULL constraint violation. See [KOALA-5442](https://canvasmedical.atlassian.net/browse/KOALA-5442).

The fix sets `sensitive=False` on the raw INSERT so the auto-generated `namespace_read_access_key` / `namespace_read_write_access_key` remain visible in the Plugin admin's Secrets inline. That admin inline is the only surface that exposes the plaintext key — developers need it to configure a sibling plugin that joins the same namespace, and `sensitive=True` would render those rows as the literal string `"SENSITIVE"` and make the namespace-sharing feature unusable.

A complementary `db_default=False` fix on the home-app model + migration is the architecturally correct long-term fix; punting on that here to avoid the migration risk and unblock installs immediately.

## Test plan

- [x] `uv run pytest plugin_runner/tests/test_namespace_schema.py` (45 passed)
- [x] Updated `test_inserts_keys_as_plugin_secrets` to assert `sensitive=False` is part of the bound params
- [ ] Verify a plugin that declares a new `namespace` in its manifest installs cleanly on a customer instance

[KOALA-5442]: https://canvasmedical.atlassian.net/browse/KOALA-5442?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ