### PR TITLE
feat: add practice_location_override to PrescribeCommand.send

### DIFF
--- a/canvas_sdk/commands/commands/prescribe.py
+++ b/canvas_sdk/commands/commands/prescribe.py
@@ -217,7 +217,7 @@ class PrescribeCommand(_ReviewableCommandMixin, _SendableCommandMixin, _BaseComm
     def send(self, practice_location_override: UUID | str | None = None) -> Effect:
         """Fire the send effect, optionally overriding the prescriber's practice location.
 
-        When ``practice_location_override`` (a PracticeLocation id) is provided, the 
+        When ``practice_location_override`` (a PracticeLocation id) is provided, the
         outgoing NewRx uses that location's address as the prescriber address.
         This lets a plugin ship white-bagged medications to a chosen office per prescription.
         """

--- a/canvas_sdk/commands/commands/prescribe.py
+++ b/canvas_sdk/commands/commands/prescribe.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 from decimal import Decimal
 from enum import Enum
 from typing import Any
+from uuid import UUID
 
 from pydantic import Field, conlist
 from pydantic_core import InitErrorDetails
@@ -13,6 +14,7 @@ from canvas_sdk.effects import Effect
 from canvas_sdk.effects.compound_medications.compound_medication import (
     CompoundMedication as CompoundMedicationEffect,
 )
+from canvas_sdk.v1.data import PracticeLocation
 from canvas_sdk.v1.data.compound_medication import CompoundMedication as CompoundMedicationModel
 
 
@@ -210,6 +212,30 @@ class PrescribeCommand(_ReviewableCommandMixin, _SendableCommandMixin, _BaseComm
                     "data": processed_data,
                 }
             ),
+        )
+
+    def send(self, practice_location_override: UUID | str | None = None) -> Effect:
+        """Fire the send effect, optionally overriding the prescriber's practice location.
+
+        When ``practice_location_override`` (a PracticeLocation id) is provided, the
+        outgoing NewRx uses that location's address as the prescriber address instead of
+        the note location (KOALA-4853) or the prescriber's primary location. This lets a
+        plugin ship white-bagged medications to a chosen office per prescription
+        (KOALA-6258).
+        """
+        self._validate_before_effect("send")
+
+        payload: dict[str, Any] = {"command": self.command_uuid}
+        if practice_location_override is not None:
+            if not PracticeLocation.objects.filter(id=practice_location_override).exists():
+                raise ValueError(
+                    f"Practice location with ID {practice_location_override} does not exist."
+                )
+            payload["practice_location_override"] = str(practice_location_override)
+
+        return Effect(
+            type=f"SEND_{self.constantized_key()}_COMMAND",
+            payload=json.dumps(payload),
         )
 
 

--- a/canvas_sdk/commands/commands/prescribe.py
+++ b/canvas_sdk/commands/commands/prescribe.py
@@ -217,11 +217,9 @@ class PrescribeCommand(_ReviewableCommandMixin, _SendableCommandMixin, _BaseComm
     def send(self, practice_location_override: UUID | str | None = None) -> Effect:
         """Fire the send effect, optionally overriding the prescriber's practice location.
 
-        When ``practice_location_override`` (a PracticeLocation id) is provided, the
-        outgoing NewRx uses that location's address as the prescriber address instead of
-        the note location (KOALA-4853) or the prescriber's primary location. This lets a
-        plugin ship white-bagged medications to a chosen office per prescription
-        (KOALA-6258).
+        When ``practice_location_override`` (a PracticeLocation id) is provided, the 
+        outgoing NewRx uses that location's address as the prescriber address.
+        This lets a plugin ship white-bagged medications to a chosen office per prescription.
         """
         self._validate_before_effect("send")
 

--- a/canvas_sdk/tests/commands/test_prescribe.py
+++ b/canvas_sdk/tests/commands/test_prescribe.py
@@ -1,0 +1,42 @@
+import json
+from unittest.mock import patch
+from uuid import uuid4
+
+import pytest
+
+from canvas_generated.messages.effects_pb2 import EffectType
+from canvas_sdk.commands.commands.prescribe import PrescribeCommand
+
+
+def test_send_without_override_omits_key() -> None:
+    """send() with no override produces the unchanged command-only payload."""
+    cmd = PrescribeCommand(command_uuid="cmd-456")
+
+    effect = cmd.send()
+
+    assert effect.type == EffectType.SEND_PRESCRIBE_COMMAND
+    assert json.loads(effect.payload) == {"command": "cmd-456"}
+
+
+def test_send_with_override_includes_key() -> None:
+    """send() with a valid override adds practice_location_override to the payload."""
+    location_id = str(uuid4())
+    cmd = PrescribeCommand(command_uuid="cmd-456")
+
+    with patch("canvas_sdk.v1.data.PracticeLocation.objects") as mock_pl:
+        mock_pl.filter.return_value.exists.return_value = True
+        effect = cmd.send(practice_location_override=location_id)
+
+    payload = json.loads(effect.payload)
+    assert payload["command"] == "cmd-456"
+    assert payload["practice_location_override"] == location_id
+
+
+def test_send_with_invalid_override_raises() -> None:
+    """A nonexistent override id raises ValueError before an effect is produced."""
+    cmd = PrescribeCommand(command_uuid="cmd-456")
+
+    with patch("canvas_sdk.v1.data.PracticeLocation.objects") as mock_pl:
+        mock_pl.filter.return_value.exists.return_value = False
+        with pytest.raises(ValueError, match="does not exist"):
+            cmd.send(practice_location_override=str(uuid4()))


### PR DESCRIPTION
[KOALA-6258](https://canvasmedical.atlassian.net/browse/KOALA-6258)

## Summary

Adds a `practice_location_override` argument to `PrescribeCommand.send()` so a plugin can choose the practice location that drives the prescriber address on an outgoing Surescripts NewRx. This enables white-bagging workflows where a provider working across multiple offices needs a medication shipped to a specific site, chosen per prescription.

## Implementation

`PrescribeCommand.send()` now accepts an optional `practice_location_override` (a PracticeLocation id). When provided, it validates the location exists and includes it in the `SEND_PRESCRIBE_COMMAND` effect payload; when omitted, the payload is unchanged. Home-app resolves the id and swaps the prescriber address on the outgoing NewRx (handled in the corresponding canvas PR).

The override applies only to plugin-initiated sends of non-controlled prescriptions.

[KOALA-6258]: https://canvasmedical.atlassian.net/browse/KOALA-6258?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ