### PR TITLE
feat: add Instruction and InstructionCoding to canvas_sdk.v1.data

### DIFF
--- a/canvas_sdk/v1/data/__init__.py
+++ b/canvas_sdk/v1/data/__init__.py
@@ -74,6 +74,7 @@ from .immunization import (
     ImmunizationStatement,
     ImmunizationStatementCoding,
 )
+from .instruction import Instruction, InstructionCoding
 from .integration_task import (
     IntegrationTask,
     IntegrationTaskChannel,
@@ -276,6 +277,8 @@ __all__ = __exports__ = (
     "ImmunizationStatement",
     "ImmunizationStatementCoding",
     "InstallmentPlan",
+    "Instruction",
+    "InstructionCoding",
     "IntegrationTask",
     "IntegrationTaskChannel",
     "IntegrationTaskReview",

--- a/canvas_sdk/v1/data/instruction.py
+++ b/canvas_sdk/v1/data/instruction.py
@@ -1,0 +1,55 @@
+from typing import cast
+
+from django.db import models
+
+from canvas_sdk.v1.data.base import (
+    AuditedModel,
+    BaseModelManager,
+    BaseQuerySet,
+    CommittableQuerySetMixin,
+    ForPatientQuerySetMixin,
+    IdentifiableModel,
+    ValueSetLookupQuerySetMixin,
+)
+from canvas_sdk.v1.data.coding import Coding
+
+
+class InstructionQuerySet(
+    CommittableQuerySetMixin,
+    ForPatientQuerySetMixin,
+    ValueSetLookupQuerySetMixin,
+    BaseQuerySet,
+):
+    """InstructionQuerySet."""
+
+
+InstructionManager = BaseModelManager.from_queryset(InstructionQuerySet)
+
+
+class Instruction(AuditedModel, IdentifiableModel):
+    """Instruction."""
+
+    class Meta:
+        db_table = "canvas_sdk_data_api_instruction_001"
+
+    objects = cast(InstructionQuerySet, InstructionManager())
+
+    patient = models.ForeignKey(
+        "v1.Patient", on_delete=models.DO_NOTHING, related_name="instructions"
+    )
+    note = models.ForeignKey("v1.Note", on_delete=models.DO_NOTHING, related_name="instructions")
+    narrative = models.CharField(max_length=4000)
+
+
+class InstructionCoding(Coding):
+    """InstructionCoding."""
+
+    class Meta:
+        db_table = "canvas_sdk_data_api_instructioncoding_001"
+
+    instruction = models.ForeignKey(
+        Instruction, on_delete=models.DO_NOTHING, related_name="codings", null=True
+    )
+
+
+__exports__ = ("Instruction", "InstructionCoding")

--- a/plugin_runner/allowed-module-imports.json
+++ b/plugin_runner/allowed-module-imports.json
@@ -1081,6 +1081,8 @@
     "ImmunizationStatement",
     "ImmunizationStatementCoding",
     "InstallmentPlan",
+    "Instruction",
+    "InstructionCoding",
     "IntegrationTask",
     "IntegrationTaskChannel",
     "IntegrationTaskReview",
@@ -1387,6 +1389,10 @@
     "ImmunizationStatement",
     "ImmunizationStatementCoding",
     "ImmunizationStatus"
+  ],
+  "canvas_sdk.v1.data.instruction": [
+    "Instruction",
+    "InstructionCoding"
   ],
   "canvas_sdk.v1.data.integration_task": [
     "IntegrationTask",


### PR DESCRIPTION
**Jira:** [KOALA-5567](https://canvasmedical.atlassian.net/browse/KOALA-5567)

## Summary

Adds a queryable SDK model for committed Instruct commands so plugins can write `Instruction.objects.for_patient(pid).committed().find(value_set)` instead of scanning `Command.data` JSON.

- `Instruction(AuditedModel, IdentifiableModel)` with `patient` / `note` FKs and a `narrative` field.
- `InstructionCoding(Coding)` with `related_name="codings"`, so the default `ValueSetLookupQuerySetMixin.q_object()` filter (`codings__system`, `codings__code__in`) wires up automatically.
- `InstructionQuerySet` composes the standard `CommittableQuerySetMixin`, `ForPatientQuerySetMixin`, and `ValueSetLookupQuerySetMixin` — the same shape as `ConditionQuerySet` minus `.active()` (there's no `clinical_status` on Instruction).
- Auto-registration in `plugin_runner/allowed-module-imports.json` regenerated by the existing pre-commit hook.

## Why

Closes the read-side gap from [Medical-Software-Foundation/canvas#270](https://github.com/Medical-Software-Foundation/canvas/pull/270) follow-up #3. The port of the CMS134v6 (dialysis education) and CMS138v6 (tobacco cessation) CQM protocols had to either drop their instruction-pathway check or fall back to scanning committed Instruct commands' `data` JSON for SNOMED codings. Both workarounds will go away once those plugins move to `Instruction.objects.find(value_set)`.

## How it works

Backed by two new database views materialized on the home-app side (see related PR below): `canvas_sdk_data_api_instruction_001` and `canvas_sdk_data_api_instructioncoding_001`. The views are created automatically by home-app's existing `post_migrate` signal handler.

## Test plan

- [x] `uv run pytest canvas_sdk/tests/data/` — 29/29 passing. The two structural tests that auto-cover the new model:
  - `test_django_model_checks` — runs Django's `check --tag models` over all SDK models.
  - `test_all_django_models_are_exported` — confirms `Instruction` and `InstructionCoding` are in `__all__`.
- [x] Smoke import:
  - `Instruction._meta.db_table == "canvas_sdk_data_api_instruction_001"` ✓
  - `InstructionCoding._meta.db_table == "canvas_sdk_data_api_instructioncoding_001"` ✓
  - QuerySet MRO has `CommittableQuerySetMixin`, `ForPatientQuerySetMixin`, `ValueSetLookupQuerySetMixin` ✓
  - `.find()`, `.committed()`, `.for_patient()` all present ✓
- [ ] End-to-end against a customer instance once home-app side ships.

## Related PRs

- **home-app side**: [canvas-medical/canvas#19076](https://github.com/canvas-medical/canvas/pull/19076) — adds the `api_instruction` / `api_instructioncoding` SDK database views.
- **docs**: [canvas-medical/documentation#1207](https://github.com/canvas-medical/documentation/pull/1207) — `Instruction` model page in the SDK reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[KOALA-5567]: https://canvasmedical.atlassian.net/browse/KOALA-5567?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ