### PR TITLE
fix: enforce max length for today_assessment field in the diagnose command

### DIFF
--- a/canvas_sdk/commands/commands/diagnose.py
+++ b/canvas_sdk/commands/commands/diagnose.py
@@ -16,7 +16,7 @@ class DiagnoseCommand(_BaseCommand):
     )
     background: str | None = None
     approximate_date_of_onset: date | None = None
-    today_assessment: str | None = None
+    today_assessment: str | None = Field(default=None, max_length=2048)
 
 
 __exports__ = ("DiagnoseCommand",)

--- a/canvas_sdk/tests/commands/test_commands.py
+++ b/canvas_sdk/tests/commands/test_commands.py
@@ -16,6 +16,7 @@ from canvas_sdk.commands import (
     AssessCommand,
     ChartSectionReviewCommand,
     CustomCommand,
+    DiagnoseCommand,
     FamilyHistoryCommand,
     GoalCommand,
     InstructCommand,
@@ -914,3 +915,42 @@ def test_vitals_supplemental_oxygen_in_originate_payload() -> None:
     effect = command.originate()
     payload = json.loads(effect.payload)
     assert payload["data"]["supplemental_oxygen"] == "LA28686-6"
+
+
+def test_diagnose_today_assessment_accepts_max_length() -> None:
+    """Test that today_assessment accepts a value at the 2048 character limit."""
+    command = DiagnoseCommand(note_uuid="test_uuid", today_assessment="a" * 2048)
+    assert command.today_assessment == "a" * 2048
+
+
+def test_diagnose_today_assessment_rejects_above_max_length() -> None:
+    """Test that today_assessment rejects a value over the 2048 character limit."""
+    with pytest.raises(ValidationError):
+        DiagnoseCommand(note_uuid="test_uuid", today_assessment="a" * 2049)
+
+
+def test_diagnose_today_assessment_rejects_above_max_length_on_assignment() -> None:
+    """Test that today_assessment is validated when assigned after construction."""
+    command = DiagnoseCommand(note_uuid="test_uuid")
+    with pytest.raises(ValidationError):
+        command.today_assessment = "a" * 2049
+
+
+def test_diagnose_today_assessment_allows_none() -> None:
+    """Test that today_assessment can be None."""
+    command = DiagnoseCommand(note_uuid="test_uuid", today_assessment=None)
+    assert command.today_assessment is None
+
+
+def test_diagnose_today_assessment_defaults_to_none() -> None:
+    """Test that today_assessment defaults to None."""
+    command = DiagnoseCommand(note_uuid="test_uuid")
+    assert command.today_assessment is None
+
+
+def test_diagnose_today_assessment_at_max_length_in_originate_payload() -> None:
+    """Test that a today_assessment at the limit survives into the originate payload."""
+    command = DiagnoseCommand(note_uuid="test_uuid", today_assessment="a" * 2048)
+    effect = command.originate()
+    payload = json.loads(effect.payload)
+    assert payload["data"]["today_assessment"] == "a" * 2048


### PR DESCRIPTION
INTERNAL TRACKING: https://canvasmedical.atlassian.net/browse/KOALA-6687

This pull request adds a maximum length validation to the `today_assessment` field in the `DiagnoseCommand` and introduces comprehensive tests to ensure this constraint is enforced. The changes help prevent overly long input and improve data integrity.

**Validation enhancements:**

* Updated the `DiagnoseCommand` model to enforce a maximum length of 2048 characters for the `today_assessment` field using a `Field` constraint.

**Testing improvements:**

* Added `DiagnoseCommand` to the test imports to enable direct testing.
* Added multiple tests to verify that `today_assessment`:
  - Accepts values up to 2048 characters.
  - Rejects values over 2048 characters, both at construction and assignment.
  - Allows `None` and defaults to `None`.
  - Correctly serializes a max-length value in the originate payload.

<!-- ## Title Guidelines

A title always has a prefix and a subject.

### Prefix
Make sure the title is prefixed with one of the following:

| Prefix | When to use |
|--------|-------------|
| `feat:`     | New feature |
| `fix:`      | Bug fix |
| `docs:`     | Documentation only changes |
| `style:`    | Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc) |
| `refactor:` | Code changes that neither fixes a bug nor adds a feature |
| `perf:`     | Code change that improves performance |
| `test:`     | Adding missing or correcting existing tests |
| `chore:`    | Changes to the build process or auxiliary tools and libraries such as documentation generation, ci, etc |

### Subject

Ensure the subject contains succinct description of the change.
* Use the imperative, present tense: "change", not "changed" nor "changes"
* Don’t capitalize first letter
* No dot (.) at the end
-->
