### PR TITLE
fix: bound the prescription text and counts when an effect is built

### DIFF
--- a/canvas_sdk/commands/commands/prescribe.py
+++ b/canvas_sdk/commands/commands/prescribe.py
@@ -17,6 +17,11 @@ from canvas_sdk.effects.compound_medications.compound_medication import (
 from canvas_sdk.v1.data import PracticeLocation
 from canvas_sdk.v1.data.compound_medication import CompoundMedication as CompoundMedicationModel
 
+_SIG_MAX_LENGTH = 1000
+_NOTE_TO_PHARMACIST_MAX_LENGTH = 210
+_REFILLS_MIN = 0
+_REFILLS_MAX = 99
+
 
 @dataclass
 class CompoundMedicationData:
@@ -81,7 +86,7 @@ class PrescribeCommand(_ReviewableCommandMixin, _SendableCommandMixin, _BaseComm
         return self.fdb_code is not None and self.fdb_code.strip() != ""
 
     def _get_error_details(self, method: str) -> list[InitErrorDetails]:
-        """Add compound medication validation to the base validation."""
+        """Add compound medication and prescription count validation to the base validation."""
         errors = super()._get_error_details(method)
 
         # Validate that exactly one medication type is provided
@@ -129,6 +134,44 @@ class PrescribeCommand(_ReviewableCommandMixin, _SendableCommandMixin, _BaseComm
                 controlled_substance_ndc=self.compound_medication_data.controlled_substance_ndc,
             )
             errors.extend(compound_med_errors)
+
+        if len(self.sig) > _SIG_MAX_LENGTH:
+            errors.append(
+                self._create_error_detail(
+                    "value", f"Sig cannot be longer than {_SIG_MAX_LENGTH} characters", self.sig
+                )
+            )
+
+        if (
+            self.note_to_pharmacist is not None
+            and len(self.note_to_pharmacist) > _NOTE_TO_PHARMACIST_MAX_LENGTH
+        ):
+            errors.append(
+                self._create_error_detail(
+                    "value",
+                    "Note to pharmacist cannot be longer than "
+                    f"{_NOTE_TO_PHARMACIST_MAX_LENGTH} characters",
+                    self.note_to_pharmacist,
+                )
+            )
+
+        if self.refills is not None and not _REFILLS_MIN <= self.refills <= _REFILLS_MAX:
+            errors.append(
+                self._create_error_detail(
+                    "value",
+                    f"Refills must be between {_REFILLS_MIN} and {_REFILLS_MAX}",
+                    self.refills,
+                )
+            )
+
+        if self.quantity_to_dispense is not None and self.quantity_to_dispense <= 0:
+            errors.append(
+                self._create_error_detail(
+                    "value",
+                    "Quantity to dispense must be greater than 0",
+                    self.quantity_to_dispense,
+                )
+            )
 
         return errors
 

--- a/canvas_sdk/tests/commands/test_prescribe.py
+++ b/canvas_sdk/tests/commands/test_prescribe.py
@@ -1,11 +1,18 @@
 import json
+from decimal import Decimal
 from unittest.mock import patch
 from uuid import uuid4
 
 import pytest
+from pydantic import ValidationError
 
 from canvas_generated.messages.effects_pb2 import EffectType
+from canvas_sdk.commands.commands.adjust_prescription import AdjustPrescriptionCommand
 from canvas_sdk.commands.commands.prescribe import PrescribeCommand
+from canvas_sdk.commands.commands.refill import RefillCommand
+
+NOTE_UUID = "9b1deb4d-3b7d-4bad-9bdd-2b0d7b3dcb6d"
+COMMAND_UUID = "1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed"
 
 
 def test_send_without_override_omits_key() -> None:
@@ -40,3 +47,259 @@ def test_send_with_invalid_override_raises() -> None:
         mock_pl.filter.return_value.exists.return_value = False
         with pytest.raises(ValueError, match="does not exist"):
             cmd.send(practice_location_override=str(uuid4()))
+
+
+# The two Surescripts-bound text fields are held to their length and nothing else. The characters
+# Surescripts refuses are left alone for now — Canvas rejects those at review, as it did before —
+# so this is a length pass only.
+#
+# Length is checked when an effect is built rather than when the field is set. On the field it raised
+# at the assigning line, which breaks a plugin filling a command in from a model's output part-way
+# through a handler. Deferring keeps the over-long value off the chart without crashing the handler
+# that produced it.
+
+
+@pytest.mark.parametrize(("field", "limit"), [("sig", 1000), ("note_to_pharmacist", 210)])
+def test_text_at_the_limit_is_accepted(field: str, limit: int) -> None:
+    """The boundary belongs on the allowed side, and the value is not rewritten."""
+    text = "x" * limit
+
+    command = PrescribeCommand.model_validate({"note_uuid": NOTE_UUID, field: text})
+
+    assert getattr(command, field) == text
+    assert command.originate()
+
+
+@pytest.mark.parametrize(("field", "limit"), [("sig", 1000), ("note_to_pharmacist", 210)])
+def test_over_long_text_can_be_set_without_raising(field: str, limit: int) -> None:
+    """The regression this shape exists to prevent: assignment stays quiet."""
+    text = "x" * (limit + 500)
+    command = PrescribeCommand()
+
+    setattr(command, field, text)
+
+    assert getattr(command, field) == text
+
+
+@pytest.mark.parametrize(
+    ("field", "limit", "message"),
+    [
+        ("sig", 1000, "Sig cannot be longer than 1000 characters"),
+        ("note_to_pharmacist", 210, "Note to pharmacist cannot be longer than 210 characters"),
+    ],
+)
+def test_over_long_text_is_refused_when_the_effect_is_built(
+    field: str, limit: int, message: str
+) -> None:
+    """Refused at the boundary instead, so it never reaches the chart.
+
+    The note's limit is 210 — not the 1024 some callers assume — so this is the one most likely to
+    be hit.
+    """
+    command = PrescribeCommand.model_validate({"note_uuid": NOTE_UUID, field: "x" * (limit + 500)})
+
+    with pytest.raises(ValidationError) as caught:
+        command.originate()
+
+    assert message in str(caught.value)
+
+
+@pytest.mark.parametrize("field", ["sig", "note_to_pharmacist"])
+def test_over_long_text_is_refused_on_an_edit_too(field: str) -> None:
+    """An edit carries the data as well, so the same limit applies."""
+    command = PrescribeCommand.model_validate({"command_uuid": COMMAND_UUID, field: "x" * 2000})
+
+    with pytest.raises(ValidationError):
+        command.edit()
+
+
+@pytest.mark.parametrize("field", ["sig", "note_to_pharmacist"])
+def test_characters_surescripts_cannot_carry_are_not_touched_yet(field: str) -> None:
+    """Explicit about the scope of this pass, so a reader knows it is unhandled, not overlooked.
+
+    A smart quote or a newline still reaches the chart and still fails at REVIEW, exactly as it
+    does today. What this pass guarantees is only that it does not raise here.
+    """
+    text = "Do not crush — don’t chew\nsecond line"
+
+    assert getattr(PrescribeCommand.model_validate({field: text}), field) == text
+
+
+def test_the_note_to_pharmacist_may_be_absent_or_empty() -> None:
+    """The field is optional, and an empty note stays empty."""
+    assert PrescribeCommand().note_to_pharmacist is None
+    assert PrescribeCommand(note_to_pharmacist="").note_to_pharmacist == ""
+
+
+def test_refill_and_adjust_prescription_inherit_the_limits() -> None:
+    """The limits are declared once on PrescribeCommand; the other two Rx commands subclass it.
+
+    Asserted because the kit this replaced had to check the same lengths in three separate parsers,
+    and a fourth Rx command added later would have needed a fourth check.
+    """
+    for command_cls in (RefillCommand, AdjustPrescriptionCommand):
+        command = command_cls(note_uuid=NOTE_UUID, note_to_pharmacist="x" * 400)
+
+        with pytest.raises(ValidationError):
+            command.originate()
+
+
+def test_a_command_filled_in_from_a_models_output_reaches_the_chart() -> None:
+    """The four fields a scribe assigns in sequence, with the text such a caller really produces.
+
+    Each assignment is its own validation pass, so this is the case that would have raised four
+    separate times. Every value is within its limits on purpose: the ones that are not are refused
+    at the effect rather than here, which is asserted above.
+    """
+    sig = "Take 1 tablet by mouth twice daily — don’t crush; 250µg"
+    command = PrescribeCommand(note_uuid=str(uuid4()), fdb_code="12345")
+
+    command.sig = sig
+    command.note_to_pharmacist = "Patient prefers ½ tablets. Call if unavailable…"
+    command.refills = 2
+    command.quantity_to_dispense = Decimal("30")
+
+    assert command.sig == sig
+    assert json.loads(command.originate().payload)["data"]["sig"] == sig
+
+
+# The counts Canvas bounds on a prescription. Each is asserted at its boundary rather than at a
+# comfortable value, because an off-by-one here is a real prescription.
+#
+# `refills` and `quantity_to_dispense` are bounded when an effect is built, not when they are set.
+# The bound is the same one Canvas enforces; what moved is *when* it fires. On the field it raised
+# at the assigning line, which breaks a plugin filling a command in from a model's output — the one
+# that does this seeds -1 for "not extracted" in both of them. Deferring keeps the bad value off the
+# chart without crashing the handler that produced it.
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [("refills", -1), ("refills", 100), ("quantity_to_dispense", 0), ("quantity_to_dispense", -1)],
+)
+def test_an_out_of_range_count_can_be_set_without_raising(field: str, value: int) -> None:
+    """The regression this shape exists to prevent: assignment stays quiet."""
+    command = PrescribeCommand()
+
+    setattr(command, field, value)
+
+    assert getattr(command, field) == value
+    assert PrescribeCommand.model_validate({field: value})
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        ("refills", -1, "Refills must be between 0 and 99"),
+        ("refills", 100, "Refills must be between 0 and 99"),
+        ("quantity_to_dispense", 0, "Quantity to dispense must be greater than 0"),
+        ("quantity_to_dispense", -1, "Quantity to dispense must be greater than 0"),
+    ],
+)
+def test_an_out_of_range_count_is_refused_when_the_effect_is_built(
+    field: str, value: int, message: str
+) -> None:
+    """Refused at the boundary instead, so it never reaches the chart."""
+    command = PrescribeCommand.model_validate({"note_uuid": NOTE_UUID, field: value})
+
+    with pytest.raises(ValidationError) as caught:
+        command.originate()
+
+    assert message in str(caught.value)
+
+
+@pytest.mark.parametrize("field", ["refills", "quantity_to_dispense"])
+def test_an_out_of_range_count_is_refused_on_an_edit_too(field: str) -> None:
+    """An edit carries data as well, so the same bound applies."""
+    command = PrescribeCommand.model_validate({"command_uuid": COMMAND_UUID, field: -1})
+
+    with pytest.raises(ValidationError):
+        command.edit()
+
+
+def test_the_bounds_are_not_gated_by_method() -> None:
+    """Every effect is checked, not just the two that carry data.
+
+    The consequence worth knowing: an object holding an out-of-range value cannot be deleted or
+    entered in error through that same object. In practice those calls need only `command_uuid`, so
+    the counts are None and nothing is checked — it takes a fully populated command to hit this.
+    """
+    command = PrescribeCommand.model_validate({"command_uuid": COMMAND_UUID, "refills": -1})
+
+    with pytest.raises(ValidationError):
+        command.delete()
+
+    assert PrescribeCommand(command_uuid=COMMAND_UUID).delete()
+
+
+@pytest.mark.parametrize(("value", "expected"), [(0, 0), (99, 99), ("3", 3)])
+def test_refills_inside_the_range_is_accepted(value: object, expected: int) -> None:
+    """Both ends of the range are valid: no refills, and the maximum Surescripts allows."""
+    command = PrescribeCommand.model_validate({"note_uuid": NOTE_UUID, "refills": value})
+
+    assert command.refills == expected
+    assert command.originate()
+
+
+@pytest.mark.parametrize("value", [0, 30, -1])
+def test_days_supply_is_not_bounded_at_all(value: int) -> None:
+    """Canvas puts no bound on days supply, so neither does this — including a negative one.
+
+    `canvas_core.commands.definitions.prescribe` declares it `fields.IntegerField(required=False)`
+    with no `min_value`, and inventing a stricter rule than the chart enforces would refuse a
+    prescription Canvas accepts.
+    """
+    command = PrescribeCommand.model_validate({"note_uuid": NOTE_UUID, "days_supply": value})
+
+    assert command.days_supply == value
+    assert command.originate()
+
+
+def test_a_count_that_is_not_a_number_is_still_refused_immediately() -> None:
+    """Moving the *bound* to the effect does not make the field untyped.
+
+    A value that cannot be an integer has no bound to defer — it would reach the payload as
+    nonsense — so the type error still raises where it is set.
+    """
+    with pytest.raises(ValidationError):
+        PrescribeCommand.model_validate({"refills": "abc"})
+
+
+@pytest.mark.parametrize("value", [-1, -0.5, "-1", Decimal("-2.5"), 0, Decimal("0"), 0.0])
+def test_a_quantity_to_dispense_at_or_below_zero_is_refused(value: object) -> None:
+    """Nothing to dispense is not a prescription.
+
+    The bound holds across the field's whole union — Decimal, float and int alike, and the string
+    a JSON body would carry, which arrives as a Decimal and compares like one.
+    """
+    command = PrescribeCommand.model_validate(
+        {"note_uuid": NOTE_UUID, "quantity_to_dispense": value}
+    )
+
+    with pytest.raises(ValidationError) as caught:
+        command.originate()
+
+    assert "Quantity to dispense must be greater than 0" in str(caught.value)
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [(Decimal("2.5"), Decimal("2.5")), ("2.5", Decimal("2.5")), (2.5, 2.5), (30, 30)],
+)
+def test_a_quantity_to_dispense_is_read_from_whatever_carries_it(
+    value: object, expected: object
+) -> None:
+    """A quantity arrives as a decimal, a float, an int, or the string a JSON body carries."""
+    assert PrescribeCommand.model_validate(
+        {"quantity_to_dispense": value}
+    ).quantity_to_dispense == (expected)
+
+
+@pytest.mark.parametrize("value", [Decimal("0.5"), 0.5, "0.5", Decimal("0.25")])
+def test_a_fractional_quantity_to_dispense_is_accepted(value: object) -> None:
+    """Half a tablet and 0.5 mL of a suspension are real quantities.
+
+    The bound is `gt=0` and not a minimum of one for this reason, which is also what Canvas
+    enforces (`canvas_core/commands/definitions/prescribe.py::dispense_quantity_validator`).
+    """
+    assert PrescribeCommand.model_validate({"quantity_to_dispense": value})


### PR DESCRIPTION
https://canvasmedical.atlassian.net/browse/KOALA-6705

The prescription fields that reach the pharmacy were unbounded: a plugin could set a 4,000-character
sig, `refills=-1`, or a quantity of zero, and nothing objected until the prescription failed downstream,
away from the plugin that caused it.

Four fields are now bounded, all of them **when the command is turned into an effect**:

| Field | Limit |
|---|---|
| `sig` | 1000 characters |
| `note_to_pharmacist` | 210 characters |
| `refills` | 0 to 99 |
| `quantity_to_dispense` | greater than zero |

`quantity_to_dispense` is `> 0` rather than `>= 1` because a fraction of a unit is a real quantity -
half a tablet, 0.5 mL of a suspension - which is the bound Canvas itself applies. `days_supply` is not
bounded, matching the chart.

## Why at the effect and not on the field

These validators would otherwise run eagerly - `validate_assignment` is on - so a bound on the field
raises at the line that assigns it, part-way through a handler. Plugins that fill a command in from a
model's output assign these one at a time, and one of them seeds -1 as the placeholder for "not
extracted", so checking at the field would turn working plugins into crashing ones. Deferring keeps the
bad value off the chart, which is the point, without moving where the failure happens. It also means
`originate()` reports every out-of-range value at once rather than only the first.

Field values are also read leniently, so a caller sending `"3"` or `"0.5"` from a JSON body is parsed
rather than refused.

## Tests

49 in `canvas_sdk/tests/commands/test_prescribe.py` - each bound at its boundary, over it, on an edit as
well as an originate, assignment staying quiet, and a full fill-the-command-in-field-by-field sequence
with the text a scribe really produces. Neutering the two length checks fails 5.

Full suite passes, mypy clean.

The characters Surescripts cannot carry - smart quotes, newlines - are deliberately left alone in this
pass; they fail at review today and still do. There is a test saying so, so it reads as deferred rather
than missed.