### PR TITLE
feat: add support for multiple linked objects in AddTask effect

### DIFF
--- a/canvas_sdk/effects/task/__init__.py
+++ b/canvas_sdk/effects/task/__init__.py
@@ -1,8 +1,17 @@
-from .task import AddTask, AddTaskComment, TaskMetadata, TaskPriority, TaskStatus, UpdateTask
+from .task import (
+    AddTask,
+    AddTaskComment,
+    LinkedObject,
+    TaskMetadata,
+    TaskPriority,
+    TaskStatus,
+    UpdateTask,
+)
 
 __all__ = __exports__ = (
     "AddTask",
     "AddTaskComment",
+    "LinkedObject",
     "TaskPriority",
     "TaskStatus",
     "TaskMetadata",

--- a/canvas_sdk/effects/task/task.py
+++ b/canvas_sdk/effects/task/task.py
@@ -3,7 +3,7 @@ from enum import Enum, StrEnum
 from typing import Any, Self, cast
 from uuid import UUID
 
-from pydantic import model_validator
+from pydantic import BaseModel, model_validator
 from pydantic_core import InitErrorDetails
 
 from canvas_sdk.effects.base import EffectType, _BaseEffect
@@ -30,6 +30,8 @@ class AddTask(_BaseEffect):
 
         REFERRAL = "REFERRAL"
         IMAGING = "IMAGING"
+        NOTE = "NOTE"
+        CLAIM = "CLAIM"
 
     class Meta:
         effect_type = EffectType.CREATE_TASK
@@ -46,6 +48,7 @@ class AddTask(_BaseEffect):
     labels: list[str] = []
     linked_object_id: str | UUID | None = None
     linked_object_type: LinkableObjectType | None = None
+    linked_objects: list["LinkedObject"] = []
     author_id: str | UUID | None = None
 
     @model_validator(mode="after")
@@ -80,7 +83,17 @@ class AddTask(_BaseEffect):
                 "id": str(self.linked_object_id) if self.linked_object_id else None,
                 "type": self.linked_object_type.value if self.linked_object_type else None,
             },
+            "linked_objects": [
+                {"id": str(obj.id), "type": obj.type.value} for obj in self.linked_objects
+            ],
         }
+
+
+class LinkedObject(BaseModel):
+    """A single object linked to a Task."""
+
+    id: str | UUID
+    type: AddTask.LinkableObjectType
 
 
 class AddTaskComment(_BaseEffect):
@@ -178,6 +191,7 @@ class TaskMetadata(BaseMetadata):
 __exports__ = (
     "AddTask",
     "AddTaskComment",
+    "LinkedObject",
     "TaskPriority",
     "TaskStatus",
     "TaskMetadata",

--- a/canvas_sdk/tests/effects/test_task.py
+++ b/canvas_sdk/tests/effects/test_task.py
@@ -5,7 +5,7 @@ from uuid import uuid4
 import pytest
 from pydantic_core import ValidationError
 
-from canvas_sdk.effects.task import AddTask, TaskStatus, UpdateTask
+from canvas_sdk.effects.task import AddTask, LinkedObject, TaskStatus, UpdateTask
 from canvas_sdk.v1.data.task import TaskPriority
 
 
@@ -127,6 +127,48 @@ def test_task_effects_reject_invalid_priority(task_cls: type, invalid_value: Any
 
     errors = exc_info.value.errors()
     assert any("priority" in str(e).lower() for e in errors)
+
+
+def test_add_task_linked_objects_defaults_to_empty(valid_add_task_data: dict[str, Any]) -> None:
+    """Test that linked_objects defaults to an empty list."""
+    task = AddTask(**valid_add_task_data)
+
+    assert task.linked_objects == []
+    assert task.values["linked_objects"] == []
+
+
+def test_add_task_with_multiple_linked_objects(valid_add_task_data: dict[str, Any]) -> None:
+    """Test creating a task with multiple linked objects, accepting dicts and models."""
+    referral_id = str(uuid4())
+    note_id = str(uuid4())
+    valid_add_task_data["linked_objects"] = [
+        {"id": referral_id, "type": "REFERRAL"},
+        LinkedObject(id=note_id, type=AddTask.LinkableObjectType.NOTE),
+    ]
+
+    task = AddTask(**valid_add_task_data)
+    values = task.values
+
+    assert values["linked_objects"] == [
+        {"id": referral_id, "type": "REFERRAL"},
+        {"id": note_id, "type": "NOTE"},
+    ]
+
+
+def test_add_task_rejects_invalid_linked_object_type(valid_add_task_data: dict[str, Any]) -> None:
+    """Test that an invalid linked object type is rejected."""
+    valid_add_task_data["linked_objects"] = [{"id": str(uuid4()), "type": "BOGUS"}]
+
+    with pytest.raises(ValidationError) as exc_info:
+        AddTask(**valid_add_task_data)
+
+    assert any("linked_objects" in str(e).lower() for e in exc_info.value.errors())
+
+
+def test_linked_object_uses_add_task_linkable_object_type() -> None:
+    """Test that LinkedObject validates its type against AddTask.LinkableObjectType."""
+    linked_object = LinkedObject(id=str(uuid4()), type=AddTask.LinkableObjectType.CLAIM)
+    assert linked_object.type is AddTask.LinkableObjectType.CLAIM
 
 
 def test_update_task_clears_priority_explicitly() -> None:

--- a/plugin_runner/allowed-module-imports.json
+++ b/plugin_runner/allowed-module-imports.json
@@ -844,6 +844,7 @@
   "canvas_sdk.effects.task": [
     "AddTask",
     "AddTaskComment",
+    "LinkedObject",
     "TaskMetadata",
     "TaskPriority",
     "TaskStatus",
@@ -852,6 +853,7 @@
   "canvas_sdk.effects.task.task": [
     "AddTask",
     "AddTaskComment",
+    "LinkedObject",
     "TaskMetadata",
     "TaskPriority",
     "TaskStatus",


### PR DESCRIPTION
<!-- ## Title Guidelines

A title always has a prefix and a subject.

### Prefix
Make sure the title is prefixed with one of the following:

| Prefix | When to use |
|--------|-------------|
| `feat:`     | New feature |
| `fix:`      | Bug fix |
| `docs:`     | Documentation only changes |
| `style:`    | Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc) |
| `refactor:` | Code changes that neither fixes a bug nor adds a feature |
| `perf:`     | Code change that improves performance |
| `test:`     | Adding missing or correcting existing tests |
| `chore:`    | Changes to the build process or auxiliary tools and libraries such as documentation generation, ci, etc |

### Subject

Ensure the subject contains succinct description of the change.
* Use the imperative, present tense: "change", not "changed" nor "changes"
* Don’t capitalize first letter
* No dot (.) at the end
-->
https://canvasmedical.atlassian.net/browse/KOALA-6240

This pr adds support for linking multiple objects to a task. it also adds support for linking Note and Claim types