### PR TITLE
feat(cli): pre-deploy plugin validation (manifest layout check + handler sandbox-load)

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -142,14 +142,14 @@ jobs:
           PYTHON_VERSION: "3.13"
       - uses: ./.github/actions/install-canvas
 
-      - name: Validate every example plugin manifest
+      - name: Validate every example plugin
         run: |
           failed=0
           for manifest in example-plugins/*/CANVAS_MANIFEST.json; do
             plugin_dir="$(dirname "$manifest")"
-            echo "::group::validate-manifest $plugin_dir"
-            if ! uv run canvas validate-manifest "$plugin_dir"; then
-              echo "::error::validate-manifest failed for $plugin_dir"
+            echo "::group::validate $plugin_dir"
+            if ! uv run canvas validate "$plugin_dir"; then
+              echo "::error::validate failed for $plugin_dir"
               failed=1
             fi
             echo "::endgroup::"

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -133,6 +133,29 @@ jobs:
           flags: sdk-core
           fail_ci_if_error: true
 
+  validate-example-plugins:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: ./.github/actions/install-python-and-uv
+        with:
+          PYTHON_VERSION: "3.13"
+      - uses: ./.github/actions/install-canvas
+
+      - name: Validate every example plugin manifest
+        run: |
+          failed=0
+          for manifest in example-plugins/*/CANVAS_MANIFEST.json; do
+            plugin_dir="$(dirname "$manifest")"
+            echo "::group::validate-manifest $plugin_dir"
+            if ! uv run canvas validate-manifest "$plugin_dir"; then
+              echo "::error::validate-manifest failed for $plugin_dir"
+              failed=1
+            fi
+            echo "::endgroup::"
+          done
+          exit $failed
+
   discover-plugins:
     runs-on: ubuntu-latest
     outputs:

--- a/canvas_cli/apps/plugin/__init__.py
+++ b/canvas_cli/apps/plugin/__init__.py
@@ -7,6 +7,7 @@ from canvas_cli.apps.plugin.plugin import (
     list_secrets,
     set_secrets,
     uninstall,
+    validate,
     validate_manifest,
 )
 
@@ -19,5 +20,6 @@ __all__ = (
     "install",
     "list",
     "uninstall",
+    "validate",
     "validate_manifest",
 )

--- a/canvas_cli/apps/plugin/plugin.py
+++ b/canvas_cli/apps/plugin/plugin.py
@@ -4,6 +4,7 @@ import ast
 import base64
 import builtins
 import json
+import sys
 import tarfile
 import tempfile
 from collections.abc import Iterable
@@ -21,6 +22,7 @@ from cookiecutter.main import cookiecutter
 from canvas_cli.apps.auth.utils import get_default_host, get_or_request_api_token
 from canvas_cli.utils.context import context
 from canvas_cli.utils.validators import validate_manifest_file
+from plugin_runner.plugin_runner import load_plugin_handlers
 
 CANVAS_IGNORE_FILENAME = ".canvasignore"
 
@@ -277,6 +279,7 @@ def install(
 
     if plugin_name.is_dir():
         validate_manifest(plugin_name)
+        _validate_plugin_loads(plugin_name)
         built_package_path = _build_package(plugin_name)
     else:
         raise typer.BadParameter(f"Plugin '{plugin_name}' needs to be a valid directory")
@@ -731,6 +734,65 @@ def validate_manifest(
         print("These handlers will not be loaded unless you add them to the manifest.\n")
 
     print(f"Plugin {plugin_name} has a valid CANVAS_MANIFEST.json file")
+
+
+def _validate_plugin_loads(plugin_name: Path) -> None:
+    """Sandbox-load every handler declared in the manifest and report failures.
+
+    Surfaces sandbox violations (disallowed imports, restricted syntax, import
+    errors) at validation time instead of at runtime on the instance. Uses the
+    same loader as the plugin runner, so a pass here means the handlers' modules
+    import cleanly under the sandbox. Raises ``typer.Exit(1)`` on any failure.
+
+    Note: this exercises module-level code only — violations that occur inside a
+    handler's ``compute()`` at request time are not caught here.
+    """
+    plugin_path = plugin_name.resolve()
+    manifest_json = json.loads((plugin_path / "CANVAS_MANIFEST.json").read_text())
+    components = manifest_json.get("components", {})
+    handlers = (
+        components.get("protocols", [])
+        + components.get("applications", [])
+        + components.get("handlers", [])
+    )
+
+    if not handlers:
+        return
+
+    # Make the plugin's package importable, mirroring what the runner does when
+    # it loads installed plugins from PLUGIN_DIRECTORY (see plugin_runner). This
+    # lets intra-package imports and Django model registration resolve the way
+    # they will on the instance.
+    parent_dir = str(plugin_path.parent)
+    if parent_dir not in sys.path:
+        sys.path.insert(0, parent_dir)
+
+    print(f"Loading {len(handlers)} handler(s) in the sandbox:")
+
+    results = load_plugin_handlers(plugin_path.name, plugin_path, handlers)
+
+    failures = [r for r in results if r.error is not None]
+    for r in results:
+        label = r.handler.get("class", "<unknown>")
+        if r.error is None:
+            print(f"  ✓ {label}")
+        else:
+            print(f"  ✗ {label}")
+            print(f"      {type(r.error).__name__}: {r.error}")
+
+    if failures:
+        print(f"\n{len(failures)} of {len(results)} handler(s) failed to load in the sandbox.")
+        raise typer.Exit(1)
+
+    print(f"All {len(results)} handler(s) load cleanly in the sandbox.")
+
+
+def validate(
+    plugin_name: Path = typer.Argument(..., help="Path to plugin to validate"),
+) -> None:
+    """Validate a plugin's manifest and that all its handlers load in the sandbox."""
+    validate_manifest(plugin_name)
+    _validate_plugin_loads(plugin_name)
 
 
 def update(

--- a/canvas_cli/apps/plugin/plugin.py
+++ b/canvas_cli/apps/plugin/plugin.py
@@ -610,6 +610,61 @@ def _find_unreferenced_handlers(plugin_path: Path, manifest_json: dict) -> built
     return unreferenced
 
 
+def _find_unresolvable_handlers(
+    plugin_path: Path, manifest_json: dict
+) -> builtins.list[tuple[str, str]]:
+    """Find manifest handler classes whose module file won't resolve at runtime.
+
+    The plugin runner loads each handler by mapping its dotted module path to a
+    file *relative to the parent of the install directory*: a plugin installed
+    at ``plugins/<name>/`` loads handler ``<name>.routes.api`` from
+    ``plugins/<name>/routes/api.py`` (see
+    ``plugin_runner.sandbox.sandbox_from_module``). The leading module segment
+    is therefore the plugin's own package (which must equal the manifest
+    ``name``) and the remaining segments are a path *inside* the plugin
+    directory — the same directory that holds ``CANVAS_MANIFEST.json``.
+
+    A common mistake is leaving ``CANVAS_MANIFEST.json`` in a parent directory
+    above the package (so ``<name>/routes/api.py`` actually lives at
+    ``<name>/<name>/routes/api.py`` once installed). That passes schema
+    validation and imports fine locally via ``sys.path``, then fails on the
+    instance with ``ModuleNotFoundError``. This check mirrors the runner's
+    resolution against the on-disk layout so the problem surfaces here instead.
+
+    Returns ``(class_ref, expected_relative_path)`` for each handler that won't
+    resolve, where ``expected_relative_path`` is where the runner will look,
+    relative to the plugin directory.
+    """
+    name = manifest_json.get("name")
+    components = manifest_json.get("components", {})
+
+    # The runner loads protocols + applications + handlers; mirror that exact
+    # set (see plugin_runner.load_or_reload_plugin).
+    class_refs = []
+    for key in ("protocols", "applications", "handlers"):
+        for item in components.get(key, []):
+            if class_ref := item.get("class", ""):
+                class_refs.append(class_ref)
+
+    unresolvable = []
+    for class_ref in class_refs:
+        module_path = class_ref.split(":", 1)[0]
+        segments = module_path.split(".")
+
+        # The leading segment must be the plugin's own package and there must be
+        # at least one submodule segment for the handler to live in a file
+        # inside the plugin directory.
+        if len(segments) < 2 or segments[0] != name:
+            unresolvable.append((class_ref, f"{module_path.replace('.', '/')}.py"))
+            continue
+
+        relative = "/".join(segments[1:]) + ".py"
+        if not plugin_path.joinpath(*segments[1:]).with_suffix(".py").exists():
+            unresolvable.append((class_ref, relative))
+
+    return unresolvable
+
+
 def validate_manifest(
     plugin_name: Path = typer.Argument(..., help="Path to plugin to validate"),
 ) -> None:
@@ -645,6 +700,25 @@ def validate_manifest(
         raise typer.Abort() from None
 
     validate_manifest_file(manifest_json)
+
+    # Check that every declared handler resolves to a file where the runner
+    # will look for it. This catches a misplaced CANVAS_MANIFEST.json (e.g. one
+    # sitting above the package directory) that would otherwise pass validation
+    # and fail to load on the instance with a ModuleNotFoundError.
+    unresolvable = _find_unresolvable_handlers(plugin_name, manifest_json)
+    if unresolvable:
+        print(
+            "\nError: these handler classes won't be found by the plugin runner "
+            "with the current directory layout:"
+        )
+        for class_ref, expected in unresolvable:
+            print(f"  - {class_ref}\n      runner expects: {plugin_name.name}/{expected}")
+        print(
+            "\nCANVAS_MANIFEST.json must live inside the plugin's package directory "
+            '(the directory whose name matches the manifest "name"), alongside the '
+            "handler packages — not in a parent directory above them.\n"
+        )
+        raise typer.Exit(code=1)
 
     # Check for unreferenced handlers
     unreferenced = _find_unreferenced_handlers(plugin_name, manifest_json)

--- a/canvas_cli/apps/plugin/tests.py
+++ b/canvas_cli/apps/plugin/tests.py
@@ -1,4 +1,5 @@
 import base64
+import json
 import shutil
 import tarfile
 from collections.abc import Generator
@@ -18,6 +19,7 @@ from .plugin import (
     _build_package,
     _find_unreferenced_handlers,
     _find_unresolvable_handlers,
+    _validate_plugin_loads,
     install,
     list_secrets,
     parse_secrets,
@@ -368,6 +370,7 @@ def test_list_no_plugins(
 @patch("requests.post")
 @patch("canvas_cli.apps.plugin.plugin.plugin_url")
 @patch("canvas_cli.apps.plugin.plugin._build_package")
+@patch("canvas_cli.apps.plugin.plugin._validate_plugin_loads")
 @patch("canvas_cli.apps.plugin.plugin.validate_manifest")
 @patch("canvas_cli.apps.plugin.plugin.get_or_request_api_token")
 @patch("pathlib.Path.is_dir")
@@ -377,6 +380,7 @@ def test_install_success_no_secrets(
     mock_is_dir: Mock,
     mock_get_token: Mock,
     mock_validate: Mock,
+    mock_validate_loads: Mock,
     mock_build: Mock,
     mock_plugin_url: Mock,
     mock_post: Mock,
@@ -425,6 +429,7 @@ def test_install_success_no_secrets(
 @patch("requests.post")
 @patch("canvas_cli.apps.plugin.plugin.plugin_url")
 @patch("canvas_cli.apps.plugin.plugin._build_package")
+@patch("canvas_cli.apps.plugin.plugin._validate_plugin_loads")
 @patch("canvas_cli.apps.plugin.plugin.validate_manifest")
 @patch("canvas_cli.apps.plugin.plugin.get_or_request_api_token")
 @patch("pathlib.Path.is_dir")
@@ -434,6 +439,7 @@ def test_install_success_with_secrets(
     mock_is_dir: Mock,
     mock_get_token: Mock,
     mock_validate: Mock,
+    mock_validate_loads: Mock,
     mock_build: Mock,
     mock_plugin_url: Mock,
     mock_post: Mock,
@@ -477,6 +483,7 @@ def test_install_success_with_secrets(
 @patch("requests.post")
 @patch("canvas_cli.apps.plugin.plugin.plugin_url")
 @patch("canvas_cli.apps.plugin.plugin._build_package")
+@patch("canvas_cli.apps.plugin.plugin._validate_plugin_loads")
 @patch("canvas_cli.apps.plugin.plugin.validate_manifest")
 @patch("canvas_cli.apps.plugin.plugin.get_or_request_api_token")
 @patch("pathlib.Path.is_dir")
@@ -486,6 +493,7 @@ def test_install_disabled(
     mock_is_dir: Mock,
     mock_get_token: Mock,
     mock_validate: Mock,
+    mock_validate_loads: Mock,
     mock_build: Mock,
     mock_plugin_url: Mock,
     mock_post: Mock,
@@ -527,6 +535,7 @@ def test_install_disabled(
 @patch("requests.post")
 @patch("canvas_cli.apps.plugin.plugin.plugin_url")
 @patch("canvas_cli.apps.plugin.plugin._build_package")
+@patch("canvas_cli.apps.plugin.plugin._validate_plugin_loads")
 @patch("canvas_cli.apps.plugin.plugin.validate_manifest")
 @patch("canvas_cli.apps.plugin.plugin.get_or_request_api_token")
 @patch("pathlib.Path.is_dir")
@@ -536,6 +545,7 @@ def test_install_conflict_calls_update(
     mock_is_dir: Mock,
     mock_get_token: Mock,
     mock_validate: Mock,
+    mock_validate_loads: Mock,
     mock_build: Mock,
     mock_plugin_url: Mock,
     mock_post: Mock,
@@ -589,6 +599,7 @@ def test_install_conflict_calls_update(
 @patch("requests.post")
 @patch("canvas_cli.apps.plugin.plugin.plugin_url")
 @patch("canvas_cli.apps.plugin.plugin._build_package")
+@patch("canvas_cli.apps.plugin.plugin._validate_plugin_loads")
 @patch("canvas_cli.apps.plugin.plugin.validate_manifest")
 @patch("canvas_cli.apps.plugin.plugin.get_or_request_api_token")
 @patch("pathlib.Path.is_dir")
@@ -598,6 +609,7 @@ def test_install_error_status_exits(
     mock_is_dir: Mock,
     mock_get_token: Mock,
     mock_validate: Mock,
+    mock_validate_loads: Mock,
     mock_build: Mock,
     mock_plugin_url: Mock,
     mock_post: Mock,
@@ -641,6 +653,7 @@ def test_install_error_status_exits(
 @patch("requests.post")
 @patch("canvas_cli.apps.plugin.plugin.plugin_url")
 @patch("canvas_cli.apps.plugin.plugin._build_package")
+@patch("canvas_cli.apps.plugin.plugin._validate_plugin_loads")
 @patch("canvas_cli.apps.plugin.plugin.validate_manifest")
 @patch("canvas_cli.apps.plugin.plugin.get_or_request_api_token")
 @patch("pathlib.Path.is_dir")
@@ -650,6 +663,7 @@ def test_install_conflict_without_package_name_exits(
     mock_is_dir: Mock,
     mock_get_token: Mock,
     mock_validate: Mock,
+    mock_validate_loads: Mock,
     mock_build: Mock,
     mock_plugin_url: Mock,
     mock_post: Mock,
@@ -1396,6 +1410,7 @@ def test_list_secrets_with_variables_field(
 @patch("requests.post")
 @patch("canvas_cli.apps.plugin.plugin.plugin_url")
 @patch("canvas_cli.apps.plugin.plugin._build_package")
+@patch("canvas_cli.apps.plugin.plugin._validate_plugin_loads")
 @patch("canvas_cli.apps.plugin.plugin.validate_manifest")
 @patch("canvas_cli.apps.plugin.plugin.get_or_request_api_token")
 @patch("pathlib.Path.is_dir")
@@ -1405,6 +1420,7 @@ def test_install_with_variables_flag(
     mock_is_dir: Mock,
     mock_get_token: Mock,
     mock_validate: Mock,
+    mock_validate_loads: Mock,
     mock_build: Mock,
     mock_plugin_url: Mock,
     mock_post: Mock,
@@ -1450,6 +1466,7 @@ def test_install_with_variables_flag(
 @patch("requests.post")
 @patch("canvas_cli.apps.plugin.plugin.plugin_url")
 @patch("canvas_cli.apps.plugin.plugin._build_package")
+@patch("canvas_cli.apps.plugin.plugin._validate_plugin_loads")
 @patch("canvas_cli.apps.plugin.plugin.validate_manifest")
 @patch("canvas_cli.apps.plugin.plugin.get_or_request_api_token")
 @patch("pathlib.Path.is_dir")
@@ -1459,6 +1476,7 @@ def test_install_conflict_passes_variables_to_update(
     mock_is_dir: Mock,
     mock_get_token: Mock,
     mock_validate: Mock,
+    mock_validate_loads: Mock,
     mock_build: Mock,
     mock_plugin_url: Mock,
     mock_post: Mock,
@@ -1495,3 +1513,131 @@ def test_install_conflict_passes_variables_to_update(
         secrets=["S=1", "V=2"],
         host="https://example.canvasmedical.com",
     )
+
+
+_CLEAN_HANDLER = """
+from canvas_sdk.handlers import BaseHandler
+
+
+class Handler(BaseHandler):
+    def compute(self):
+        return []
+"""
+
+_FORBIDDEN_IMPORT_HANDLER = """
+import subprocess
+
+from canvas_sdk.handlers import BaseHandler
+
+
+class Handler(BaseHandler):
+    def compute(self):
+        return []
+"""
+
+
+def _scaffold_plugin(plugin_dir: Path, handler_body: str) -> Path:
+    """Write a minimal, schema-valid plugin whose single handler module contains
+    ``handler_body``. Returns the plugin directory.
+    """
+    name = plugin_dir.name
+    (plugin_dir / "handlers").mkdir(parents=True)
+    (plugin_dir / "__init__.py").touch()
+    (plugin_dir / "handlers" / "__init__.py").touch()
+    (plugin_dir / "README.md").write_text("readme")
+    (plugin_dir / "handlers" / "my_handler.py").write_text(handler_body)
+
+    manifest = {
+        "sdk_version": "0.1.4",
+        "plugin_version": "0.0.1",
+        "name": name,
+        "description": "test",
+        "components": {
+            "protocols": [
+                {
+                    "class": f"{name}.handlers.my_handler:Handler",
+                    "description": "a handler",
+                }
+            ]
+        },
+        "tags": {},
+        "references": [],
+        "license": "",
+        "diagram": False,
+        "readme": "./README.md",
+    }
+    (plugin_dir / "CANVAS_MANIFEST.json").write_text(json.dumps(manifest))
+    return plugin_dir
+
+
+def test_validate_plugin_loads_success(tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
+    """A plugin whose handlers import cleanly under the sandbox passes."""
+    plugin = _scaffold_plugin(tmp_path / "clean_loads_plugin", _CLEAN_HANDLER)
+
+    _validate_plugin_loads(plugin)
+
+    captured = capsys.readouterr()
+    assert "✓ clean_loads_plugin.handlers.my_handler:Handler" in captured.out
+    assert "load cleanly" in captured.out
+
+
+def test_validate_plugin_loads_surfaces_sandbox_violation(
+    tmp_path: Path, capsys: pytest.CaptureFixture
+) -> None:
+    """A disallowed import surfaces as a failure and exits non-zero."""
+    plugin = _scaffold_plugin(tmp_path / "bad_loads_plugin", _FORBIDDEN_IMPORT_HANDLER)
+
+    with pytest.raises(typer.Exit) as exc_info:
+        _validate_plugin_loads(plugin)
+
+    assert exc_info.value.exit_code == 1
+    captured = capsys.readouterr()
+    assert "✗ bad_loads_plugin.handlers.my_handler:Handler" in captured.out
+    assert "'subprocess' is not an allowed import" in captured.out
+
+
+def test_validate_command_passes_for_clean_plugin(tmp_path: Path, cli_runner: CliRunner) -> None:
+    """`canvas validate` exits 0 when manifest and sandbox-load both succeed."""
+    plugin = _scaffold_plugin(tmp_path / "clean_cmd_plugin", _CLEAN_HANDLER)
+
+    result = cli_runner.invoke(app, ["validate", str(plugin)])
+
+    assert result.exit_code == 0
+
+
+def test_validate_command_fails_for_sandbox_violation(
+    tmp_path: Path, cli_runner: CliRunner
+) -> None:
+    """`canvas validate` exits 1 when a handler fails to load in the sandbox."""
+    plugin = _scaffold_plugin(tmp_path / "bad_cmd_plugin", _FORBIDDEN_IMPORT_HANDLER)
+
+    result = cli_runner.invoke(app, ["validate", str(plugin)])
+
+    assert result.exit_code == 1
+
+
+def test_validate_plugin_loads_resolves_intra_package_imports(
+    tmp_path: Path, capsys: pytest.CaptureFixture
+) -> None:
+    """A handler that imports from a sibling module in its own package loads
+    cleanly — validation must make the plugin's package importable (mirroring
+    how the runner loads installed plugins from PLUGIN_DIRECTORY).
+    """
+    handler_body = """
+from multimod_plugin.constants import GREETING
+
+from canvas_sdk.handlers import BaseHandler
+
+
+class Handler(BaseHandler):
+    def compute(self):
+        return [GREETING]
+"""
+    plugin = _scaffold_plugin(tmp_path / "multimod_plugin", handler_body)
+    (plugin / "constants.py").write_text('GREETING = "hello"\n')
+
+    _validate_plugin_loads(plugin)
+
+    captured = capsys.readouterr()
+    assert "✓ multimod_plugin.handlers.my_handler:Handler" in captured.out
+    assert "load cleanly" in captured.out

--- a/canvas_cli/apps/plugin/tests.py
+++ b/canvas_cli/apps/plugin/tests.py
@@ -17,6 +17,7 @@ from canvas_cli.main import app
 from .plugin import (
     _build_package,
     _find_unreferenced_handlers,
+    _find_unresolvable_handlers,
     install,
     list_secrets,
     parse_secrets,
@@ -842,10 +843,21 @@ def plugin_with_manifest(tmp_path: Path) -> Path:
     manifest_file = plugin_dir / "CANVAS_MANIFEST.json"
     manifest_file.write_text(__import__("json").dumps(manifest))
 
-    # Create handlers directory
+    # Create handlers directory with the referenced handler file, so the
+    # handler resolves where the runner will look for it.
     handlers_dir = plugin_dir / "handlers"
     handlers_dir.mkdir()
     (handlers_dir / "__init__.py").touch()
+    (handlers_dir / "my_handler.py").write_text("""
+from canvas_sdk.handlers import BaseHandler
+from canvas_sdk.effects import Effect
+
+class MyHandler(BaseHandler):
+    RESPONDS_TO = "test"
+
+    def compute(self) -> list[Effect]:
+        return []
+""")
 
     return plugin_dir
 
@@ -1240,6 +1252,109 @@ class Protocol1(BaseHandler):
     # Should only detect Handler2 as unreferenced
     assert len(unreferenced) == 1
     assert "test_plugin.handlers.handler2:Handler2" in unreferenced
+
+
+def test_find_unresolvable_handlers_all_resolve(tmp_path: Path) -> None:
+    """All declared handlers resolve to files where the runner will look."""
+    plugin_dir = tmp_path / "test_plugin"
+    (plugin_dir / "routes").mkdir(parents=True)
+    (plugin_dir / "routes" / "api.py").touch()
+    (plugin_dir / "apps").mkdir()
+    (plugin_dir / "apps" / "chart.py").touch()
+    (plugin_dir / "protocols").mkdir()
+    (plugin_dir / "protocols" / "hook.py").touch()
+
+    manifest = {
+        "name": "test_plugin",
+        "components": {
+            "protocols": [{"class": "test_plugin.protocols.hook:Hook"}],
+            "applications": [{"class": "test_plugin.apps.chart:ChartApp"}],
+            "handlers": [{"class": "test_plugin.routes.api:API"}],
+        },
+    }
+
+    assert _find_unresolvable_handlers(plugin_dir, manifest) == []
+
+
+def test_find_unresolvable_handlers_detects_misplaced_manifest(tmp_path: Path) -> None:
+    """A manifest above the package directory (so the package is nested one
+    level too deep) is flagged — this is the spruce failure mode.
+    """
+    project_root = tmp_path / "project"
+    # Package nested under project_root/test_plugin/ while the manifest lives at
+    # project_root/, so the handler file is one directory too deep.
+    package = project_root / "test_plugin" / "routes"
+    package.mkdir(parents=True)
+    (package / "api.py").touch()
+
+    manifest = {
+        "name": "test_plugin",
+        "components": {
+            "handlers": [{"class": "test_plugin.routes.api:API"}],
+        },
+    }
+
+    # validate_manifest is run against project_root (where CANVAS_MANIFEST.json
+    # sits), so the runner would look for project_root/routes/api.py — missing.
+    unresolvable = _find_unresolvable_handlers(project_root, manifest)
+
+    assert len(unresolvable) == 1
+    class_ref, expected = unresolvable[0]
+    assert class_ref == "test_plugin.routes.api:API"
+    assert expected == "routes/api.py"
+
+
+def test_find_unresolvable_handlers_detects_wrong_package_name(tmp_path: Path) -> None:
+    """A handler whose leading module segment isn't the manifest name can't be
+    loaded by the runner and is flagged.
+    """
+    plugin_dir = tmp_path / "test_plugin"
+    (plugin_dir / "routes").mkdir(parents=True)
+    (plugin_dir / "routes" / "api.py").touch()
+
+    manifest = {
+        "name": "test_plugin",
+        "components": {
+            "handlers": [{"class": "other_package.routes.api:API"}],
+        },
+    }
+
+    unresolvable = _find_unresolvable_handlers(plugin_dir, manifest)
+
+    assert len(unresolvable) == 1
+    assert unresolvable[0][0] == "other_package.routes.api:API"
+
+
+def test_validate_manifest_misplaced_manifest_exits(tmp_path: Path) -> None:
+    """validate_manifest fails when a handler won't resolve at runtime."""
+    project_root = tmp_path / "test_plugin"
+    # Doubled package nesting: handler file is one level too deep.
+    package = project_root / "test_plugin" / "routes"
+    package.mkdir(parents=True)
+    (package / "api.py").touch()
+
+    manifest = {
+        "sdk_version": "0.1.4",
+        "plugin_version": "0.0.1",
+        "name": "test_plugin",
+        "description": "Test plugin",
+        "components": {
+            "handlers": [{"class": "test_plugin.routes.api:API", "description": "x"}],
+            "commands": [],
+            "content": [],
+            "effects": [],
+            "views": [],
+        },
+        "tags": {},
+        "references": [],
+        "license": "",
+        "diagram": False,
+        "readme": "./README.md",
+    }
+    (project_root / "CANVAS_MANIFEST.json").write_text(__import__("json").dumps(manifest))
+
+    with pytest.raises(typer.Exit):
+        validate_manifest(project_root)
 
 
 @patch("canvas_cli.apps.plugin.plugin.print")

--- a/canvas_cli/main.py
+++ b/canvas_cli/main.py
@@ -26,6 +26,9 @@ app.command(short_help="Enable a plugin from a Canvas instance")(plugin.enable)
 app.command(short_help="Disable a plugin from a Canvas instance")(plugin.disable)
 app.command(short_help="List all plugins from a Canvas instance")(plugin.list)
 app.command(short_help="Validate the Canvas Manifest json file")(plugin.validate_manifest)
+app.command(short_help="Validate a plugin's manifest and that its handlers load in the sandbox.")(
+    plugin.validate
+)
 app.command(
     short_help="Listen and print log streams or fetches historical logs from a Canvas instance."
 )(logs_command)

--- a/plugin_runner/plugin_runner.py
+++ b/plugin_runner/plugin_runner.py
@@ -11,6 +11,7 @@ import warnings
 from collections import defaultdict
 from collections.abc import Iterable
 from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
 from http import HTTPStatus
 from time import sleep
 from typing import Any, NotRequired, TypedDict, cast
@@ -18,6 +19,7 @@ from typing import Any, NotRequired, TypedDict, cast
 import grpc
 import redis
 import sentry_sdk
+from django.apps import apps as django_apps
 from django.core.signals import request_finished, request_started
 from redis.backoff import ExponentialBackoff
 from redis.exceptions import ConnectionError, TimeoutError
@@ -60,6 +62,7 @@ from plugin_runner.installation import (
     enabled_plugins,
     install_plugin,
     install_plugins,
+    register_plugin_app_config,
     uninstall_plugin,
 )
 from plugin_runner.sandbox import Sandbox, sandbox_from_module
@@ -744,6 +747,110 @@ def verify_plugin_namespace_access(
     }
 
 
+@dataclass
+class HandlerLoadResult:
+    """Outcome of sandbox-loading a single declared handler.
+
+    Pure data — carries either the executed sandbox ``scope`` (success) or the
+    ``error`` that was raised. ``report`` indicates whether the error warrants
+    Sentry reporting at runtime (false for developer-fault cases like a handler
+    declared from a foreign package).
+    """
+
+    handler: dict[str, Any]
+    name_and_class: str | None
+    handler_class: str | None
+    scope: dict[str, Any] | None
+    error: Exception | None
+    report: bool
+
+
+def load_plugin_handlers(
+    name: str,
+    path: pathlib.Path,
+    handlers: list[dict[str, Any]],
+    evaluated_modules: dict[str, bool] | None = None,
+) -> list[HandlerLoadResult]:
+    """Sandbox-load each declared handler for a plugin.
+
+    Runs the exact sandbox path used at runtime (``sandbox_from_module`` +
+    ``execute``) plus the Django model-registration reset, but mutates no global
+    plugin state (``LOADED_PLUGINS``) and does no logging or Sentry reporting —
+    callers decide what to do with the returned results. Shared by
+    ``load_or_reload_plugin`` and the ``canvas validate`` pre-flight so the two
+    cannot drift on sandbox semantics.
+    """
+    if evaluated_modules is None:
+        # Share evaluated_modules across all handlers in this plugin so that
+        # common submodules (like constants.py) are only evaluated and reloaded
+        # once, not once per handler.
+        evaluated_modules = {}
+
+    # Clear stale model registrations before handler sandboxes re-execute model
+    # files.  Without this, lazy_related_operation resolves string references
+    # (e.g. through="StaffSpecialty") to class objects from the prior execution,
+    # causing model-identity mismatches in ManyToManyField through-model resolution.
+    django_apps.all_models.pop(name, None)
+    django_apps.app_configs.pop(name, None)
+    django_apps.clear_cache()
+
+    results: list[HandlerLoadResult] = []
+
+    for handler in handlers:
+        # TODO add class colon validation to existing schema validation
+        try:
+            handler_module, handler_class = handler["class"].split(":")
+        except ValueError as e:
+            results.append(HandlerLoadResult(handler, None, None, None, e, report=True))
+            continue
+
+        handler_package = handler_module.split(".")[0]
+        if handler_package != name:
+            results.append(
+                HandlerLoadResult(
+                    handler,
+                    None,
+                    handler_class,
+                    None,
+                    ValueError(
+                        f'Plugin "{name}" declares handler from foreign package "{handler_package}"'
+                    ),
+                    report=False,
+                )
+            )
+            continue
+
+        name_and_class = f"{name}:{handler_module}:{handler_class}"
+
+        try:
+            # Suppress Django's "Model was already registered" RuntimeWarning.
+            # When importlib.reload re-imports model modules, Django's metaclass
+            # calls apps.register_model() again for each model class.
+            with warnings.catch_warnings():
+                warnings.filterwarnings(
+                    "ignore",
+                    message=r"Model '.*' was already registered",
+                    category=RuntimeWarning,
+                )
+                sandbox = sandbox_from_module(path.parent, handler_module, evaluated_modules)
+                scope = sandbox.execute()
+        except Exception as e:
+            results.append(
+                HandlerLoadResult(handler, name_and_class, handler_class, None, e, report=True)
+            )
+            continue
+
+        results.append(
+            HandlerLoadResult(handler, name_and_class, handler_class, scope, None, report=False)
+        )
+
+    # Re-register the AppConfig so that the freshly-created model classes are
+    # visible to Django's relation graph (needed for select_related, etc.).
+    register_plugin_app_config(name)
+
+    return results
+
+
 def load_or_reload_plugin(path: pathlib.Path) -> bool:
     """Given a path, load or reload a plugin."""
     log.info(f'Loading plugin at "{path}"')
@@ -805,7 +912,6 @@ def load_or_reload_plugin(path: pathlib.Path) -> bool:
                 # The default SQLite connection is read-only; swap to the writable
                 # one for schema initialisation and plugin migrations.
                 import django.db
-                from django.apps import apps as django_apps
 
                 original_default = django.db.connections["default"]
                 try:
@@ -846,93 +952,54 @@ def load_or_reload_plugin(path: pathlib.Path) -> bool:
 
             return False
 
+        # TODO when we encounter an exception here, disable the plugin in response
+        results = load_plugin_handlers(name, path, handlers)
+
         any_failed = False
         loaded_handler_count = 0
 
-        # Share evaluated_modules across all handlers in this plugin so that common
-        # submodules (like constants.py) are only evaluated and reloaded once, not
-        # once per handler.
-        evaluated_modules: dict[str, bool] = {}
-
-        # Clear stale model registrations before handler sandboxes re-execute model
-        # files.  Without this, lazy_related_operation resolves string references
-        # (e.g. through="StaffSpecialty") to class objects from the prior execution,
-        # causing model-identity mismatches in ManyToManyField through-model resolution.
-        from django.apps import apps as django_apps
-
-        from plugin_runner.installation import register_plugin_app_config
-
-        django_apps.all_models.pop(name, None)
-        django_apps.app_configs.pop(name, None)
-        django_apps.clear_cache()
-
-        for handler in handlers:
-            # TODO add class colon validation to existing schema validation
-            # TODO when we encounter an exception here, disable the plugin in response
-            try:
-                handler_module, handler_class = handler["class"].split(":")
-
-                handler_package = handler_module.split(".")[0]
-                if handler_package != name:
-                    log.error(
-                        f'Plugin "{name}" declares handler from foreign package '
-                        f'"{handler_package}" — skipping'
-                    )
-                    any_failed = True
-                    continue
-
-                name_and_class = f"{name}:{handler_module}:{handler_class}"
-            except ValueError as e:
-                log.exception(f'Unable to parse class for plugin "{name}": "{handler["class"]}"')
-                sentry_sdk.capture_exception(e)
-
+        for r in results:
+            if r.error is not None:
                 any_failed = True
-
+                if not r.report:
+                    log.error(f"{r.error} — skipping")
+                elif r.name_and_class is None:
+                    log.error(
+                        f'Unable to parse class for plugin "{name}": "{r.handler["class"]}"',
+                        exc_info=r.error,
+                    )
+                    sentry_sdk.capture_exception(r.error)
+                else:
+                    log.error(f"Error importing module '{r.name_and_class}'", exc_info=r.error)
+                    sentry_sdk.capture_exception(r.error)
                 continue
 
-            try:
-                # Suppress Django's "Model was already registered" RuntimeWarning.
-                # When importlib.reload re-imports model modules, Django's metaclass
-                # calls apps.register_model() again for each model class.
-                with warnings.catch_warnings():
-                    warnings.filterwarnings(
-                        "ignore",
-                        message=r"Model '.*' was already registered",
-                        category=RuntimeWarning,
-                    )
-                    sandbox = sandbox_from_module(path.parent, handler_module, evaluated_modules)
-                    result = sandbox.execute()
+            name_and_class = cast(str, r.name_and_class)
+            handler_class = cast(str, r.handler_class)
+            result = cast(dict, r.scope)
 
-                if name_and_class in LOADED_PLUGINS:
-                    log.info(f"Reloading handler '{name_and_class}'")
+            if name_and_class in LOADED_PLUGINS:
+                log.info(f"Reloading handler '{name_and_class}'")
 
-                    LOADED_PLUGINS[name_and_class]["active"] = True
+                LOADED_PLUGINS[name_and_class]["active"] = True
 
-                    LOADED_PLUGINS[name_and_class]["class"] = result[handler_class]
-                    LOADED_PLUGINS[name_and_class]["sandbox"] = result
-                    LOADED_PLUGINS[name_and_class]["secrets"] = secrets_json
-                    LOADED_PLUGINS[name_and_class]["namespace_config"] = namespace_config
-                else:
-                    log.info(f'Loading handler "{name_and_class}"')
+                LOADED_PLUGINS[name_and_class]["class"] = result[handler_class]
+                LOADED_PLUGINS[name_and_class]["sandbox"] = result
+                LOADED_PLUGINS[name_and_class]["secrets"] = secrets_json
+                LOADED_PLUGINS[name_and_class]["namespace_config"] = namespace_config
+            else:
+                log.info(f'Loading handler "{name_and_class}"')
 
-                    LOADED_PLUGINS[name_and_class] = {
-                        "active": True,
-                        "class": result[handler_class],
-                        "sandbox": result,
-                        "handler": handler,
-                        "secrets": secrets_json,
-                        "namespace_config": namespace_config,
-                    }
+                LOADED_PLUGINS[name_and_class] = {
+                    "active": True,
+                    "class": result[handler_class],
+                    "sandbox": result,
+                    "handler": r.handler,
+                    "secrets": secrets_json,
+                    "namespace_config": namespace_config,
+                }
 
-                loaded_handler_count += 1
-            except Exception as e:
-                log.exception(f"Error importing module '{name_and_class}'")
-                sentry_sdk.capture_exception(e)
-                any_failed = True
-
-        # Re-register the AppConfig so that the freshly-created model classes are
-        # visible to Django's relation graph (needed for select_related, etc.).
-        register_plugin_app_config(name)
+            loaded_handler_count += 1
 
         plugin_version = manifest_json.get("plugin_version", "unknown")
         total_handlers = len(handlers)

--- a/plugin_runner/tests/test_plugin_runner.py
+++ b/plugin_runner/tests/test_plugin_runner.py
@@ -38,6 +38,7 @@ from plugin_runner.plugin_runner import (
     PluginRunner,
     load_or_reload_plugin,
     load_plugin,
+    load_plugin_handlers,
     load_plugins,
     synchronize_plugins,
     synchronize_plugins_and_report_errors,
@@ -303,6 +304,67 @@ def test_load_plugin_logs_warning_when_handler_fails(
     # cross_plugin_thief declares one handler from a foreign package, so 0/1 should load.
     assert "cross_plugin_thief" in warning_messages[0]
     assert "0/1 handlers loaded successfully" in warning_messages[0]
+
+
+def _manifest_handlers(path: Path) -> list[dict[str, Any]]:
+    """Read the declared handlers from a plugin's manifest, as the runner does."""
+    components = json.loads((path / "CANVAS_MANIFEST.json").read_text())["components"]
+    return (
+        components.get("protocols", [])
+        + components.get("applications", [])
+        + components.get("handlers", [])
+    )
+
+
+@pytest.mark.parametrize("install_test_plugin", ["example_plugin"], indirect=True)
+def test_load_plugin_handlers_returns_success_results(install_test_plugin: Path) -> None:
+    """load_plugin_handlers returns a success result, with its executed scope, per handler."""
+    handlers = _manifest_handlers(install_test_plugin)
+
+    results = load_plugin_handlers(install_test_plugin.name, install_test_plugin, handlers)
+
+    assert len(results) == len(handlers)
+    assert all(r.error is None for r in results)
+    assert all(r.scope is not None for r in results)
+    assert all(r.name_and_class is not None for r in results)
+
+
+@pytest.mark.parametrize(
+    "install_test_plugin", ["test_module_forbidden_imports_plugin"], indirect=True
+)
+def test_load_plugin_handlers_reports_forbidden_import(install_test_plugin: Path) -> None:
+    """A forbidden module-level import surfaces as a reportable error result, and
+    load_plugin_handlers does not mutate global LOADED_PLUGINS.
+    """
+    before = set(LOADED_PLUGINS)
+    handlers = _manifest_handlers(install_test_plugin)
+
+    results = load_plugin_handlers(install_test_plugin.name, install_test_plugin, handlers)
+
+    failures = [r for r in results if r.error is not None]
+    assert failures
+    assert all(isinstance(r.error, ImportError) for r in failures)
+    assert all(r.report for r in failures)
+    assert all(r.scope is None for r in failures)
+    # purely diagnostic: no runtime registration side effects
+    assert set(LOADED_PLUGINS) == before
+
+
+@pytest.mark.parametrize("install_test_plugin", ["cross_plugin_thief"], indirect=True)
+def test_load_plugin_handlers_flags_foreign_package_without_reporting(
+    install_test_plugin: Path,
+) -> None:
+    """A handler declared from a foreign package is flagged as an error but not
+    marked for Sentry reporting (developer fault, not a runtime fault).
+    """
+    handlers = _manifest_handlers(install_test_plugin)
+
+    results = load_plugin_handlers(install_test_plugin.name, install_test_plugin, handlers)
+
+    foreign = [r for r in results if r.error is not None and not r.report]
+    assert foreign
+    assert all("foreign package" in str(r.error) for r in foreign)
+    assert all(r.name_and_class is None for r in foreign)
 
 
 @pytest.mark.parametrize("install_test_plugin", ["example_plugin"], indirect=True)

--- a/uv.lock
+++ b/uv.lock
@@ -2,6 +2,10 @@ version = 1
 revision = 3
 requires-python = ">=3.11, <3.15"
 
+[options]
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer-span = "P7D"
+
 [[package]]
 name = "annotated-types"
 version = "0.7.0"


### PR DESCRIPTION
Adds two layers of pre-deploy validation to the `canvas` CLI so plugin problems surface before install instead of as failures on the instance: a static on-disk layout check in `validate-manifest`, and a sandbox-load check that actually imports every handler the way the runner will.

## Background

The runner loads each handler by mapping its dotted module path to a file relative to the *parent* of the install directory (`plugin_runner.sandbox.sandbox_from_module`): a plugin installed at `plugins/<name>/` loads handler `<name>.routes.api` from `plugins/<name>/routes/api.py`. So the leading module segment is the plugin's own package (which must equal the manifest `name`) and the rest is a path *inside* the plugin directory — the same directory that holds `CANVAS_MANIFEST.json`.

A plugin scaffolded with `CANVAS_MANIFEST.json` in a parent directory *above* its package ends up with the package nested one level too deep (`<name>/<name>/routes/api.py` once installed). That layout passes manifest-schema validation and imports fine locally via `sys.path`, then fails to load on the instance with `ModuleNotFoundError: Could not load module "<name>.routes.api"`. We hit exactly this on a customer instance: the plugin loaded locally, passed `validate-manifest`, passed the import lint, and had a green test suite, but every deploy failed identically because the manifest sat one directory above the package.

## Layout check

`validate-manifest` now collects every declared handler class (`protocols` + `applications` + `handlers`, matching what the runner loads) and, for each, checks that the module file exists where the runner will look for it. If any don't resolve, it prints which classes and the path the runner expects, explains that `CANVAS_MANIFEST.json` must live inside the package directory, and exits non-zero. Because `canvas install` calls `validate-manifest`, this also gates installs.

## Sandbox-load check

A static file-exists check still can't catch a handler that imports a disallowed module or trips a RestrictedPython rule — those only surface when the runner sandbox-executes the module on the instance. This adds that check at validation time by reusing the runner's exact load path.

The per-handler sandbox-load loop (and the Django model-registration reset around it) is extracted out of `plugin_runner.load_or_reload_plugin` into a new pure-data `load_plugin_handlers(name, path, handlers)` that returns a result per handler (executed scope or the error raised) and mutates no global state. `load_or_reload_plugin` now consumes those results to populate `LOADED_PLUGINS` exactly as before, so runtime and validation can't drift on sandbox semantics. The existing runner load tests pass unchanged, which is the proof the refactor is behavior-preserving.

A new `canvas validate <plugin>` command runs the full pre-flight: `validate-manifest` (schema, tags, layout, unreferenced warnings) followed by sandbox-loading every handler, printing per-handler PASS/FAIL with the specific violation, and exiting non-zero on any failure. `validate-manifest` remains as the manifest-only command. `canvas install` now runs the sandbox-load step after `validate-manifest`, so violations are caught before upload. Validation puts the plugin's parent directory on `sys.path` before loading, mirroring how the runner makes installed plugins importable from `PLUGIN_DIRECTORY`, so intra-package imports and Django model registration resolve the way they will on the instance.

This catches import-time and compile-time sandbox violations. It does not catch disallowed attribute/item access inside a handler's `compute()` — RestrictedPython checks those when the line runs at request time, not at module import — so a green `canvas validate` means "imports cleanly under the sandbox," not "guaranteed sandbox-clean."

## Tests

Layout check: coverage for the all-resolve case, the misplaced-manifest (nested-package) case, the wrong-leading-package-name case, and the end-to-end `validate-manifest` failure. Updated the existing `plugin_with_manifest` fixture to actually create the handler file it references (previously it declared a handler with no backing file).

Sandbox-load: direct `load_plugin_handlers` tests for the success, forbidden-import (reportable error, no global mutation), and foreign-package (flagged but not Sentry-reported) cases; CLI tests that `canvas validate` passes a clean plugin, fails a disallowed-import plugin, and resolves intra-package imports. All `install` tests updated to mock the new step.

---

Companion prevention-side change (Studio agent now scaffolds the correct layout): canvas-medical/studio#97

## CI guard

Adds a `validate-example-plugins` job to `build-and-test.yml` that runs `canvas validate` (manifest checks + sandbox-load) on every `example-plugins/*/CANVAS_MANIFEST.json`. Previously nothing ran validation in CI at all, so the examples weren't guarded against this (or any other manifest/sandbox) regression. All current example plugins pass.
