### PR TITLE
fix(plugin-runner): retry transient install failures instead of disabling [KOALA-5810]

### DIFF
--- a/plugin_runner/exceptions.py
+++ b/plugin_runner/exceptions.py
@@ -24,6 +24,18 @@ class NamespaceWaitTimeout(PluginInstallationError):
     """
 
 
+class TransientPluginInstallationError(PluginInstallationError):
+    """Raised when install fails for a non-deterministic infra-level reason.
+
+    Wraps network errors during S3 download (e.g. ``requests.ConnectionError``,
+    ``requests.Timeout``) and database connection blips (e.g.
+    ``psycopg.InterfaceError``, ``psycopg.OperationalError``) — the kind of
+    failure that should clear up on a retry. Callers should retry with backoff
+    and must not auto-disable the plugin when they see this, because the
+    plugin's code itself is fine.
+    """
+
+
 class PluginUninstallationError(PluginError):
     """An exception raised when a plugin fails to uninstall."""
 

--- a/plugin_runner/installation.py
+++ b/plugin_runner/installation.py
@@ -55,11 +55,13 @@ MAX_TRANSIENT_INSTALL_ATTEMPTS = 3
 TRANSIENT_INSTALL_BACKOFF_SECONDS = 1.0
 
 # Exception classes treated as transient infra failures: network blips during
-# S3 download and database connection resets. The plugin's code is fine — a
-# retry should clear the failure.
+# S3 download (including streams interrupted mid-pull) and database connection
+# resets. The plugin's code is fine — a retry should clear the failure.
+# HTTPError is handled separately because it's only transient on 5xx status.
 _TRANSIENT_INSTALL_EXCEPTIONS: tuple[type[Exception], ...] = (
     requests.exceptions.ConnectionError,
     requests.exceptions.Timeout,
+    requests.exceptions.ChunkedEncodingError,
     psycopg.InterfaceError,
     psycopg.OperationalError,
 )
@@ -356,6 +358,20 @@ def install_plugin(plugin_name: str, attributes: PluginAttributes) -> None:
             f'Transient failure installing plugin "{plugin_name}", version '
             f"{attributes['version']}: {type(e).__name__}: {e}"
         ) from e
+    except requests.exceptions.HTTPError as e:
+        # 5xx from S3 (e.g. 503 SlowDown, 500 InternalError, 502/504) is a
+        # service-side blip — retry. 4xx (404 missing object, 403 forbidden)
+        # is deterministic and falls through to the PluginInstallationError
+        # path so the plugin is disabled as usual.
+        status = e.response.status_code if e.response is not None else None
+        if status is not None and status >= 500:
+            raise TransientPluginInstallationError(
+                f'Transient failure installing plugin "{plugin_name}", version '
+                f"{attributes['version']}: HTTP {status}: {e}"
+            ) from e
+        log.exception(f'Failed to install plugin "{plugin_name}", version {attributes["version"]}')
+        sentry_sdk.capture_exception(e)
+        raise PluginInstallationError() from e
     except PluginInstallationError:
         log.exception(f'Failed to install plugin "{plugin_name}", version {attributes["version"]}')
         raise

--- a/plugin_runner/installation.py
+++ b/plugin_runner/installation.py
@@ -3,11 +3,13 @@ import os
 import shutil
 import tarfile
 import tempfile
+import time
 from collections.abc import Generator
 from contextlib import contextmanager
 from pathlib import Path
 from typing import TypedDict
 
+import psycopg
 import requests
 import sentry_sdk
 from psycopg.rows import dict_row
@@ -20,6 +22,7 @@ from plugin_runner.exceptions import (
     NamespaceWaitTimeout,
     PluginInstallationError,
     PluginUninstallationError,
+    TransientPluginInstallationError,
 )
 from plugin_runner.namespace import (
     compute_models_hash,  # noqa: F401 — re-export
@@ -44,6 +47,22 @@ from settings import (
 
 # Plugin "packages" include this prefix in the database record for the plugin and the S3 bucket key.
 UPLOAD_TO_PREFIX = "plugins"
+
+# Retry budget for transient infra-level install failures (KOALA-5810).
+# 3 attempts at 1s/2s/4s backoff = 7s worst-case per plugin before giving up
+# and leaving the plugin enabled for the next sync pass to retry.
+MAX_TRANSIENT_INSTALL_ATTEMPTS = 3
+TRANSIENT_INSTALL_BACKOFF_SECONDS = 1.0
+
+# Exception classes treated as transient infra failures: network blips during
+# S3 download and database connection resets. The plugin's code is fine — a
+# retry should clear the failure.
+_TRANSIENT_INSTALL_EXCEPTIONS: tuple[type[Exception], ...] = (
+    requests.exceptions.ConnectionError,
+    requests.exceptions.Timeout,
+    psycopg.InterfaceError,
+    psycopg.OperationalError,
+)
 
 
 def clear_registered_models(plugin_name: str) -> None:
@@ -212,11 +231,13 @@ def install_plugin(plugin_name: str, attributes: PluginAttributes) -> None:
 
         plugin_installation_path = Path(PLUGIN_DIRECTORY) / plugin_name
 
-        # if plugin exists, first uninstall it
-        if plugin_installation_path.exists():
-            uninstall_plugin(plugin_name)
-
         with download_plugin(attributes["package"]) as plugin_file_path:
+            # Defer uninstalling the existing version until the new package is
+            # safely on local disk. A transient S3/network failure during
+            # download then leaves the running version in place (KOALA-5810).
+            if plugin_installation_path.exists():
+                uninstall_plugin(plugin_name)
+
             extract_plugin(plugin_file_path, plugin_installation_path)
 
         # Read the manifest first so we can decide whether to defer the
@@ -327,6 +348,14 @@ def install_plugin(plugin_name: str, attributes: PluginAttributes) -> None:
         # Transient bootstrap race — install_plugins logs this at WARNING.
         # Skip the ERROR-level traceback here to avoid contradictory severity.
         raise
+    except _TRANSIENT_INSTALL_EXCEPTIONS as e:
+        # Network blip during S3 download or DB connection reset. install_plugins
+        # logs this at WARNING and retries with backoff — skip the ERROR-level
+        # traceback here to avoid implying a permanent failure.
+        raise TransientPluginInstallationError(
+            f'Transient failure installing plugin "{plugin_name}", version '
+            f"{attributes['version']}: {type(e).__name__}: {e}"
+        ) from e
     except PluginInstallationError:
         log.exception(f'Failed to install plugin "{plugin_name}", version {attributes["version"]}')
         raise
@@ -415,29 +444,52 @@ def install_plugins() -> None:
         ) from e
 
     for plugin_name, attributes in enabled_plugins().items():
-        try:
-            install_plugin(plugin_name, attributes)
-        except NamespaceWaitTimeout as e:
-            # Bootstrap race: the schema manager hasn't created the namespace
-            # yet (e.g. index-1 container booted before index-0). Leave the
-            # plugin enabled so the next install pass — triggered by a
-            # pubsub event or a container restart — can complete the install.
-            log.warning(
-                f'Namespace wait timed out for plugin "{plugin_name}", version'
-                f" {attributes['version']}; plugin remains enabled and will be retried"
-            )
-            sentry_sdk.capture_exception(e)
-            continue
-        except PluginInstallationError as e:
-            disable_plugin(plugin_name)
+        for attempt in range(1, MAX_TRANSIENT_INSTALL_ATTEMPTS + 1):
+            try:
+                install_plugin(plugin_name, attributes)
+                break
+            except NamespaceWaitTimeout as e:
+                # Bootstrap race: the schema manager hasn't created the namespace
+                # yet (e.g. index-1 container booted before index-0). Leave the
+                # plugin enabled so the next install pass — triggered by a
+                # pubsub event or a container restart — can complete the install.
+                log.warning(
+                    f'Namespace wait timed out for plugin "{plugin_name}", version'
+                    f" {attributes['version']}; plugin remains enabled and will be retried"
+                )
+                sentry_sdk.capture_exception(e)
+                break
+            except TransientPluginInstallationError as e:
+                if attempt < MAX_TRANSIENT_INSTALL_ATTEMPTS:
+                    backoff = TRANSIENT_INSTALL_BACKOFF_SECONDS * (2 ** (attempt - 1))
+                    log.warning(
+                        f'Transient failure installing plugin "{plugin_name}", version'
+                        f" {attributes['version']} (attempt {attempt}/"
+                        f"{MAX_TRANSIENT_INSTALL_ATTEMPTS}); retrying in {backoff}s: {e}"
+                    )
+                    time.sleep(backoff)
+                    continue
+                # Retries exhausted. Leave the plugin enabled so the next sync
+                # pass picks it up — a transient failure shouldn't require a
+                # human to re-enable the plugin.
+                log.warning(
+                    f'Transient failure installing plugin "{plugin_name}", version'
+                    f" {attributes['version']} after {MAX_TRANSIENT_INSTALL_ATTEMPTS}"
+                    f" attempts; plugin remains enabled and will be retried on the"
+                    f" next sync: {e}"
+                )
+                sentry_sdk.capture_exception(e)
+                break
+            except PluginInstallationError as e:
+                disable_plugin(plugin_name)
 
-            log.error(
-                f'Installation failed for plugin "{plugin_name}", version {attributes["version"]};'
-                " the plugin has been disabled"
-            )
+                log.error(
+                    f'Installation failed for plugin "{plugin_name}", version'
+                    f" {attributes['version']}; the plugin has been disabled"
+                )
 
-            sentry_sdk.capture_exception(e)
+                sentry_sdk.capture_exception(e)
 
-            continue
+                break
 
     return None

--- a/plugin_runner/tests/test_plugin_installer.py
+++ b/plugin_runner/tests/test_plugin_installer.py
@@ -298,15 +298,7 @@ def test_install_plugins_does_not_disable_on_transient_download_failure(
     mocker: MockerFixture,
     transient_exc: Exception,
 ) -> None:
-    """KOALA-5810: transient HTTP failures during S3 download must not auto-disable.
-
-    Both vida (`vitals_visualizer` v0.35.1, urllib3 HTTP-retry traceback) and
-    doctronic (`note_webhook_notification` v0.0.1, ConnectionResetError during
-    S3 download) hit this path: `download_plugin` raised a transient transport
-    error, `install_plugin` wrapped it to PluginInstallationError, and the
-    `install_plugins` loop hard-disabled the plugin via raw SQL — leaving it
-    disabled for ~32h (vida) and ~8 days (doctronic) until a human re-enabled.
-    """
+    """Ensures that transient download errors do not result in a plugin being disabled."""
     mock_plugins = {
         "transient_plugin": PluginAttributes(
             version="1.0", package="plugins/transient_plugin.tar.gz", secrets={}
@@ -330,14 +322,7 @@ def test_install_plugins_does_not_disable_on_transient_download_failure(
 def test_install_plugins_does_not_disable_on_transient_db_interface_error(
     mocker: MockerFixture,
 ) -> None:
-    """KOALA-5810: transient psycopg InterfaceError must not auto-disable.
-
-    Mirrors the vida (production) trigger: `InterfaceError('connection already
-    closed')` surfaced from a DB op during install. `install_plugin`'s catch-all
-    wraps it to PluginInstallationError and the loop disables the plugin. A
-    transient DB connection blip should be retried, not turned into a sticky
-    `is_enabled=False` that requires manual intervention.
-    """
+    """Ensures that transient database errors do not result in a plugin being disabled."""
     plugin_name = "db_blip_plugin"
     mock_plugins = {
         plugin_name: PluginAttributes(
@@ -385,7 +370,7 @@ def test_install_plugins_does_not_disable_on_transient_db_interface_error(
 def test_install_plugin_preserves_existing_files_on_transient_download_failure(
     mocker: MockerFixture,
 ) -> None:
-    """KOALA-5810: a transient download failure must not destroy the working version.
+    """A transient download failure must not destroy the working version.
 
     `install_plugin` defers the rmtree of the existing plugin directory until
     after the new package is on local disk. So when `download_plugin` raises

--- a/plugin_runner/tests/test_plugin_installer.py
+++ b/plugin_runner/tests/test_plugin_installer.py
@@ -5,10 +5,16 @@ import tempfile
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import psycopg
 import pytest
+import requests
 from pytest_mock import MockerFixture
 
-from plugin_runner.exceptions import NamespaceWaitTimeout, PluginInstallationError
+from plugin_runner.exceptions import (
+    NamespaceWaitTimeout,
+    PluginInstallationError,
+    TransientPluginInstallationError,
+)
 from plugin_runner.installation import (
     PluginAttributes,
     _extract_rows_to_dict,
@@ -272,6 +278,201 @@ def test_install_plugins_disables_on_other_install_errors(
 
     install_plugins()
 
+    mock_disable.assert_called_once_with("broken_plugin")
+
+
+@pytest.mark.parametrize(
+    "transient_exc",
+    [
+        pytest.param(
+            requests.exceptions.ConnectionError("[Errno 104] Connection reset by peer"),
+            id="connection-reset-during-s3-download",
+        ),
+        pytest.param(
+            requests.exceptions.Timeout("Read timed out"),
+            id="http-timeout-during-s3-download",
+        ),
+    ],
+)
+def test_install_plugins_does_not_disable_on_transient_download_failure(
+    mocker: MockerFixture,
+    transient_exc: Exception,
+) -> None:
+    """KOALA-5810: transient HTTP failures during S3 download must not auto-disable.
+
+    Both vida (`vitals_visualizer` v0.35.1, urllib3 HTTP-retry traceback) and
+    doctronic (`note_webhook_notification` v0.0.1, ConnectionResetError during
+    S3 download) hit this path: `download_plugin` raised a transient transport
+    error, `install_plugin` wrapped it to PluginInstallationError, and the
+    `install_plugins` loop hard-disabled the plugin via raw SQL — leaving it
+    disabled for ~32h (vida) and ~8 days (doctronic) until a human re-enabled.
+    """
+    mock_plugins = {
+        "transient_plugin": PluginAttributes(
+            version="1.0", package="plugins/transient_plugin.tar.gz", secrets={}
+        ),
+    }
+    mocker.patch("plugin_runner.installation.enabled_plugins", return_value=mock_plugins)
+    mock_download = mocker.patch(
+        "plugin_runner.installation.download_plugin",
+        side_effect=transient_exc,
+    )
+    mock_disable = mocker.patch("plugin_runner.installation.disable_plugin")
+    mocker.patch("plugin_runner.installation.time.sleep")
+
+    install_plugins()
+
+    mock_disable.assert_not_called()
+    # Retried up to the configured budget before giving up.
+    assert mock_download.call_count == 3
+
+
+def test_install_plugins_does_not_disable_on_transient_db_interface_error(
+    mocker: MockerFixture,
+) -> None:
+    """KOALA-5810: transient psycopg InterfaceError must not auto-disable.
+
+    Mirrors the vida (production) trigger: `InterfaceError('connection already
+    closed')` surfaced from a DB op during install. `install_plugin`'s catch-all
+    wraps it to PluginInstallationError and the loop disables the plugin. A
+    transient DB connection blip should be retried, not turned into a sticky
+    `is_enabled=False` that requires manual intervention.
+    """
+    plugin_name = "db_blip_plugin"
+    mock_plugins = {
+        plugin_name: PluginAttributes(
+            version="1.0", package=f"plugins/{plugin_name}.tar.gz", secrets={}
+        ),
+    }
+
+    def fake_extract(plugin_file_path: Path, plugin_installation_path: Path) -> None:
+        plugin_installation_path.mkdir(parents=True, exist_ok=True)
+        (plugin_installation_path / "CANVAS_MANIFEST.json").write_text(
+            json.dumps(
+                {
+                    "name": plugin_name,
+                    "custom_data": {"namespace": "org__blip", "access": "read_write"},
+                }
+            )
+        )
+
+    mock_download = MagicMock()
+    mock_download.__enter__ = MagicMock(return_value=Path("unused.tar.gz"))
+    mock_download.__exit__ = MagicMock(return_value=None)
+
+    mocker.patch("plugin_runner.installation.enabled_plugins", return_value=mock_plugins)
+    mocker.patch("plugin_runner.installation.download_plugin", return_value=mock_download)
+    mocker.patch("plugin_runner.installation.extract_plugin", side_effect=fake_extract)
+    mocker.patch("plugin_runner.installation.install_plugin_secrets")
+    mocker.patch("plugin_runner.installation.clear_registered_models")
+    mocker.patch("plugin_runner.installation.is_schema_manager", return_value=True)
+    mock_setup = mocker.patch(
+        "plugin_runner.installation.setup_read_write_namespace",
+        side_effect=psycopg.InterfaceError("connection already closed"),
+    )
+    mock_disable = mocker.patch("plugin_runner.installation.disable_plugin")
+    mocker.patch("plugin_runner.installation.time.sleep")
+
+    try:
+        install_plugins()
+        mock_disable.assert_not_called()
+        # Retried up to the configured budget before giving up.
+        assert mock_setup.call_count == 3
+    finally:
+        uninstall_plugin(plugin_name)
+
+
+def test_install_plugin_preserves_existing_files_on_transient_download_failure(
+    mocker: MockerFixture,
+) -> None:
+    """KOALA-5810: a transient download failure must not destroy the working version.
+
+    `install_plugin` defers the rmtree of the existing plugin directory until
+    after the new package is on local disk. So when `download_plugin` raises
+    `requests.ConnectionError`, the previously-loaded plugin remains intact
+    and the worker keeps serving it until the next install pass retries.
+    """
+    from settings import PLUGIN_DIRECTORY
+
+    plugin_name = "preserved_plugin"
+    plugins_dir = Path(PLUGIN_DIRECTORY)
+    plugins_dir.mkdir(parents=True, exist_ok=True)
+    plugin_path = plugins_dir / plugin_name
+    plugin_path.mkdir(parents=True, exist_ok=True)
+    sentinel = plugin_path / "PLUGIN.py"
+    sentinel.write_text("# old version still running")
+
+    mocker.patch(
+        "plugin_runner.installation.download_plugin",
+        side_effect=requests.exceptions.ConnectionError("[Errno 104] Connection reset by peer"),
+    )
+
+    try:
+        with pytest.raises(PluginInstallationError):
+            install_plugin(
+                plugin_name,
+                PluginAttributes(
+                    version="2.0", package=f"plugins/{plugin_name}.tar.gz", secrets={}
+                ),
+            )
+
+        assert plugin_path.exists(), "old plugin directory must remain on disk"
+        assert sentinel.read_text() == "# old version still running"
+    finally:
+        uninstall_plugin(plugin_name)
+
+
+def test_install_plugins_retries_and_succeeds_after_transient_failure(
+    mocker: MockerFixture,
+) -> None:
+    """A transient failure on attempt N should be retried and recover on attempt N+1."""
+    mock_plugins = {
+        "flaky_plugin": PluginAttributes(
+            version="1.0", package="plugins/flaky_plugin.tar.gz", secrets={}
+        ),
+    }
+    mocker.patch("plugin_runner.installation.enabled_plugins", return_value=mock_plugins)
+    mock_install = mocker.patch(
+        "plugin_runner.installation.install_plugin",
+        side_effect=[
+            TransientPluginInstallationError("connection reset"),
+            None,
+        ],
+    )
+    mock_disable = mocker.patch("plugin_runner.installation.disable_plugin")
+    mocker.patch("plugin_runner.installation.time.sleep")
+
+    install_plugins()
+
+    assert mock_install.call_count == 2
+    mock_disable.assert_not_called()
+
+
+def test_install_plugins_disables_on_deterministic_install_error_without_retry(
+    mocker: MockerFixture,
+) -> None:
+    """Deterministic failures (bad manifest, invalid format) still disable on first try.
+
+    Regression guard: the new retry budget for transient errors must not extend
+    to deterministic failures, which would waste time before the inevitable
+    disable.
+    """
+    mock_plugins = {
+        "broken_plugin": PluginAttributes(
+            version="1.0", package="plugins/broken_plugin.tar.gz", secrets={}
+        ),
+    }
+    mocker.patch("plugin_runner.installation.enabled_plugins", return_value=mock_plugins)
+    mock_install = mocker.patch(
+        "plugin_runner.installation.install_plugin",
+        side_effect=PluginInstallationError("manifest invalid"),
+    )
+    mock_disable = mocker.patch("plugin_runner.installation.disable_plugin")
+    mocker.patch("plugin_runner.installation.time.sleep")
+
+    install_plugins()
+
+    assert mock_install.call_count == 1
     mock_disable.assert_called_once_with("broken_plugin")
 
 

--- a/plugin_runner/tests/test_plugin_installer.py
+++ b/plugin_runner/tests/test_plugin_installer.py
@@ -281,6 +281,13 @@ def test_install_plugins_disables_on_other_install_errors(
     mock_disable.assert_called_once_with("broken_plugin")
 
 
+def _http_error(status: int) -> requests.exceptions.HTTPError:
+    """Build a requests.HTTPError carrying a response with the given status."""
+    response = MagicMock()
+    response.status_code = status
+    return requests.exceptions.HTTPError(f"{status} Server Error", response=response)
+
+
 @pytest.mark.parametrize(
     "transient_exc",
     [
@@ -291,6 +298,20 @@ def test_install_plugins_disables_on_other_install_errors(
         pytest.param(
             requests.exceptions.Timeout("Read timed out"),
             id="http-timeout-during-s3-download",
+        ),
+        pytest.param(
+            requests.exceptions.ChunkedEncodingError(
+                "Connection broken: InvalidChunkLength(got length b'', 0 bytes read)"
+            ),
+            id="chunked-encoding-error-mid-stream",
+        ),
+        pytest.param(
+            _http_error(503),
+            id="s3-503-slow-down",
+        ),
+        pytest.param(
+            _http_error(500),
+            id="s3-500-internal-error",
         ),
     ],
 )
@@ -431,6 +452,42 @@ def test_install_plugins_retries_and_succeeds_after_transient_failure(
 
     assert mock_install.call_count == 2
     mock_disable.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "status",
+    [
+        pytest.param(403, id="forbidden"),
+        pytest.param(404, id="not-found"),
+    ],
+)
+def test_install_plugins_disables_on_4xx_http_error_without_retry(
+    mocker: MockerFixture,
+    status: int,
+) -> None:
+    """4xx HTTP errors from S3 are deterministic — disable on first try.
+
+    Regression guard: only 5xx responses count as transient. A 403 or 404
+    from S3 means the package object is missing or unauthorized — retrying
+    won't help, and we shouldn't keep the plugin enabled in that state.
+    """
+    mock_plugins = {
+        "broken_plugin": PluginAttributes(
+            version="1.0", package="plugins/broken_plugin.tar.gz", secrets={}
+        ),
+    }
+    mocker.patch("plugin_runner.installation.enabled_plugins", return_value=mock_plugins)
+    mock_download = mocker.patch(
+        "plugin_runner.installation.download_plugin",
+        side_effect=_http_error(status),
+    )
+    mock_disable = mocker.patch("plugin_runner.installation.disable_plugin")
+    mocker.patch("plugin_runner.installation.time.sleep")
+
+    install_plugins()
+
+    assert mock_download.call_count == 1
+    mock_disable.assert_called_once_with("broken_plugin")
 
 
 def test_install_plugins_disables_on_deterministic_install_error_without_retry(


### PR DESCRIPTION
## Summary

Fixes [KOALA-5810](https://canvasmedical.atlassian.net/browse/KOALA-5810): the plugin-runner hard-disables plugins on transient DB/network failures during `synchronize_plugins` with no retry, requiring a human to re-enable.

Two production incidents reinforced the defect:
- **vida** (`vitals_visualizer` v0.35.1): auto-disabled by a urllib3 HTTP-retry traceback during S3 download; stayed disabled ~32 hours.
- **doctronic** (`note_webhook_notification` v0.0.1, surfaced via Pylon #27534): auto-disabled by `ConnectionResetError [Errno 104]` during S3 download; stayed disabled ~8 days.

In both cases the plugin's code was fine — only the install path failed. The runner's disable handler (`installation.py: install_plugins → disable_plugin`) wrote `is_enabled=false` via raw SQL, bypassing the ORM and leaving no `django_admin_log` audit trail.

This change mirrors the precedent set by [#1685 / KOALA-5448](https://github.com/canvas-medical/canvas-plugins/pull/1685) (which fixed the namespace-wait-timeout variant) and extends it to the transient HTTP and DB-connection variants.

## What changed

- **New exception**: `TransientPluginInstallationError(PluginInstallationError)` — sibling to `NamespaceWaitTimeout`.
- **`install_plugin()`**: wraps `requests.ConnectionError`, `requests.Timeout`, `psycopg.InterfaceError`, and `psycopg.OperationalError` into the new transient exception. Deterministic failures (bad manifest, invalid format, validation errors) continue to surface as `PluginInstallationError`.
- **`install_plugin()` rmtree reorder**: the existing-version rmtree is now deferred until after `download_plugin` returns successfully, so a failed download no longer destroys the running version on disk.
- **`install_plugins()`**: per-plugin retry loop, 3 attempts with 1s/2s/4s exponential backoff. If all attempts fail, the plugin stays `is_enabled=true` and the next sync pass (pubsub reload or container restart) picks it up. `NamespaceWaitTimeout` and deterministic `PluginInstallationError` paths are unchanged.

## Test plan

- [x] `plugin_runner/tests/test_plugin_installer.py` — 6 new/updated tests, all 14 in the file pass:
  - `[connection-reset-during-s3-download]` — doctronic scenario, no disable, 3 retry attempts.
  - `[http-timeout-during-s3-download]` — HTTP timeout variant, no disable, 3 retries.
  - `test_install_plugins_does_not_disable_on_transient_db_interface_error` — vida `InterfaceError` scenario, no disable, 3 retries.
  - `test_install_plugin_preserves_existing_files_on_transient_download_failure` — covers the rmtree reorder: the old plugin files remain intact on disk after a failed download.
  - `test_install_plugins_retries_and_succeeds_after_transient_failure` — happy-path: first attempt transient-fails, second attempt succeeds, no disable.
  - `test_install_plugins_disables_on_deterministic_install_error_without_retry` — regression guard: deterministic failures still disable on first try (no wasted retry budget).
- [x] Full `plugin_runner/` test suite: 2035 passed.
- [ ] Soak in non-prod: trigger a synthetic transient failure (e.g., temporarily block S3 egress on a worker) and confirm the plugin remains enabled and reloads on the next sync tick.

_Generated from Support Stack investigation._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[KOALA-5810]: https://canvasmedical.atlassian.net/browse/KOALA-5810?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ