### PR TITLE
feat: filter plugin logs by plugin and handler

### DIFF
--- a/canvas_cli/apps/logs/logs.py
+++ b/canvas_cli/apps/logs/logs.py
@@ -147,6 +147,8 @@ def search_logs(
     host: str,
     source: str | None,
     levels: list[str],
+    plugins: list[str] | None = None,
+    handlers: list[str] | None = None,
     start_time: str | None,
     end_time: str | None,
     size: int,
@@ -164,6 +166,10 @@ def search_logs(
         params["source"] = source
     if levels:
         params["level"] = levels
+    if plugins:
+        params["plugin"] = plugins
+    if handlers:
+        params["handler"] = handlers
     if start_time:
         params["start_time"] = start_time
     if end_time:
@@ -194,6 +200,8 @@ def iter_history(
     host: str,
     source: str | None,
     levels: list[str],
+    plugins: list[str] | None = None,
+    handlers: list[str] | None = None,
     start_time: str | None,
     end_time: str | None,
     page_size: int,
@@ -226,6 +234,8 @@ def iter_history(
             token=token,
             source=source,
             levels=levels,
+            plugins=plugins,
+            handlers=handlers,
             start_time=start_time,
             end_time=end_time,
             size=min(page_size, int(remaining) if remaining != float("inf") else page_size),
@@ -305,6 +315,11 @@ def logs(
     ),
     level: list[str] = typer.Option([], help="Repeatable. --level ERROR --level WARN"),
     source: str | None = typer.Option(None, help="Filter by source/service."),
+    plugin: list[str] = typer.Option([], help="Repeatable. --plugin foo --plugin bar."),
+    handler: list[str] = typer.Option(
+        [],
+        help="Repeatable. Qualified handler name (e.g. my_plugin.handlers.Foo).",
+    ),
     page_size: int = typer.Option(DEFAULT_PAGE_SIZE, help="Fetch size per page (historical)."),
     limit: int | None = typer.Option(None, help="Max historical logs to print."),
     all_: bool = typer.Option(False, "--all", help="Fetch all pages until exhausted (historical)."),
@@ -327,7 +342,7 @@ def logs(
         raise typer.BadParameter("--since cannot be combined with --start/--end.")
     if all_ and (limit is not None):
         raise typer.BadParameter("--all cannot be combined with --limit.")
-    if cursor_opt and any([since, start, end, level, source]):
+    if cursor_opt and any([since, start, end, level, source, plugin, handler]):
         raise typer.BadParameter(
             "--cursor cannot be combined with filters. "
             "Use --cursor alone to resume, or start a new query without --cursor."
@@ -364,6 +379,8 @@ def logs(
         args = {
             "source": cursor.get("source", source),
             "levels": cursor.get("levels", [lv.upper() for lv in level]),
+            "plugins": cursor.get("plugins", plugin),
+            "handlers": cursor.get("handlers", handler),
             "start_time": cursor.get("start", start_time),
             "end_time": cursor.get("end", end_time),
             "cursor": cursor.get("cursor"),

--- a/canvas_cli/apps/logs/tests.py
+++ b/canvas_cli/apps/logs/tests.py
@@ -577,6 +577,95 @@ def test_logs_with_source_filter(
 
 
 @patch("canvas_cli.apps.logs.logs.iter_history")
+def test_logs_with_plugin_filters(
+    mock_iter_history: Mock,
+    cli_runner: CliRunner,
+) -> None:
+    """Repeating ``--plugin`` collects multiple values and forwards them."""
+    mock_iter_history.return_value = iter([])
+
+    result = cli_runner.invoke(app, "logs --plugin foo --plugin bar --no-follow --host localhost")
+    assert result.exit_code == 0
+
+    call_args = mock_iter_history.call_args
+    assert call_args.kwargs["plugins"] == ["foo", "bar"]
+    # Handlers default to the typer-provided empty list when unspecified.
+    assert call_args.kwargs["handlers"] == []
+
+
+@patch("canvas_cli.apps.logs.logs.iter_history")
+def test_logs_with_handler_filters(
+    mock_iter_history: Mock,
+    cli_runner: CliRunner,
+) -> None:
+    """Repeating ``--handler`` collects multiple values and forwards them."""
+    mock_iter_history.return_value = iter([])
+
+    result = cli_runner.invoke(
+        app,
+        "logs --handler my_plugin.handlers.foo:MyHandler "
+        "--handler my_plugin.handlers.bar:OtherHandler --no-follow --host localhost",
+    )
+    assert result.exit_code == 0
+
+    call_args = mock_iter_history.call_args
+    assert call_args.kwargs["handlers"] == [
+        "my_plugin.handlers.foo:MyHandler",
+        "my_plugin.handlers.bar:OtherHandler",
+    ]
+    assert call_args.kwargs["plugins"] == []
+
+
+@patch("canvas_cli.apps.logs.logs.requests.get")
+def test_search_logs_includes_plugin_and_handler_params(
+    mock_get: Mock, sample_search_response: dict[str, Any], mock_token: str
+) -> None:
+    """``search_logs`` forwards plugins/handlers as repeated query params.
+
+    ``requests`` serializes a list value as repeated keys (``?plugin=a&plugin=b``)
+    which is exactly what ``request.GET.getlist("plugin")`` reads on the server.
+    """
+    mock_response = Mock()
+    mock_response.json.return_value = sample_search_response
+    mock_response.raise_for_status.return_value = None
+    mock_get.return_value = mock_response
+
+    search_logs(
+        token=mock_token,
+        host="",
+        source=None,
+        levels=[],
+        plugins=["foo", "bar"],
+        handlers=["my_plugin.handlers.X:Handler"],
+        start_time=None,
+        end_time=None,
+        size=10,
+        search_after=None,
+    )
+
+    params = mock_get.call_args.kwargs["params"]
+    assert params["plugin"] == ["foo", "bar"]
+    assert params["handler"] == ["my_plugin.handlers.X:Handler"]
+
+
+@pytest.mark.parametrize(
+    "cmd",
+    (
+        "logs --cursor some-cursor --plugin foo --host localhost",
+        "logs --cursor some-cursor --handler my_plugin.handlers.X:H --host localhost",
+    ),
+)
+def test_logs_cursor_conflicts_with_plugin_and_handler(
+    cmd: str,
+    cli_runner: CliRunner,
+) -> None:
+    """``--cursor`` rejects the new filters too — same shape as --level/--source."""
+    result = cli_runner.invoke(app, cmd)
+    assert result.exit_code != 0
+    assert "--cursor cannot be combined with filters" in result.output
+
+
+@patch("canvas_cli.apps.logs.logs.iter_history")
 def test_logs_with_pagination_parameters(
     mock_iter_history: Mock,
     cli_runner: CliRunner,

--- a/logger/logger.py
+++ b/logger/logger.py
@@ -1,5 +1,8 @@
 import logging
 import os
+from collections.abc import Generator
+from contextlib import contextmanager
+from contextvars import ContextVar
 from typing import Any
 
 from django.conf import settings
@@ -8,6 +11,50 @@ from logstash_async.handler import AsynchronousLogstashHandler
 from logger.logstash import LogstashFormatterECS
 from logger.pubsub import PubSubLogHandler
 
+_current_handler_name: ContextVar[str | None] = ContextVar("_current_handler_name", default=None)
+_current_plugin_name: ContextVar[str | None] = ContextVar("_current_plugin_name", default=None)
+
+
+@contextmanager
+def plugin_context(handler_name: str | None) -> Generator[None, None, None]:
+    """Bind the active plugin's handler name (and derived plugin name)."""
+    if not handler_name:
+        yield
+        return
+    plugin_name = handler_name.split(".", 1)[0] or None
+    handler_token = _current_handler_name.set(handler_name)
+    plugin_token = _current_plugin_name.set(plugin_name)
+    try:
+        yield
+    finally:
+        _current_plugin_name.reset(plugin_token)
+        _current_handler_name.reset(handler_token)
+
+
+class PluginNameFilter(logging.Filter):
+    """Surface active plugin/handler names onto each ``LogRecord``.
+
+    Writes:
+
+    - ``record.plugin_name`` — used by the logstash formatters to emit
+      ``labels.plugin``.
+    - ``record.handler_name`` — used by the logstash formatters to emit
+      ``labels.handler``.
+    - ``record.plugin_name_prefix`` — the literal ``"[<plugin_name>] "``
+      referenced by the streaming/pub-sub format template; empty string
+      when no plugin is active so the template stays interpolation-safe
+      either way.
+    """
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        """Populate plugin/handler name fields from the current context vars."""
+        plugin_name = _current_plugin_name.get()
+        handler_name = _current_handler_name.get()
+        record.plugin_name = plugin_name
+        record.handler_name = handler_name
+        record.plugin_name_prefix = f"[{plugin_name}] " if plugin_name else ""
+        return True
+
 
 class PluginLogger:
     """A custom logger for plugins."""
@@ -15,6 +62,7 @@ class PluginLogger:
     def __init__(self) -> None:
         self.logger = logging.getLogger("plugin_runner_logger")
         self.logger.setLevel(logging.INFO)
+        self.logger.addFilter(PluginNameFilter())
 
         log_prefix = f"{os.getenv('HOSTNAME', '?')}: {os.getenv('APTIBLE_PROCESS_INDEX', '?')}"
 
@@ -22,7 +70,7 @@ class PluginLogger:
             log_prefix = f"[{log_prefix}] "
 
         formatter = logging.Formatter(
-            f"plugin-runner {log_prefix}%(levelname)s %(asctime)s %(message)s"
+            f"plugin-runner {log_prefix}%(plugin_name_prefix)s%(levelname)s %(asctime)s %(message)s"
         )
 
         streaming_handler = logging.StreamHandler()

--- a/logger/logstash.py
+++ b/logger/logstash.py
@@ -256,6 +256,15 @@ class LogstashFormatterECS(logging.Formatter):
 
         now = datetime.datetime.now(datetime.UTC)
 
+        plugin_name = fields.get("plugin_name")
+        handler_name = fields.get("handler_name")
+
+        plugin_labels: dict[str, str] = {}
+        if plugin_name:
+            plugin_labels["plugin"] = plugin_name
+        if handler_name:
+            plugin_labels["handler"] = handler_name
+
         log_record = {
             **self.defaults,
             "@timestamp": now.isoformat(timespec="milliseconds").replace("+00:00", "Z"),
@@ -263,6 +272,11 @@ class LogstashFormatterECS(logging.Formatter):
             "log": {
                 "level": fields.get("levelname", ""),
             },
+            **(
+                {"labels": {**self.defaults.get("labels", {}), **plugin_labels}}
+                if plugin_labels
+                else {}
+            ),
             **(
                 {
                     "error": {

--- a/logger/tests/test_logger.py
+++ b/logger/tests/test_logger.py
@@ -1,0 +1,134 @@
+"""Tests for plugin name / handler name propagation in plugin-runner logging.
+
+Covers the contextvar-based binding (``plugin_context``), the per-record
+filter that surfaces the names onto ``LogRecord`` instances, and the ECS
+formatter's ``labels.plugin`` / ``labels.handler`` emission.
+"""
+
+import json
+import logging
+
+from logger.logger import (
+    PluginNameFilter,
+    _current_handler_name,
+    _current_plugin_name,
+    plugin_context,
+)
+from logger.logstash import LogstashFormatterECS
+
+
+def test_plugin_context_binds_handler_and_derived_plugin_name() -> None:
+    """``plugin_context(handler_name)`` binds the handler verbatim and the
+    plugin folder derived from its leading dotted segment.
+    """
+    with plugin_context("my_plugin.handlers.foo.MyHandler"):
+        assert _current_handler_name.get() == "my_plugin.handlers.foo.MyHandler"
+        assert _current_plugin_name.get() == "my_plugin"
+
+    # Both vars are released on exit so unrelated callers see a clean slate.
+    assert _current_handler_name.get() is None
+    assert _current_plugin_name.get() is None
+
+
+def test_plugin_context_is_noop_for_falsy_input() -> None:
+    """Passing ``None`` (or empty string) doesn't bind anything — callers can
+    feed through optional values without guarding.
+    """
+    with plugin_context(None):
+        assert _current_handler_name.get() is None
+        assert _current_plugin_name.get() is None
+
+    with plugin_context(""):
+        assert _current_handler_name.get() is None
+        assert _current_plugin_name.get() is None
+
+
+def test_plugin_context_nested_inner_overrides_outer() -> None:
+    """Nested blocks swap both vars on entry and restore on exit."""
+    with plugin_context("plugin_a.Handler"):
+        assert _current_plugin_name.get() == "plugin_a"
+
+        with plugin_context("plugin_b.Other"):
+            assert _current_plugin_name.get() == "plugin_b"
+            assert _current_handler_name.get() == "plugin_b.Other"
+
+        # Outer values restored after the inner block exits.
+        assert _current_plugin_name.get() == "plugin_a"
+        assert _current_handler_name.get() == "plugin_a.Handler"
+
+
+def _make_record() -> logging.LogRecord:
+    """Build a minimal LogRecord for filter/formatter tests."""
+    return logging.LogRecord(
+        name="test",
+        level=logging.INFO,
+        pathname="",
+        lineno=0,
+        msg="hello",
+        args=(),
+        exc_info=None,
+    )
+
+
+def test_plugin_name_filter_populates_attributes_inside_plugin_context() -> None:
+    """While ``plugin_context`` is active the filter writes plugin/handler
+    names plus the streaming-format prefix string onto the record.
+    """
+    record = _make_record()
+    name_filter = PluginNameFilter()
+
+    with plugin_context("my_plugin.handlers.MyHandler"):
+        assert name_filter.filter(record) is True
+
+    assert record.plugin_name == "my_plugin"  # type: ignore[attr-defined]
+    assert record.handler_name == "my_plugin.handlers.MyHandler"  # type: ignore[attr-defined]
+    assert record.plugin_name_prefix == "[my_plugin] "  # type: ignore[attr-defined]
+
+
+def test_plugin_name_filter_outside_plugin_context() -> None:
+    """Without an active plugin the filter sets ``plugin_name``/``handler_name``
+    to None and emits an empty prefix so the format template stays
+    interpolation-safe.
+    """
+    record = _make_record()
+    name_filter = PluginNameFilter()
+
+    assert name_filter.filter(record) is True
+    assert record.plugin_name is None  # type: ignore[attr-defined]
+    assert record.handler_name is None  # type: ignore[attr-defined]
+    assert record.plugin_name_prefix == ""  # type: ignore[attr-defined]
+
+
+def test_logstash_formatter_emits_labels_plugin_and_handler() -> None:
+    """ECS output carries ``labels.plugin`` and ``labels.handler`` (alongside
+    the static ``labels.customer`` default) when both are bound.
+    """
+    formatter = LogstashFormatterECS()
+    record = _make_record()
+    PluginNameFilter().filter(record)  # baseline (no plugin context)
+
+    with plugin_context("my_plugin.handlers.MyHandler"):
+        # Re-run the filter with plugin_context active; in production the
+        # logger-level filter does this automatically before the formatter.
+        record = _make_record()
+        PluginNameFilter().filter(record)
+        output = json.loads(formatter.format(record))
+
+    assert output["labels"]["plugin"] == "my_plugin"
+    assert output["labels"]["handler"] == "my_plugin.handlers.MyHandler"
+    # The static customer label survives the merge.
+    assert "customer" in output["labels"]
+
+
+def test_logstash_formatter_omits_plugin_labels_when_no_plugin_context() -> None:
+    """Without an active plugin the ECS output keeps only the static labels
+    (no spurious ``plugin``/``handler`` keys).
+    """
+    formatter = LogstashFormatterECS()
+    record = _make_record()
+    PluginNameFilter().filter(record)
+
+    output = json.loads(formatter.format(record))
+
+    assert "plugin" not in output.get("labels", {})
+    assert "handler" not in output.get("labels", {})

--- a/plugin_runner/plugin_runner.py
+++ b/plugin_runner/plugin_runner.py
@@ -48,6 +48,7 @@ from canvas_sdk.utils.metrics import measured
 from canvas_sdk.v1.data.base import IS_SQLITE
 from canvas_sdk.v1.plugin_database_context import plugin_database_context
 from logger import log
+from logger.logger import plugin_context
 from plugin_runner.authentication import token_for_plugin
 from plugin_runner.ddl import generate_plugin_migrations
 from plugin_runner.exceptions import (
@@ -275,93 +276,97 @@ class PluginRunner(PluginRunnerServicer):
             effect_list = []
 
             for plugin_name in relevant_plugins:
-                log.debug(f"Processing {plugin_name}")
-                sentry_sdk.set_tag("plugin-name", plugin_name)
-
                 plugin = LOADED_PLUGINS[plugin_name]
                 handler_class = plugin["class"]
-                base_plugin_name = plugin_name.split(":")[0]
-                namespace_config = plugin.get("namespace_config")
+                base_plugin_name, handler_path, handler_classname = plugin_name.split(":")
 
-                secrets = plugin.get("secrets", {})
+                sentry_sdk.set_tag("plugin-name", plugin_name)
 
-                secrets.update(
-                    {"graphql_jwt": token_for_plugin(plugin_name=plugin_name, audience="home")}
-                )
+                with plugin_context(f"{handler_path}.{handler_classname}"):
+                    log.debug(f"Processing {plugin_name}")
 
-                try:
-                    handler = handler_class(event, secrets, ENVIRONMENT)
+                    namespace_config = plugin.get("namespace_config")
 
-                    if not handler.accept_event():
+                    secrets = plugin.get("secrets", {})
+
+                    secrets.update(
+                        {"graphql_jwt": token_for_plugin(plugin_name=plugin_name, audience="home")}
+                    )
+
+                    try:
+                        handler = handler_class(event, secrets, ENVIRONMENT)
+
+                        if not handler.accept_event():
+                            continue
+                        relevant_plugin_handlers.append(handler_class)
+
+                        classname = (
+                            handler.__class__.__name__
+                            if isinstance(handler, ClinicalQualityMeasure)
+                            else None
+                        )
+
+                        handler_name = metrics.get_qualified_name(handler.compute)
+
+                        # Determine namespace and access level for database context
+                        db_namespace = namespace_config["namespace"] if namespace_config else None
+                        db_access_level = (
+                            namespace_config["access_level"] if namespace_config else "read"
+                        )
+
+                        with (
+                            metrics.measure(
+                                name=handler_name,
+                                track_queries=True,
+                                track_memory_usage=True,
+                                extra_tags={
+                                    "plugin": base_plugin_name,
+                                    "event": event_name,
+                                },
+                            ),
+                            plugin_database_context(
+                                base_plugin_name,
+                                namespace=db_namespace,
+                                access_level=db_access_level,
+                            ),
+                        ):
+                            _effects = handler.compute()
+                            if _effects is None:
+                                # Plugin authors sometimes forget to return their
+                                # effects list. Treat as empty with a warning so
+                                # the author can fix it, instead of raising
+                                # ``TypeError: 'NoneType' object is not iterable``
+                                # (KOALA-5365 / HOME-APP-RT8).
+                                log.warning(
+                                    f"{handler_name} returned None from compute(); "
+                                    "expected an iterable of effects. Treating as "
+                                    "an empty list."
+                                )
+                                _effects = []
+                            effects = [
+                                Effect(
+                                    type=effect.type,
+                                    payload=effect.payload,
+                                    plugin_name=base_plugin_name,
+                                    classname=classname,
+                                    handler_name=handler_name,
+                                    actor=event.actor.id,
+                                    source=event.source,
+                                )
+                                for effect in _effects
+                            ]
+                            effects = validate_effects(effects)
+
+                            apply_effects_to_context(effects, event=event)
+
+                            log.info(f"{plugin_name}.compute() completed.")
+
+                    except Exception as e:
+                        log.exception(f"Encountered exception in plugin {plugin_name}")
+                        sentry_sdk.capture_exception(e)
                         continue
-                    relevant_plugin_handlers.append(handler_class)
 
-                    classname = (
-                        handler.__class__.__name__
-                        if isinstance(handler, ClinicalQualityMeasure)
-                        else None
-                    )
-                    handler_name = metrics.get_qualified_name(handler.compute)
-
-                    # Determine namespace and access level for database context
-                    db_namespace = namespace_config["namespace"] if namespace_config else None
-                    db_access_level = (
-                        namespace_config["access_level"] if namespace_config else "read"
-                    )
-
-                    with (
-                        metrics.measure(
-                            name=handler_name,
-                            track_queries=True,
-                            track_memory_usage=True,
-                            extra_tags={
-                                "plugin": base_plugin_name,
-                                "event": event_name,
-                            },
-                        ),
-                        plugin_database_context(
-                            base_plugin_name,
-                            namespace=db_namespace,
-                            access_level=db_access_level,
-                        ),
-                    ):
-                        _effects = handler.compute()
-                        if _effects is None:
-                            # Plugin authors sometimes forget to return their
-                            # effects list. Treat as empty with a warning so
-                            # the author can fix it, instead of raising
-                            # ``TypeError: 'NoneType' object is not iterable``
-                            # (KOALA-5365 / HOME-APP-RT8).
-                            log.warning(
-                                f"{handler_name} returned None from compute(); "
-                                "expected an iterable of effects. Treating as "
-                                "an empty list."
-                            )
-                            _effects = []
-                        effects = [
-                            Effect(
-                                type=effect.type,
-                                payload=effect.payload,
-                                plugin_name=base_plugin_name,
-                                classname=classname,
-                                handler_name=handler_name,
-                                actor=event.actor.id,
-                                source=event.source,
-                            )
-                            for effect in _effects
-                        ]
-                        effects = validate_effects(effects)
-
-                        apply_effects_to_context(effects, event=event)
-
-                        log.info(f"{plugin_name}.compute() completed.")
-
-                except Exception as e:
-                    log.exception(f"Encountered exception in plugin {plugin_name}")
-                    sentry_sdk.capture_exception(e)
-                    continue
-
-                effect_list += effects
+                    effect_list += effects
 
             sentry_sdk.set_tag("plugin-name", None)
 


### PR DESCRIPTION
[KOALA-5386](https://canvasmedical.atlassian.net/browse/KOALA-5386)

This pull request introduces support for plugin and handler-level filtering in log search and enhances logging infrastructure to propagate and surface plugin/handler names in log records and ECS output. It also provides thorough tests for these new features, ensuring correct context propagation and log formatting.

**Log Filtering Enhancements:**

* Added support for filtering logs by plugin and handler names in the CLI (`--plugin`, `--handler`), including proper parameter forwarding and conflict checking with `--cursor`. [[1]](diffhunk://#diff-0c1956ebbc8acab168dd8e047c5de06db64f0e181ed7aeb48d107f77b80b0c62R150-R151) [[2]](diffhunk://#diff-0c1956ebbc8acab168dd8e047c5de06db64f0e181ed7aeb48d107f77b80b0c62R318-R322) [[3]](diffhunk://#diff-0c1956ebbc8acab168dd8e047c5de06db64f0e181ed7aeb48d107f77b80b0c62L330-R345) [[4]](diffhunk://#diff-0c1956ebbc8acab168dd8e047c5de06db64f0e181ed7aeb48d107f77b80b0c62R382-R383) [[5]](diffhunk://#diff-0c1956ebbc8acab168dd8e047c5de06db64f0e181ed7aeb48d107f77b80b0c62R169-R172) [[6]](diffhunk://#diff-0c1956ebbc8acab168dd8e047c5de06db64f0e181ed7aeb48d107f77b80b0c62R203-R204) [[7]](diffhunk://#diff-0c1956ebbc8acab168dd8e047c5de06db64f0e181ed7aeb48d107f77b80b0c62R237-R238)
* Comprehensive tests for plugin/handler CLI options, parameter forwarding, and error handling in log filtering.

**Plugin/Handler Context Propagation in Logging:**

* Introduced `plugin_context` context manager and `PluginNameFilter` to propagate plugin and handler names using context variables, and surface them onto each `LogRecord` for downstream formatting. [[1]](diffhunk://#diff-17499aadecd5656936e9819af92406ba5c5d5f2e1ef0e0191f82c29a28826cecR3-R5) [[2]](diffhunk://#diff-17499aadecd5656936e9819af92406ba5c5d5f2e1ef0e0191f82c29a28826cecR14-R73)
* Updated `PluginLogger` to use the new filter and inject plugin/handler information into log messages.
* Modified ECS log formatter to emit `labels.plugin` and `labels.handler` fields when available.
* Wrapped plugin handler execution in `plugin_runner` with `plugin_context` to ensure correct logging context during event processing. [[1]](diffhunk://#diff-dbc2fadbd23e0736a22da6585669aaac1a2b659ff075e5ab49777949c72dde1aR51) [[2]](diffhunk://#diff-dbc2fadbd23e0736a22da6585669aaac1a2b659ff075e5ab49777949c72dde1aL278-R287) [[3]](diffhunk://#diff-dbc2fadbd23e0736a22da6585669aaac1a2b659ff075e5ab49777949c72dde1aR308)

**Testing and Validation:**

* Added detailed unit tests for context propagation, filter behavior, and ECS formatter output to ensure correct plugin/handler labeling in logs.

[KOALA-5386]: https://canvasmedical.atlassian.net/browse/KOALA-5386?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ