### PR TITLE
fix: assess command validations

### DIFF
--- a/canvas_sdk/commands/commands/assess.py
+++ b/canvas_sdk/commands/commands/assess.py
@@ -1,9 +1,14 @@
 from enum import Enum
+from typing import Any
 from uuid import UUID
 
 from pydantic import Field
+from pydantic_core import InitErrorDetails
 
 from canvas_sdk.commands.base import _BaseCommand
+from canvas_sdk.v1.data import Command, Condition, Note
+
+CONDITION_VALIDATED_METHODS = frozenset({"originate", "edit"})
 
 
 class AssessCommand(_BaseCommand):
@@ -22,23 +27,40 @@ class AssessCommand(_BaseCommand):
     )
     background: str | None = None
     status: Status | None = None
-    narrative: str | None = None
+    narrative: str | None = Field(default=None, max_length=2048)
 
+    def _is_target_patient(self, patient_id: str) -> bool:
+        """Return whether the given patient is the one whose chart this command writes to."""
+        if self.note_uuid:
+            return Note.objects.filter(id=self.note_uuid, patient__id=patient_id).exists()
 
-# how do we make sure that condition_id is a valid condition for the patient?
+        if self.command_uuid:
+            return Command.objects.filter(id=self.command_uuid, patient__id=patient_id).exists()
 
-# idea1:
-# create a class attribute 'pre_validate_condition': bool
-#      True: before doing any actions against the home-app instance, will first check
-#            if its an active condition for that patient, and it not then logs a message
-#            and doesn't do the action. can even create a cache so that we dont always
-#            have to keep asking home-app for every patient
-#      False: still tries to do it but will run up against whatever home-app barriers
-#             we have against actions like that (if those dont already exist, then
-#             definitely create them!)
+        return True
 
+    def _get_error_details(self, method: Any) -> list[InitErrorDetails]:
+        errors = super()._get_error_details(method)
 
-# idea2:
-# validator that checks that condition.patient is the same as note.patient
+        if not self.condition_id or method not in CONDITION_VALIDATED_METHODS:
+            return errors
+
+        condition_patient_id = (
+            Condition.objects.filter(id=self.condition_id)
+            .values_list("patient__id", flat=True)
+            .first()
+        )
+
+        if condition_patient_id is None or not self._is_target_patient(condition_patient_id):
+            errors.append(
+                self._create_error_detail(
+                    "value",
+                    f"Condition {self.condition_id} does not belong to this command's patient",
+                    self.condition_id,
+                )
+            )
+
+        return errors
+
 
 __exports__ = ("AssessCommand",)

--- a/canvas_sdk/tests/commands/test_assess.py
+++ b/canvas_sdk/tests/commands/test_assess.py
@@ -1,0 +1,175 @@
+import datetime
+
+import pytest
+from pydantic_core import ValidationError
+
+from canvas_sdk.commands import AssessCommand
+from canvas_sdk.test_utils.factories import NoteFactory, PatientFactory
+from canvas_sdk.v1.data import Command, Condition, Note, Patient
+
+
+@pytest.fixture
+def patient(db: None) -> Patient:
+    """A patient who owns the note the command is charted in."""
+    return PatientFactory.create()
+
+
+@pytest.fixture
+def other_patient(db: None) -> Patient:
+    """An unrelated patient, used to build a cross-patient condition."""
+    return PatientFactory.create()
+
+
+@pytest.fixture
+def note(patient: Patient) -> Note:
+    """A note belonging to `patient`."""
+    return NoteFactory.create(patient=patient)
+
+
+def _condition(patient: Patient | None) -> Condition:
+    """Create a minimal active condition for the given patient."""
+    return Condition.objects.create(
+        patient=patient,
+        deleted=False,
+        onset_date=datetime.date(2024, 1, 1),
+        resolution_date=datetime.date(2024, 1, 1),
+        clinical_status="active",
+        notes="",
+        surgical=False,
+    )
+
+
+@pytest.fixture
+def condition(patient: Patient) -> Condition:
+    """A condition belonging to the same patient as the note."""
+    return _condition(patient)
+
+
+@pytest.fixture
+def foreign_condition(other_patient: Patient) -> Condition:
+    """A condition belonging to a different patient than the note."""
+    return _condition(other_patient)
+
+
+@pytest.fixture
+def command(note: Note) -> Command:
+    """A persisted assess command anchored to `note`, for exercising edit()."""
+    return Command.objects.create(
+        note=note,
+        patient=note.patient,
+        state="staged",
+        schema_key="assess",
+        data={},
+        origination_source="plugin",
+        anchor_object_type="",
+        anchor_object_dbid=0,
+    )
+
+
+# --- narrative max length -------------------------------------------------
+
+
+def test_narrative_accepts_max_length() -> None:
+    """Narrative accepts a value at the 2048 character limit."""
+    assert AssessCommand(note_uuid="n", narrative="a" * 2048).narrative == "a" * 2048
+
+
+def test_narrative_rejects_above_max_length() -> None:
+    """Narrative rejects a value over the 2048 character limit."""
+    with pytest.raises(ValidationError):
+        AssessCommand(note_uuid="n", narrative="a" * 2049)
+
+
+def test_narrative_rejects_above_max_length_on_assignment() -> None:
+    """Narrative is validated when assigned after construction."""
+    assess = AssessCommand(note_uuid="n")
+    with pytest.raises(ValidationError):
+        assess.narrative = "a" * 2049
+
+
+def test_narrative_defaults_to_none() -> None:
+    """Narrative defaults to None."""
+    assert AssessCommand(note_uuid="n").narrative is None
+
+
+# --- condition ownership on originate -------------------------------------
+
+
+def test_originate_accepts_condition_belonging_to_the_notes_patient(
+    note: Note, condition: Condition
+) -> None:
+    """A condition on the note's own patient originates without error."""
+    effect = AssessCommand(note_uuid=str(note.id), condition_id=str(condition.id)).originate()
+
+    assert effect is not None
+
+
+def test_originate_rejects_condition_belonging_to_another_patient(
+    note: Note, foreign_condition: Condition
+) -> None:
+    """A condition on a different patient is rejected before an effect is emitted."""
+    assess = AssessCommand(note_uuid=str(note.id), condition_id=str(foreign_condition.id))
+
+    with pytest.raises(ValidationError, match="does not belong to this command's patient"):
+        assess.originate()
+
+
+def test_originate_rejects_unknown_condition(note: Note) -> None:
+    """A condition_id that matches no condition is rejected like any foreign condition."""
+    assess = AssessCommand(
+        note_uuid=str(note.id), condition_id="8bcb9b2e-0f3e-4f9a-9d9a-4b2c1f7d0a11"
+    )
+
+    with pytest.raises(ValidationError, match="does not belong to this command's patient"):
+        assess.originate()
+
+
+def test_originate_rejects_condition_with_no_patient(note: Note) -> None:
+    """A condition charted against no patient is rejected; patient is nullable."""
+    orphan = _condition(patient=None)
+    assess = AssessCommand(note_uuid=str(note.id), condition_id=str(orphan.id))
+
+    with pytest.raises(ValidationError, match="does not belong to this command's patient"):
+        assess.originate()
+
+
+def test_originate_without_condition_id_is_unvalidated(note: Note) -> None:
+    """Omitting condition_id skips the ownership check entirely."""
+    effect = AssessCommand(note_uuid=str(note.id), narrative="No condition yet").originate()
+
+    assert effect is not None
+
+
+# --- condition ownership on edit ------------------------------------------
+
+
+def test_edit_accepts_condition_belonging_to_the_commands_patient(
+    command: Command, condition: Condition
+) -> None:
+    """Editing resolves the patient through the command when no note_uuid is set."""
+    effect = AssessCommand(command_uuid=str(command.id), condition_id=str(condition.id)).edit()
+
+    assert effect is not None
+
+
+def test_edit_rejects_condition_belonging_to_another_patient(
+    command: Command, foreign_condition: Condition
+) -> None:
+    """Editing a command to point at another patient's condition is rejected."""
+    assess = AssessCommand(command_uuid=str(command.id), condition_id=str(foreign_condition.id))
+
+    with pytest.raises(ValidationError, match="does not belong to this command's patient"):
+        assess.edit()
+
+
+# --- methods that don't write condition_id --------------------------------
+
+
+@pytest.mark.parametrize("method", ["commit", "delete", "enter_in_error"])
+def test_methods_that_do_not_send_values_skip_the_ownership_check(
+    command: Command, foreign_condition: Condition, method: str
+) -> None:
+    """commit/delete/enter_in_error act on an existing command, so they skip validation."""
+    assess = AssessCommand(command_uuid=str(command.id), condition_id=str(foreign_condition.id))
+
+    assert getattr(assess, method)() is not None

--- a/canvas_sdk/tests/commands/test_assess.py
+++ b/canvas_sdk/tests/commands/test_assess.py
@@ -173,3 +173,20 @@ def test_methods_that_do_not_send_values_skip_the_ownership_check(
     assess = AssessCommand(command_uuid=str(command.id), condition_id=str(foreign_condition.id))
 
     assert getattr(assess, method)() is not None
+
+
+# --- condition ownership with no note or command anchor -------------------
+
+
+def test_originate_without_an_anchor_skips_the_ownership_check(condition: Condition) -> None:
+    """Without a note or command to resolve the patient from, ownership can't be checked.
+
+    The command still fails on the required note_uuid, but the cross-patient condition
+    error is never raised.
+    """
+    assess = AssessCommand(condition_id=str(condition.id))
+
+    with pytest.raises(ValidationError, match="note_uuid") as exc_info:
+        assess.originate()
+
+    assert "does not belong to this command's patient" not in str(exc_info.value)


### PR DESCRIPTION
INTERNAL TRACKING: https://canvasmedical.atlassian.net/browse/KOALA-6683

This pull request enhances validation and testing for the `AssessCommand` class, focusing on ensuring data integrity and correct patient-condition associations. The main changes include enforcing a maximum length for the `narrative` field, adding robust validation to ensure a condition belongs to the correct patient during command operations, and introducing comprehensive tests to verify these behaviors.

**Validation improvements:**

* The `narrative` field on `AssessCommand` is now limited to a maximum of 2048 characters and validated on assignment.
* Added logic to `_get_error_details` to validate that the `condition_id` (if provided) belongs to the same patient as the associated note or command, preventing cross-patient data errors during `originate` and `edit` operations.

**Testing enhancements:**

* Added a new test suite in `test_assess.py` covering:
  - Maximum length enforcement and defaulting behavior for the `narrative` field.
  - Validation that `condition_id` must belong to the correct patient during `originate` and `edit`.
  - Cases where validation is skipped (e.g., for methods like `commit`, `delete`, `enter_in_error`, or when `condition_id` is omitted).

**Dependency and import updates:**

* Imported new dependencies (`Any`, `InitErrorDetails`, and relevant models) to support enhanced validation logic.


<!-- ## Title Guidelines

A title always has a prefix and a subject.

### Prefix
Make sure the title is prefixed with one of the following:

| Prefix | When to use |
|--------|-------------|
| `feat:`     | New feature |
| `fix:`      | Bug fix |
| `docs:`     | Documentation only changes |
| `style:`    | Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc) |
| `refactor:` | Code changes that neither fixes a bug nor adds a feature |
| `perf:`     | Code change that improves performance |
| `test:`     | Adding missing or correcting existing tests |
| `chore:`    | Changes to the build process or auxiliary tools and libraries such as documentation generation, ci, etc |

### Subject

Ensure the subject contains succinct description of the change.
* Use the imperative, present tense: "change", not "changed" nor "changes"
* Don’t capitalize first letter
* No dot (.) at the end
-->
