### PR TITLE
feat: add supplemental oxygen field to the vitals command

### DIFF
--- a/canvas_sdk/commands/commands/vitals.py
+++ b/canvas_sdk/commands/commands/vitals.py
@@ -37,6 +37,12 @@ class VitalsCommand(BaseCommand):
         IRREGULARLY_IRREGULAR = 1
         REGULARLY_IRREGULAR = 2
 
+    class SupplementalOxygen(Enum):
+        # LOINC LL4908-1 answer codes.
+        CONTINUOUS_HIGH_FLOW = "LA28684-1"
+        CONTINUOUS_LOW_FLOW = "LA28685-8"
+        INTERMITTENT = "LA28686-6"
+
     height: conint(ge=10, le=108) | None = None  # type: ignore[valid-type]
     weight_lbs: conint(ge=1, le=1500) | None = None  # type: ignore[valid-type]
     weight_oz: int | None = None
@@ -50,6 +56,7 @@ class VitalsCommand(BaseCommand):
     pulse_rhythm: PulseRhythm | None = None
     respiration_rate: conint(ge=6, le=60) | None = None  # type: ignore[valid-type]
     oxygen_saturation: conint(ge=60, le=100) | None = None  # type: ignore[valid-type]
+    supplemental_oxygen: SupplementalOxygen | None = None
     note: constr(max_length=150) | None = None  # type: ignore[valid-type]
 
 

--- a/canvas_sdk/tests/commands/test_commands.py
+++ b/canvas_sdk/tests/commands/test_commands.py
@@ -888,3 +888,29 @@ def test_vitals_body_temperature_float_in_originate_payload() -> None:
     effect = command.originate()
     payload = json.loads(effect.payload)
     assert payload["data"]["body_temperature"] == 98.6
+
+
+def test_vitals_supplemental_oxygen_accepts_enum_value() -> None:
+    """Test that supplemental_oxygen accepts a SupplementalOxygen enum member."""
+    command = VitalsCommand(
+        note_uuid="test_uuid",
+        supplemental_oxygen=VitalsCommand.SupplementalOxygen.CONTINUOUS_HIGH_FLOW,
+    )
+    assert command.supplemental_oxygen == VitalsCommand.SupplementalOxygen.CONTINUOUS_HIGH_FLOW
+
+
+def test_vitals_supplemental_oxygen_defaults_to_none() -> None:
+    """Test that supplemental_oxygen defaults to None."""
+    command = VitalsCommand(note_uuid="test_uuid")
+    assert command.supplemental_oxygen is None
+
+
+def test_vitals_supplemental_oxygen_in_originate_payload() -> None:
+    """Test that a selected supplemental_oxygen serializes as its enum value."""
+    command = VitalsCommand(
+        note_uuid="test_uuid",
+        supplemental_oxygen=VitalsCommand.SupplementalOxygen.INTERMITTENT,
+    )
+    effect = command.originate()
+    payload = json.loads(effect.payload)
+    assert payload["data"]["supplemental_oxygen"] == "LA28686-6"


### PR DESCRIPTION
INTERNAL TRACKING: https://canvasmedical.atlassian.net/browse/KOALA-6634

This pull request adds support for capturing and serializing supplemental oxygen usage in the `VitalsCommand`. The main changes include introducing a new `SupplementalOxygen` enum with LOINC answer codes, updating the `VitalsCommand` model to include this field, and adding comprehensive tests to ensure correct behavior and serialization.

**VitalsCommand model updates:**

* Added a `SupplementalOxygen` enum (with LOINC codes) for capturing supplemental oxygen usage (`canvas_sdk/commands/commands/vitals.py`).
* Added a new `supplemental_oxygen` field to the `VitalsCommand` model, allowing it to accept values from the new enum (`canvas_sdk/commands/commands/vitals.py`).

**Testing:**

* Added tests to verify that `supplemental_oxygen` accepts enum values, defaults to `None`, and serializes correctly in the originate payload (`canvas_sdk/tests/commands/test_commands.py`).

<!-- ## Title Guidelines

A title always has a prefix and a subject.

### Prefix
Make sure the title is prefixed with one of the following:

| Prefix | When to use |
|--------|-------------|
| `feat:`     | New feature |
| `fix:`      | Bug fix |
| `docs:`     | Documentation only changes |
| `style:`    | Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc) |
| `refactor:` | Code changes that neither fixes a bug nor adds a feature |
| `perf:`     | Code change that improves performance |
| `test:`     | Adding missing or correcting existing tests |
| `chore:`    | Changes to the build process or auxiliary tools and libraries such as documentation generation, ci, etc |

### Subject

Ensure the subject contains succinct description of the change.
* Use the imperative, present tense: "change", not "changed" nor "changes"
* Don’t capitalize first letter
* No dot (.) at the end
-->
