### PR TITLE
feat(data): add RefillRequest data model

### DIFF
--- a/canvas_sdk/tests/v1/data/test_refill_request.py
+++ b/canvas_sdk/tests/v1/data/test_refill_request.py
@@ -1,0 +1,30 @@
+"""Tests for RefillRequest models and querysets."""
+
+from canvas_sdk.v1.data import RefillRequest as ExportedRefillRequest
+from canvas_sdk.v1.data.refill_request import RefillRequest, RefillRequestCoding
+
+
+def test_refill_request_manager_omits_deleted_filter() -> None:
+    """RefillRequest is not an AuditedModel and its view has no `deleted` column, so its
+    manager must not inject a ``deleted=False`` filter. Compiling the query would raise
+    ``FieldError: Cannot resolve keyword 'deleted'`` if the wrong manager were used.
+    """
+    sql = str(RefillRequest.objects.all().query)
+    assert "deleted" not in sql.lower()
+
+
+def test_refill_request_patient_filter_compiles() -> None:
+    """A patient-scoped query builds valid SQL without referencing `deleted`."""
+    sql = str(RefillRequest.objects.filter(patient__id="pat-1").query)
+    assert "deleted" not in sql.lower()
+    assert "patient" in sql.lower()
+
+
+def test_refill_request_is_exported() -> None:
+    """RefillRequest is re-exported from canvas_sdk.v1.data."""
+    assert ExportedRefillRequest is RefillRequest
+
+
+def test_refill_request_coding_relates_to_refill_request() -> None:
+    """RefillRequestCoding points back at RefillRequest via the codings relation."""
+    assert RefillRequestCoding._meta.get_field("refill_request").related_model is RefillRequest

--- a/canvas_sdk/v1/data/__init__.py
+++ b/canvas_sdk/v1/data/__init__.py
@@ -180,6 +180,7 @@ from .questionnaire import (
 )
 from .reason_for_visit import ReasonForVisitSettingCoding
 from .referral import Referral, ReferralReport, ReferralReportCoding, ReferralReview
+from .refill_request import RefillRequest, RefillRequestCoding
 from .service_provider import ServiceProvider
 from .snapshot import Snapshot, SnapshotImage
 from .specialty_report_template import (
@@ -388,6 +389,8 @@ __all__ = __exports__ = (
     "ReferralReport",
     "ReferralReportCoding",
     "ReferralReview",
+    "RefillRequest",
+    "RefillRequestCoding",
     "ResponseOption",
     "ResponseOptionSet",
     "ServiceProvider",

--- a/canvas_sdk/v1/data/prescription.py
+++ b/canvas_sdk/v1/data/prescription.py
@@ -132,10 +132,9 @@ class Prescription(IdentifiableModel, AuditedModel):
         max_length=1, choices=PrescriptionResponse, null=True, blank=True
     )
     reason_code = models.CharField(max_length=3, null=True, blank=True)
-    # TODO: uncomment when RefillRequest is added to Data Module
-    # refill_request = models.ForeignKey(
-    #     "v1.RefillRequest", on_delete=models.CASCADE, null=True, blank=True, related_name="response"
-    # )
+    refill_request = models.ForeignKey(
+        "v1.RefillRequest", on_delete=models.CASCADE, null=True, blank=True, related_name="response"
+    )
     related_refill = models.OneToOneField("self", on_delete=models.CASCADE, null=True, blank=True)
     is_epcs = models.BooleanField(null=True, default=False)
 

--- a/canvas_sdk/v1/data/refill_request.py
+++ b/canvas_sdk/v1/data/refill_request.py
@@ -3,7 +3,6 @@ from typing import cast
 from django.db import models
 
 from canvas_sdk.v1.data.base import (
-    BaseModelManager,
     BaseQuerySet,
     ForPatientQuerySetMixin,
     IdentifiableModel,
@@ -16,16 +15,16 @@ class RefillRequestQuerySet(ForPatientQuerySetMixin, BaseQuerySet):
     """RefillRequestQuerySet."""
 
 
-RefillRequestManager = BaseModelManager.from_queryset(RefillRequestQuerySet)
-
-
 class RefillRequest(TimestampedModel, IdentifiableModel):
     """RefillRequest."""
 
     class Meta:
         db_table = "canvas_sdk_data_api_refillrequest_001"
 
-    objects = cast(RefillRequestQuerySet, RefillRequestManager())
+    # Plain Manager (not BaseModelManager): RefillRequest is not an AuditedModel and
+    # has no `deleted` column, so BaseModelManager's deleted=False filter would raise
+    # FieldError on every query. Mirrors ReferralReport (also TimestampedModel-only).
+    objects = cast(RefillRequestQuerySet, models.Manager.from_queryset(RefillRequestQuerySet)())
 
     patient = models.ForeignKey(
         "v1.Patient", on_delete=models.DO_NOTHING, related_name="refill_requests", null=True

--- a/canvas_sdk/v1/data/refill_request.py
+++ b/canvas_sdk/v1/data/refill_request.py
@@ -1,0 +1,52 @@
+from typing import cast
+
+from django.db import models
+
+from canvas_sdk.v1.data.base import (
+    BaseModelManager,
+    BaseQuerySet,
+    ForPatientQuerySetMixin,
+    IdentifiableModel,
+    TimestampedModel,
+)
+from canvas_sdk.v1.data.coding import Coding
+
+
+class RefillRequestQuerySet(ForPatientQuerySetMixin, BaseQuerySet):
+    """RefillRequestQuerySet."""
+
+
+RefillRequestManager = BaseModelManager.from_queryset(RefillRequestQuerySet)
+
+
+class RefillRequest(TimestampedModel, IdentifiableModel):
+    """RefillRequest."""
+
+    class Meta:
+        db_table = "canvas_sdk_data_api_refillrequest_001"
+
+    objects = cast(RefillRequestQuerySet, RefillRequestManager())
+
+    patient = models.ForeignKey(
+        "v1.Patient", on_delete=models.DO_NOTHING, related_name="refill_requests", null=True
+    )
+    staff = models.ForeignKey(
+        "v1.Staff", on_delete=models.DO_NOTHING, related_name="refill_requests", null=True
+    )
+    message_id = models.CharField(max_length=35, blank=True, default="")
+    ignored = models.BooleanField(default=False)
+    content = models.JSONField(default=dict)
+
+
+class RefillRequestCoding(Coding):
+    """RefillRequestCoding."""
+
+    class Meta:
+        db_table = "canvas_sdk_data_api_refillrequestcoding_001"
+
+    refill_request = models.ForeignKey(
+        RefillRequest, on_delete=models.DO_NOTHING, related_name="codings"
+    )
+
+
+__exports__ = ("RefillRequest", "RefillRequestCoding")

--- a/plugin_runner/allowed-module-imports.json
+++ b/plugin_runner/allowed-module-imports.json
@@ -1240,6 +1240,8 @@
     "ReferralReport",
     "ReferralReportCoding",
     "ReferralReview",
+    "RefillRequest",
+    "RefillRequestCoding",
     "ResponseOption",
     "ResponseOptionSet",
     "ServiceProvider",
@@ -1654,6 +1656,10 @@
     "ReferralReport",
     "ReferralReportCoding",
     "ReferralReportQuerySet"
+  ],
+  "canvas_sdk.v1.data.refill_request": [
+    "RefillRequest",
+    "RefillRequestCoding"
   ],
   "canvas_sdk.v1.data.report_template_base": [
     "BaseReportTemplate",

--- a/uv.lock
+++ b/uv.lock
@@ -2,6 +2,10 @@ version = 1
 revision = 3
 requires-python = ">=3.11, <3.15"
 
+[options]
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer-span = "P7D"
+
 [[package]]
 name = "annotated-types"
 version = "0.7.0"


### PR DESCRIPTION
INTERNAL TRACKING: https://canvasmedical.atlassian.net/browse/KOALA-6505


This adds the `RefillRequest` and `RefillRequestCoding` SDK data models under `canvas_sdk/v1/data/refill_request.py`, following the existing conventions in `prescription.py` and `medication.py`: `RefillRequest` extends `TimestampedModel` + `IdentifiableModel` with a `ForPatientQuerySetMixin` queryset, and `RefillRequestCoding` extends `Coding` the same way `MedicationCoding` does. `RefillRequest` maps `patient`, `staff`, `message_id`, `ignored`, and `content` — the columns exposed by the backing home-app view. Both models are exported from `canvas_sdk/v1/data/__init__.py` alongside the other `v1.data` exports.

This also uncomments the `Prescription.refill_request` foreign key in `prescription.py`, which was left as a TODO pending this model's existence.

This is the companion PR to the canvas home-app PR that adds the backing `RefillRequest`/`RefillRequestCoding` data-module database views — see that PR for the view definitions this model reads from.

Validation:
- `uv run python -c "..."` import smoke test for `RefillRequest`, `RefillRequestCoding`, the `v1.data` re-export, and `Prescription` — passes
- `uv run pytest canvas_sdk/tests/v1/data/` (171 tests) and a broader `-k "data or prescription or refill"` sweep — all passing, no regressions
- `ruff check`, `ruff format --check`, `mypy`, and the full `prek` hook suite (including the `update-allowed-imports` generator, which picked up the new module) — all passing
- No dedicated `RefillRequest` model test was added, since the queryset only composes existing, already-tested mixins (`ForPatientQuerySetMixin`) with no new behavior to assert; the model's correctness is exercised by the import/load test and the `prescription.py` test suite covering the new FK

Authored by Claude + Beau.

---

**Update — addressed review feedback:** Cerberus correctly flagged that `RefillRequest` wired up `BaseModelManager`, whose `get_queryset()` filters `deleted=False` — but `RefillRequest` is not an `AuditedModel` and its view has no `deleted` column, so every query would have raised `FieldError`. Fixed to use a plain `models.Manager.from_queryset(...)` (matching the sibling non-audited `ReferralReport`), and added a query-compilation regression test that would have caught it. The `codecov/project` red was a CI artifact-download flake (ECONNRESET) with `codecov/patch` green; the new push re-runs CI.