### PR TITLE
fix: scope reporting default privileges to canvas_sdk_read_only (SUPPORT-2188)

### DIFF
--- a/plugin_runner/init_namespace_schema.sql
+++ b/plugin_runner/init_namespace_schema.sql
@@ -79,7 +79,15 @@ BEGIN
         EXECUTE 'GRANT USAGE ON SCHEMA {namespace} TO reporting';
         EXECUTE 'GRANT SELECT ON ALL TABLES IN SCHEMA {namespace} TO reporting';
         -- Ensure future tables created in this schema are also readable.
-        EXECUTE 'ALTER DEFAULT PRIVILEGES IN SCHEMA {namespace} GRANT SELECT ON TABLES TO reporting';
+        -- ALTER DEFAULT PRIVILEGES is per-creating-role: pg_default_acl is
+        -- keyed on (schema, defaclrole), so we must target the role that
+        -- actually creates plugin tables. Plugin custom-model tables are
+        -- created by ddl.py:execute_create_table_sql via the Django
+        -- connection, which authenticates as canvas_sdk_read_only — not the
+        -- role running this init script. Without FOR ROLE, the default
+        -- silently attaches to current_user (e.g. aptible in prod) and
+        -- never fires for plugin tables. SUPPORT-2188.
+        EXECUTE 'ALTER DEFAULT PRIVILEGES FOR ROLE canvas_sdk_read_only IN SCHEMA {namespace} GRANT SELECT ON TABLES TO reporting';
     END IF;
 END
 $$;


### PR DESCRIPTION
## Summary

- The DO block in `plugin_runner/init_namespace_schema.sql` grants `reporting` SELECT on existing tables and sets a default for *future* tables. But the `ALTER DEFAULT PRIVILEGES` statement omits `FOR ROLE`, so it implicitly targets `current_user` — which is `aptible` in production.
- `ALTER DEFAULT PRIVILEGES` is per-creating-role. `pg_default_acl` rows are keyed on `(schema, defaclrole)`. A row scoped to `aptible` only fires for tables that `aptible` creates.
- Plugin custom-model tables are created by `ddl.py:execute_create_table_sql` through the Django connection, which authenticates as `canvas_sdk_read_only` — a different role. The aptible-scoped default never matched them, so `reporting` got no SELECT and read-replica queries fail with permission-denied for every plugin-defined table.

## Fix

Target the default at `canvas_sdk_read_only` directly. The four built-in namespace tables created earlier in this init script (`namespace_auth`, `attribute_hub`, `custom_attribute`, `schema_version`) are already covered by the explicit `GRANT SELECT ON ALL TABLES IN SCHEMA` on the line above, so the now-removed implicit-`current_user` default was effectively a no-op for them. `aptible` doesn't create additional tables in this schema after init, so nothing else relies on the dropped row.

A code comment is added explaining the per-role semantics so a future contributor doesn't "simplify" the explicit `FOR ROLE` back out.

Linear/Jira: [SUPPORT-2188](https://canvasmedical.atlassian.net/browse/SUPPORT-2188)

## Scope of the existing breakage

Production instances confirmed affected (per the SUPPORT-2188 investigation):

| Instance | Schema | Tables |
|---|---|---|
| duohealth | `duo__sticky_note` | `stickynote`, `stickynoteaudit` |
| training | `canvas__wound_care` | `woundassessment` |
| training | `note_timeline__restrictions` | `notetypeaccessconfig` |
| eventide | `custom_data__recent_patients` | `recentpatientinteraction` |
| brigade | `custom_data__recent_patients` | `recentpatientinteraction` |
| steadymd | `canvas_medical__sticky_note` | `stickynote`, `stickynoteaudit` |
| transformtxk | `custom_data__templates` | `consulttypesetting` |

All owned by `canvas_sdk_read_only`. Hypothesis reproduces 100% of the time against `pg_default_acl`.

## Backfill

This PR fixes the default going forward but does **not** retroactively grant on tables that already exist. A one-time backfill is required on each affected instance:

```sql
GRANT SELECT ON <schema>.<table> TO reporting;
```

Already manually applied for `duohealth`; the remaining instances are tracked in SUPPORT-2188.

## Test plan

- [ ] On a fresh namespace, re-run the init script and confirm `pg_default_acl` has a row for `(schema, canvas_sdk_read_only)` with `reporting=r/canvas_sdk_read_only`.
- [ ] Create a plugin custom-model table via the Django path; confirm `has_table_privilege('reporting', '<schema>.<table>', 'SELECT')` returns `true` without a manual grant.
- [ ] Confirm built-in namespace tables (`namespace_auth`, `attribute_hub`, `custom_attribute`, `schema_version`) still have reporting SELECT — they're covered by the explicit `GRANT SELECT ON ALL TABLES IN SCHEMA` above the changed line.
- [ ] Confirm the DO block still no-ops cleanly in local/dev environments without a `reporting` role.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SUPPORT-2188]: https://canvasmedical.atlassian.net/browse/SUPPORT-2188?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ