### PR TITLE
fix: stop displaying plugin secret values in canvas config list

### DIFF
--- a/canvas_cli/apps/plugin/plugin.py
+++ b/canvas_cli/apps/plugin/plugin.py
@@ -506,14 +506,9 @@ def list_secrets(
         if variables_list:
             for var in variables_list:
                 name = var["name"]
-                sensitive = var.get("sensitive", True)
-                if sensitive:
-                    display = "[set]" if var.get("is_set") else "[not set]"
-                    print(f"  {name} = {display}  (sensitive)")
-                else:
-                    value = var.get("value", "")
-                    display = value if value else "[not set]"
-                    print(f"  {name} = {display}")
+                display = "[set]" if var.get("is_set") else "[not set]"
+                annotation = "  (sensitive)" if var.get("sensitive") else ""
+                print(f"  {name} = {display}{annotation}")
         elif secrets_list := data.get("secrets", []):
             # Legacy fallback: server doesn't return variables yet
             pprint(secrets_list)

--- a/canvas_cli/apps/plugin/tests.py
+++ b/canvas_cli/apps/plugin/tests.py
@@ -1186,7 +1186,7 @@ def test_list_secrets_with_variables_field(
     mock_requests_get: Mock,
     mock_print: Mock,
 ) -> None:
-    """Test list_secrets with the new server `variables` response (sensitive + non-sensitive)."""
+    """list_secrets renders is_set/not-set uniformly and never displays values."""
     mock_plugin_url.return_value = "https://example.canvasmedical.com/api/plugins/p/metadata"
     mock_get_token.return_value = "test-token"
 
@@ -1196,8 +1196,8 @@ def test_list_secrets_with_variables_field(
         "variables": [
             {"name": "API_KEY", "sensitive": True, "is_set": True},
             {"name": "MISSING_SECRET", "sensitive": True, "is_set": False},
-            {"name": "REGION", "sensitive": False, "value": "us-west-2"},
-            {"name": "EMPTY_VAR", "sensitive": False, "value": ""},
+            {"name": "REGION", "sensitive": False, "is_set": True},
+            {"name": "EMPTY_VAR", "sensitive": False, "is_set": False},
         ]
     }
     mock_requests_get.return_value = mock_response
@@ -1207,8 +1207,8 @@ def test_list_secrets_with_variables_field(
     printed = [c.args[0] for c in mock_print.call_args_list]
     assert any("API_KEY = [set]  (sensitive)" in p for p in printed)
     assert any("MISSING_SECRET = [not set]  (sensitive)" in p for p in printed)
-    assert any("REGION = us-west-2" in p for p in printed)
-    assert any("EMPTY_VAR = [not set]" in p for p in printed)
+    assert any("REGION = [set]" in p and "(sensitive)" not in p for p in printed)
+    assert any("EMPTY_VAR = [not set]" in p and "(sensitive)" not in p for p in printed)
 
 
 @patch("builtins.open", new_callable=mock_open, read_data=b"fake package data")

--- a/canvas_cli/main.py
+++ b/canvas_cli/main.py
@@ -41,7 +41,7 @@ if os.environ.get("CONTROL_ROOM_BETA", "").lower() == "true":
 
 # Config app
 config_app = typer.Typer(
-    help="Manage plugin variables. Sensitive values are write-only; non-sensitive values are readable.",
+    help="Manage plugin variables. Values are write-only; only key names and whether they are set are returned.",
     rich_markup_mode=None,
     add_completion=False,
 )


### PR DESCRIPTION
## Summary

- `canvas config list` now renders every variable as `[set]` / `[not set]` (with a `  (sensitive)` annotation when the manifest marks it sensitive). Values are never displayed.
- Help text on the `config` subcommand updated to reflect that values are write-only at the API surface.

## Background

Pairs with canvas-medical/canvas#19025, which stops the home-app `/metadata` endpoint from returning `value` for non-sensitive variables. The previous CLI render fell back to the literal value for non-sensitive vars; once the server stops sending it, those rows would have rendered as `[not set]` even when set. Now the render is uniform and unconditional on `is_set`, so it stays correct against both the patched server and any older deployments that still return `value`.

Read access to the actual value continues to live in Django admin behind `managing_users`. If Control Room ever needs to read values back it should get its own JWT-authenticated endpoint with a deliberately scoped audience.

## Test plan

- [x] `uv run pytest canvas_cli/apps/plugin/tests.py -k list_secrets -v` (3 passed)
- [ ] CI green