### PR TITLE
fix: exclude node_modules when bundling plugins

### DIFF
--- a/canvas_cli/apps/plugin/plugin.py
+++ b/canvas_cli/apps/plugin/plugin.py
@@ -56,7 +56,7 @@ def _build_package(package: Path) -> Path:
     if not package.exists() or not package.is_dir():
         raise typer.BadParameter(f"Couldn't build {package}, not a dir")
 
-    default_ignore = ["__pycache__", "*.pyc", "*.pyo"]
+    default_ignore = ["__pycache__", "*.pyc", "*.pyo", "node_modules"]
 
     ignore_file = Path.cwd() / CANVAS_IGNORE_FILENAME
     if ignore_file.exists():

--- a/canvas_cli/apps/plugin/tests.py
+++ b/canvas_cli/apps/plugin/tests.py
@@ -79,6 +79,8 @@ def init_plugin(cli_runner: CliRunner, init_plugin_name: str) -> Path:
     (plugin_dir / "__pycache__" / "module.cpython-312.pyc").write_bytes(b"\x00")
     (plugin_dir / "handlers" / ".crush").mkdir()
     (plugin_dir / "handlers" / ".crush" / "cache.json").write_text("{}")
+    (plugin_dir / "node_modules").mkdir()
+    (plugin_dir / "node_modules" / "left-pad.js").write_text("module.exports = {}")
 
     return plugin_dir
 
@@ -134,6 +136,8 @@ def test_build_package(init_plugin: Path) -> None:
         assert not any("__pycache__" in name for name in names)
         # hidden directories nested inside subdirectories should be excluded
         assert not any(".crush" in name for name in names)
+        # node_modules should be excluded by default
+        assert not any("node_modules" in name for name in names)
 
 
 @pytest.mark.parametrize(
@@ -143,7 +147,7 @@ def test_build_package(init_plugin: Path) -> None:
         (
             [],
             ["CANVAS_MANIFEST.json", "handlers"],
-            [".hidden-dir", ".hidden.file", "symlink", "__pycache__"],
+            [".hidden-dir", ".hidden.file", "symlink", "__pycache__", "node_modules"],
         ),
         # 2. Relative path
         (["*.md"], ["CANVAS_MANIFEST.json", "handlers"], ["README.md"]),

--- a/uv.lock
+++ b/uv.lock
@@ -2,6 +2,10 @@ version = 1
 revision = 3
 requires-python = ">=3.11, <3.15"
 
+[options]
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer-span = "P7D"
+
 [[package]]
 name = "annotated-types"
 version = "0.7.0"


### PR DESCRIPTION
Adds `node_modules` to the default ignore list in `_build_package`, so it's excluded from plugin bundles alongside `__pycache__`, `*.pyc`, and `*.pyo`.

JS dependency trees are large and never needed at runtime in the plugin sandbox, and they routinely tripped the existing >100-files / >1mb bundle-size warnings. Authors no longer have to add a `.canvasignore` just to keep `node_modules` out.

The fixture used by the build tests now creates a `node_modules` directory, and both `test_build_package` and the default-ignored-patterns parametrize case assert it is excluded.