### PR TITLE
fix: introduces retries for plugin runner plugin installations

### DIFF
--- a/plugin_runner/installation.py
+++ b/plugin_runner/installation.py
@@ -51,8 +51,10 @@ UPLOAD_TO_PREFIX = "plugins"
 # PluginInstallationError, and disable the customer's plugin with no retry. We
 # now retry the download a few times with exponential backoff before treating
 # the failure as terminal.
-MAX_DOWNLOAD_ATTEMPTS = int(os.getenv("PLUGIN_DOWNLOAD_MAX_ATTEMPTS", "3"))
-DOWNLOAD_RETRY_BACKOFF_SECONDS = float(os.getenv("PLUGIN_DOWNLOAD_RETRY_BACKOFF", "0.5"))
+# Clamp the env-driven knobs: at least one attempt (so the retry loop always
+# runs and `last_error` is always bound) and a non-negative backoff.
+MAX_DOWNLOAD_ATTEMPTS = max(1, int(os.getenv("PLUGIN_DOWNLOAD_MAX_ATTEMPTS", "3")))
+DOWNLOAD_RETRY_BACKOFF_SECONDS = max(0.0, float(os.getenv("PLUGIN_DOWNLOAD_RETRY_BACKOFF", "0.5")))
 
 # Transient network failures worth retrying. requests surfaces a connection
 # reset as a ConnectionError, e.g.

--- a/plugin_runner/installation.py
+++ b/plugin_runner/installation.py
@@ -3,6 +3,7 @@ import os
 import shutil
 import tarfile
 import tempfile
+import time
 from collections.abc import Generator
 from contextlib import contextmanager
 from pathlib import Path
@@ -44,6 +45,65 @@ from settings import (
 
 # Plugin "packages" include this prefix in the database record for the plugin and the S3 bucket key.
 UPLOAD_TO_PREFIX = "plugins"
+
+# KOALA-4328: a single transient connection reset while downloading a plugin
+# package (e.g. during a deploy/restart) used to bubble up, get wrapped in a
+# PluginInstallationError, and disable the customer's plugin with no retry. We
+# now retry the download a few times with exponential backoff before treating
+# the failure as terminal.
+MAX_DOWNLOAD_ATTEMPTS = int(os.getenv("PLUGIN_DOWNLOAD_MAX_ATTEMPTS", "3"))
+DOWNLOAD_RETRY_BACKOFF_SECONDS = float(os.getenv("PLUGIN_DOWNLOAD_RETRY_BACKOFF", "0.5"))
+
+# Transient network failures worth retrying. requests surfaces a connection
+# reset as a ConnectionError, e.g.
+# "('Connection aborted.', ConnectionResetError(104, 'Connection reset by peer'))",
+# and a body read interrupted mid-stream as a ChunkedEncodingError. This mirrors
+# the transient set the Redis client already retries on (see
+# plugin_runner.get_client). HTTP 5xx responses are also transient but are
+# handled separately because they surface via raise_for_status as HTTPError.
+_TRANSIENT_DOWNLOAD_ERRORS = (
+    requests.exceptions.ConnectionError,
+    requests.exceptions.Timeout,
+    requests.exceptions.ChunkedEncodingError,
+)
+
+
+def _download_request_with_retries(
+    method: str, url: str, headers: dict[str, str]
+) -> requests.Response:
+    """Perform the plugin download request, retrying transient network failures.
+
+    Retries cover connection-level errors and S3 5xx responses (e.g. the
+    "503 Service Unavailable"/"SlowDown" S3 throttles during a deploy). A 4xx is
+    deterministic (expired signature, missing object), so it fails fast rather
+    than burning the retry budget. After ``MAX_DOWNLOAD_ATTEMPTS`` the last
+    transient error is re-raised so the install genuinely fails (and the plugin
+    is disabled) — but only once we've actually tried.
+    """
+    last_error: Exception
+    for attempt in range(1, MAX_DOWNLOAD_ATTEMPTS + 1):
+        try:
+            response = requests.request(method=method, url=url, headers=headers)
+            response.raise_for_status()
+            return response
+        except requests.exceptions.HTTPError as e:
+            status = e.response.status_code if e.response is not None else None
+            if status is None or status < 500:
+                raise  # deterministic client error — retrying won't help
+            last_error = e
+        except _TRANSIENT_DOWNLOAD_ERRORS as e:
+            last_error = e
+
+        if attempt < MAX_DOWNLOAD_ATTEMPTS:
+            backoff = DOWNLOAD_RETRY_BACKOFF_SECONDS * (2 ** (attempt - 1))
+            log.warning(
+                f"Transient error downloading plugin package "
+                f"(attempt {attempt}/{MAX_DOWNLOAD_ATTEMPTS}): {last_error}; "
+                f"retrying in {backoff:.1f}s"
+            )
+            time.sleep(backoff)
+
+    raise last_error
 
 
 def clear_registered_models(plugin_name: str) -> None:
@@ -196,10 +256,9 @@ def download_plugin(plugin_package: str) -> Generator[Path, None, None]:
         prefix_dir.mkdir()  # create an intermediate directory reflecting the prefix
         download_path = Path(temp_dir) / plugin_package
 
-        with open(download_path, "wb") as download_file:
-            response = requests.request(method=method, url=f"https://{host}{path}", headers=headers)
-            response.raise_for_status()
+        response = _download_request_with_retries(method, f"https://{host}{path}", headers)
 
+        with open(download_path, "wb") as download_file:
             download_file.write(response.content)
 
         yield download_path

--- a/plugin_runner/tests/test_plugin_installer.py
+++ b/plugin_runner/tests/test_plugin_installer.py
@@ -6,8 +6,10 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
+import requests
 from pytest_mock import MockerFixture
 
+from plugin_runner import installation
 from plugin_runner.exceptions import NamespaceWaitTimeout, PluginInstallationError
 from plugin_runner.installation import (
     PluginAttributes,
@@ -286,3 +288,141 @@ def test_download() -> None:
             assert plugin_path.exists()
             assert plugin_path.read_bytes() == b"some content in a file"
         mock_request.assert_called_once()
+
+
+def test_download_retries_on_transient_connection_error(mocker: MockerFixture) -> None:
+    """A transient connection reset during download must be retried, not fatal (KOALA-4328).
+
+    Before the fix a single ConnectionResetError (surfaced by requests as a
+    ConnectionError) during a deploy/restart would propagate, get wrapped in
+    PluginInstallationError, and disable the customer's plugin. The download
+    should instead retry and recover when the next attempt succeeds.
+    """
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.content = b"recovered content"
+
+    transient = requests.exceptions.ConnectionError(
+        "('Connection aborted.', ConnectionResetError(104, 'Connection reset by peer'))"
+    )
+
+    # Don't actually sleep between retries.
+    mocker.patch("time.sleep")
+
+    with patch(
+        "requests.request",
+        side_effect=[transient, mock_response],
+    ) as mock_request:
+        with download_plugin("plugins/plugin1.tar.gz") as plugin_path:
+            assert plugin_path.exists()
+            assert plugin_path.read_bytes() == b"recovered content"
+
+        # First attempt reset the connection; the retry succeeded.
+        assert mock_request.call_count == 2
+
+
+def test_download_gives_up_after_exhausting_retries(mocker: MockerFixture) -> None:
+    """When every download attempt resets, the error propagates after the configured retries.
+
+    Exhausting retries is the only path that should still fail the install (and
+    ultimately disable the plugin) — but only after we've genuinely tried.
+    """
+    transient = requests.exceptions.ConnectionError(
+        "('Connection aborted.', ConnectionResetError(104, 'Connection reset by peer'))"
+    )
+
+    mocker.patch("time.sleep")
+
+    with (
+        patch("requests.request", side_effect=transient) as mock_request,
+        pytest.raises(requests.exceptions.ConnectionError),
+        download_plugin("plugins/plugin1.tar.gz"),
+    ):
+        pass
+
+    assert mock_request.call_count == installation.MAX_DOWNLOAD_ATTEMPTS
+
+
+def test_download_retries_on_s3_5xx(mocker: MockerFixture) -> None:
+    """An S3 5xx (e.g. "503 Service Unavailable"/SlowDown throttle) is transient (KOALA-4328).
+
+    Observed in production: a deploy-time 503 from S3 surfaced via
+    raise_for_status as an HTTPError and disabled the customer's plugin.
+    """
+    failing = MagicMock()
+    failing.status_code = 503
+    failing.raise_for_status.side_effect = requests.exceptions.HTTPError(
+        "503 Server Error: Service Unavailable", response=failing
+    )
+
+    ok = MagicMock()
+    ok.status_code = 200
+    ok.content = b"recovered content"
+    ok.raise_for_status.return_value = None
+
+    mocker.patch("time.sleep")
+
+    with patch("requests.request", side_effect=[failing, ok]) as mock_request:
+        with download_plugin("plugins/plugin1.tar.gz") as plugin_path:
+            assert plugin_path.read_bytes() == b"recovered content"
+
+        assert mock_request.call_count == 2
+
+
+def test_download_does_not_retry_on_4xx(mocker: MockerFixture) -> None:
+    """A 4xx (e.g. expired signature, missing object) is deterministic and must fail fast."""
+    forbidden = MagicMock()
+    forbidden.status_code = 403
+    forbidden.raise_for_status.side_effect = requests.exceptions.HTTPError(
+        "403 Client Error: Forbidden", response=forbidden
+    )
+
+    mocker.patch("time.sleep")
+
+    with (
+        patch("requests.request", side_effect=[forbidden, forbidden]) as mock_request,
+        pytest.raises(requests.exceptions.HTTPError),
+        download_plugin("plugins/plugin1.tar.gz"),
+    ):
+        pass
+
+    # No retry — we gave up after the first deterministic failure.
+    assert mock_request.call_count == 1
+
+
+def test_install_plugins_keeps_plugin_enabled_when_download_recovers(
+    mocker: MockerFixture,
+) -> None:
+    """End-to-end (KOALA-4328): a transient download reset that recovers must not disable the plugin.
+
+    This is the customer-facing guarantee — a connection reset during a deploy
+    should never silently disable an otherwise-healthy plugin.
+    """
+    plugin_name = "resilient_plugin"
+    mock_plugins = {
+        plugin_name: PluginAttributes(
+            version="1.0", package=f"plugins/{plugin_name}.tar.gz", secrets={}
+        ),
+    }
+    tarball = _create_tarball(plugin_name)
+
+    mocker.patch("plugin_runner.installation.enabled_plugins", return_value=mock_plugins)
+    mocker.patch("time.sleep")
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.content = tarball.read_bytes()
+
+    transient = requests.exceptions.ConnectionError(
+        "('Connection aborted.', ConnectionResetError(104, 'Connection reset by peer'))"
+    )
+
+    mock_disable = mocker.patch("plugin_runner.installation.disable_plugin")
+
+    try:
+        with patch("requests.request", side_effect=[transient, mock_response]):
+            install_plugins()
+
+        mock_disable.assert_not_called()
+    finally:
+        uninstall_plugin(plugin_name)

--- a/plugin_runner/tests/test_plugin_installer.py
+++ b/plugin_runner/tests/test_plugin_installer.py
@@ -343,6 +343,28 @@ def test_download_gives_up_after_exhausting_retries(mocker: MockerFixture) -> No
     assert mock_request.call_count == installation.MAX_DOWNLOAD_ATTEMPTS
 
 
+def test_download_single_attempt_raises_real_error(mocker: MockerFixture) -> None:
+    """With a single attempt the loop still runs once and surfaces the real error.
+
+    Guards the boundary behind the max(1, ...) clamp on MAX_DOWNLOAD_ATTEMPTS: an
+    empty retry loop must never reach `raise last_error` with last_error unbound
+    (which would raise a confusing UnboundLocalError instead).
+    """
+    mocker.patch.object(installation, "MAX_DOWNLOAD_ATTEMPTS", 1)
+    mocker.patch("time.sleep")
+
+    transient = requests.exceptions.ConnectionError("Connection reset by peer")
+
+    with (
+        patch("requests.request", side_effect=transient) as mock_request,
+        pytest.raises(requests.exceptions.ConnectionError),
+        download_plugin("plugins/plugin1.tar.gz"),
+    ):
+        pass
+
+    assert mock_request.call_count == 1
+
+
 def test_download_retries_on_s3_5xx(mocker: MockerFixture) -> None:
     """An S3 5xx (e.g. "503 Service Unavailable"/SlowDown throttle) is transient (KOALA-4328).
 


### PR DESCRIPTION
https://canvasmedical.atlassian.net/browse/KOALA-4328

Retry transient plugin-package download failures before disabling a plugin.

A single transient failure while downloading a plugin from S3 — a connection reset, an S3 5xx, or a body read interrupted mid-stream — would bubble up, get wrapped in `PluginInstallationError`, and disable the customer's plugin with no retry. On a deploy/restart, every container re-downloads at once, so a brief blip silently took plugins offline (KOALA-4328). Production logs confirm both failure modes still occur fleet-wide — connection resets and S3 `503 Service Unavailable` responses, each disabling plugins during deploys.

`download_plugin` now retries transient errors with exponential backoff (3 attempts, configurable via `PLUGIN_DOWNLOAD_MAX_ATTEMPTS` / `PLUGIN_DOWNLOAD_RETRY_BACKOFF`): connection errors / timeouts / `ChunkedEncodingError`, and S3 **5xx** responses. A **4xx** (expired signature, missing object) still fails fast, and exhausting retries still disables the plugin — genuine failures are unchanged.

5 new tests in `test_plugin_installer.py` (recovery, exhaustion, 5xx retry, 4xx fail-fast, end-to-end "stays enabled"). Full suite green.

