### PR TITLE
fix(sandbox): make sandbox compatible with RestrictedPython 8.2

### DIFF
--- a/plugin_runner/sandbox.py
+++ b/plugin_runner/sandbox.py
@@ -857,9 +857,13 @@ class Sandbox:
             # they are NOT used by the implementation => No need to worry here.
             # Instead ast.c creates 'AugAssign' nodes, which can be visited.
             if isinstance(node.ctx, ast.Load):
+                # `node.slice` is already a plain `ast.expr` on Python 3.9+
+                # (we require >=3.11), so no `transform_slice` wrapper is
+                # needed — RestrictedPython 8.2 removed the helper for the
+                # same reason. See the upstream `visit_Subscript` for parity.
                 new_node = ast.Call(
                     func=ast.Name("_getitem_", ast.Load()),
-                    args=[node.value, self.transform_slice(node.slice)],
+                    args=[node.value, node.slice],
                     keywords=[],
                 )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ dependencies = [
   "rapidfuzz>=3.10.1,<4",
   "redis>=5.0.4,<6",
   "requests",
-  "restrictedpython>=8.0",
+  "restrictedpython>=8.0,<8.3",
   "sentry-sdk>=2.33.2",
   "statsd>=4.0.1,<5",
   "stripe>=14.1.0",

--- a/uv.lock
+++ b/uv.lock
@@ -163,7 +163,7 @@ requires-dist = [
     { name = "rapidfuzz", specifier = ">=3.10.1,<4" },
     { name = "redis", specifier = ">=5.0.4,<6" },
     { name = "requests" },
-    { name = "restrictedpython", specifier = ">=8.0" },
+    { name = "restrictedpython", specifier = ">=8.0,<8.3" },
     { name = "sentry-sdk", specifier = ">=2.33.2" },
     { name = "statsd", specifier = ">=4.0.1,<5" },
     { name = "stripe", specifier = ">=14.1.0" },
@@ -1941,11 +1941,11 @@ wheels = [
 
 [[package]]
 name = "restrictedpython"
-version = "8.0"
+version = "8.2"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/76/f3/3cfd684abf456f536a842e4fabe1ca360a8e94d1fc329f261c34c1d98825/restrictedpython-8.0.tar.gz", hash = "sha256:3af2312bc67e5fced887fb85b006c89861da72488128b155beea81eb6a0a9b24", size = 448747, upload-time = "2025-01-23T07:15:53.14Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/97/04/7314639eab9edd57b5c8f6e158a558f5a5a65453c37a51fb8f9ecc1d112e/restrictedpython-8.2.tar.gz", hash = "sha256:b835c2ff87d71b76f6d8b129096cc5a1e893bf01839ab802ba47a4129f1bdfe4", size = 449323, upload-time = "2026-05-29T06:27:57.285Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/df/31/b33804f873742ab20c8ed82a75652bf60a6205116dfec8bb092a6ebef084/RestrictedPython-8.0-py3-none-any.whl", hash = "sha256:ed3d894efd7d6cac0a5f13f75583b8458378d400d7dd4c083b59233eba85fe69", size = 27238, upload-time = "2025-01-23T07:15:50.428Z" },
+    { url = "https://files.pythonhosted.org/packages/35/59/b2778bfafcc37fdfd87c02702bbfc5753c58c28c7eb82999b7b49ec6e0e7/restrictedpython-8.2-py3-none-any.whl", hash = "sha256:6ff69e2fe06674bfe88943f17f2ce8353a9bc743ee37ea7bec38ff8b4851afd1", size = 27176, upload-time = "2026-05-29T06:27:55.651Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Fixes [KOALA-5840](https://canvasmedical.atlassian.net/browse/KOALA-5840).

RestrictedPython 8.2 ([released 2026-05-29](https://pypi.org/project/RestrictedPython/8.2/)) dropped Python 3.9 support and, with it, the `transform_slice` helper on `RestrictingNodeTransformer`. Our `Sandbox.Transformer.visit_Subscript` (`plugin_runner/sandbox.py:862`) still called `self.transform_slice(node.slice)`, so any sandbox compile of plugin code containing a slice expression (`arr[a:b]`, `s[::-1]`, etc.) raised:

```
AttributeError: 'Transformer' object has no attribute 'transform_slice'
```

Releases were only unaffected because `uv.lock` had pinned 8.0 since January. The next routine `uv lock --upgrade` would have silently shipped a broken sandbox.

## Why `transform_slice` is gone, and why removing the call is safe

The helper bridged a Python 3.8 → 3.9 AST shape change:
- **3.8**: `Subscript.slice` could be an `ast.Index` (wrapping the real expression) or an `ast.Slice` — neither was usable as a `Call` arg.
- **3.9**: `ast.Index` was removed; `Subscript.slice` is just a plain `ast.expr`.

The 8.1 implementation showed this clearly — the method's first branch was a no-op fast path:

```python
def transform_slice(self, slice_):
    if isinstance(slice_, ast.expr):
        # Python 3.9+
        return slice_           # already the right shape
    elif isinstance(slice_, ast.Index):
        return slice_.value     # Python 3.8 only
    elif isinstance(slice_, ast.Slice):
        # ...build a slice(a, b, c) Call node — Python 3.8 only
```

Once 8.2 dropped 3.9 (so the minimum became 3.10), only the no-op branch was reachable, and the upstream maintainers deleted the method as dead code. Upstream's own 8.2 `visit_Subscript` just passes `node.slice` to `_getitem_` directly. Our project's `requires-python = ">=3.11,<3.15"` means the no-op branch was the only one we ever hit either — so dropping the call is behaviorally a no-op for us.

## Change

- `plugin_runner/sandbox.py` — `args=[node.value, self.transform_slice(node.slice)]` → `args=[node.value, node.slice]`, matching upstream 8.2.
- `pyproject.toml` — `restrictedpython>=8.0` → `restrictedpython>=8.0,<8.3` (upper bound caps unreviewed major-version drift).
- `uv.lock` — resolved version moves 8.0 → 8.2.

## Test plan

- [x] Confirmed `RestrictingNodeTransformer` in the new venv genuinely lacks `transform_slice` (`hasattr(...) == False`).
- [x] `plugin_runner/tests/test_sandbox.py` — 1712 passed under RestrictedPython 8.2 (covers slice/subscript behavior heavily).
- [x] Full `plugin_runner/` suite — 2029 passed under 8.2.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[KOALA-5840]: https://canvasmedical.atlassian.net/browse/KOALA-5840?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ