### PR TITLE
fix: add patient validation to change medication command

### DIFF
--- a/canvas_sdk/commands/base.py
+++ b/canvas_sdk/commands/base.py
@@ -5,6 +5,7 @@ from types import NoneType, UnionType
 from typing import TYPE_CHECKING, Any, Union, get_args, get_origin
 
 from django.core.exceptions import ImproperlyConfigured
+from pydantic import ConfigDict
 
 from canvas_sdk.base import TrackableFieldsModel
 from canvas_sdk.commands.constants import Coding
@@ -29,6 +30,8 @@ class _BaseCommand(TrackableFieldsModel):
         enter_in_error_required_fields = ("command_uuid",)
         delegate_required_fields = ("command_uuid",)
         sign_required_fields = ("command_uuid",)
+
+    model_config = ConfigDict(strict=False)
 
     _dirty_excluded_keys = [
         "note_uuid",

--- a/canvas_sdk/commands/base.py
+++ b/canvas_sdk/commands/base.py
@@ -11,6 +11,7 @@ from canvas_sdk.commands.constants import Coding
 from canvas_sdk.effects import Effect
 from canvas_sdk.effects.command_custom_html import _CommandCustomHtml
 from canvas_sdk.effects.command_metadata.base import _CommandMetadata
+from canvas_sdk.v1.data import Command, Note
 
 if TYPE_CHECKING:
     from canvas_sdk.effects.protocol_card import Recommendation
@@ -114,6 +115,37 @@ class _BaseCommand(TrackableFieldsModel):
             for name, definition in schema["properties"].items()
             if name not in base_properties
         }
+
+    def _anchor_patient_id(self) -> str | None:
+        """The patient whose chart this command writes to, when that can be known.
+
+        Returns:
+            The patient's id, or None when there is nothing to resolve it from *or* the anchor is
+            not persisted yet. The second case is not an error: a plugin may return several effects
+            from one handler, and the note or command a later effect names may not exist at the
+            moment that effect is built.
+        """
+        if note_uuid := self.note_uuid:
+            return Note.objects.filter(id=note_uuid).values_list("patient__id", flat=True).first()
+
+        if command_uuid := self.command_uuid:
+            return (
+                Command.objects.filter(id=command_uuid)
+                .values_list("patient__id", flat=True)
+                .first()
+            )
+
+        return None
+
+    def _is_target_patient(self, patient_id: str) -> bool:
+        """Whether the given patient is the one whose chart this command writes to.
+
+        True when the anchor cannot be resolved: a command that does not yet know its patient must
+        not refuse a record on the suspicion that it belongs to someone else
+        """
+        anchor_patient_id = self._anchor_patient_id()
+
+        return anchor_patient_id is None or anchor_patient_id == patient_id
 
     def originate(self, line_number: int = -1, commit: bool = False) -> Effect:
         """Originate a new command in the note body."""

--- a/canvas_sdk/commands/commands/assess.py
+++ b/canvas_sdk/commands/commands/assess.py
@@ -6,7 +6,7 @@ from pydantic import Field
 from pydantic_core import InitErrorDetails
 
 from canvas_sdk.commands.base import _BaseCommand
-from canvas_sdk.v1.data import Command, Condition, Note
+from canvas_sdk.v1.data import Condition
 
 CONDITION_VALIDATED_METHODS = frozenset({"originate", "edit"})
 
@@ -28,24 +28,6 @@ class AssessCommand(_BaseCommand):
     background: str | None = None
     status: Status | None = None
     narrative: str | None = Field(default=None, max_length=2048)
-
-    def _is_target_patient(self, patient_id: str) -> bool:
-        """Return whether the given patient is the one whose chart this command writes to."""
-        if self.note_uuid:
-            anchor_patient_id = (
-                Note.objects.filter(id=self.note_uuid).values_list("patient__id", flat=True).first()
-            )
-        elif self.command_uuid:
-            anchor_patient_id = (
-                Command.objects.filter(id=self.command_uuid)
-                .values_list("patient__id", flat=True)
-                .first()
-            )
-        else:
-            return True
-
-        # Anchor may not be persisted yet (same-batch effect);
-        return anchor_patient_id is None or anchor_patient_id == patient_id
 
     def _get_error_details(self, method: Any) -> list[InitErrorDetails]:
         errors = super()._get_error_details(method)

--- a/canvas_sdk/commands/commands/change_medication.py
+++ b/canvas_sdk/commands/commands/change_medication.py
@@ -1,10 +1,11 @@
 from typing import Literal
+from uuid import UUID
 
 from pydantic import Field
 from pydantic_core import InitErrorDetails
 
 from canvas_sdk.commands.base import _BaseCommand as BaseCommand
-from canvas_sdk.v1.data import Medication, Note
+from canvas_sdk.v1.data import Medication
 
 
 class ChangeMedicationCommand(BaseCommand):
@@ -14,7 +15,7 @@ class ChangeMedicationCommand(BaseCommand):
         key = "changeMedication"
         commit_required_fields = ("medication_id",)
 
-    medication_id: str | None = Field(
+    medication_id: UUID | None = Field(
         default=None, json_schema_extra={"commands_api_name": "medication"}
     )
     sig: str | None = None
@@ -22,35 +23,24 @@ class ChangeMedicationCommand(BaseCommand):
     def _get_error_details(
         self, method: Literal["originate", "edit", "delete", "commit", "enter_in_error"]
     ) -> list[InitErrorDetails]:
+        """Check that the medication being changed is one this patient actually has."""
         errors = super()._get_error_details(method)
 
-        note = None
+        if not self.medication_id or (patient_id := self._anchor_patient_id()) is None:
+            return errors
 
-        if self.note_uuid:
-            note = Note.objects.filter(id=self.note_uuid).first()
-
-            if not note:
-                errors.append(
-                    self._create_error_detail(
-                        "value",
-                        f"note with id {self.note_uuid} not found.",
-                        self.note_uuid,
-                    )
+        if (
+            not Medication.objects.active()
+            .filter(id=self.medication_id, patient__id=patient_id)
+            .exists()
+        ):
+            errors.append(
+                self._create_error_detail(
+                    "value",
+                    f"Medication with Id {self.medication_id} not found or not associated with the patient.",
+                    self.medication_id,
                 )
-
-        if self.medication_id and note:
-            medication = Medication.objects.filter(
-                id=self.medication_id, patient=note.patient
-            ).first()
-
-            if not medication:
-                errors.append(
-                    self._create_error_detail(
-                        "value",
-                        f"Medication with Id {self.medication_id} not found or not associated with the patient.",
-                        self.medication_id,
-                    )
-                )
+            )
 
         return errors
 

--- a/canvas_sdk/tests/commands/test_change_medication.py
+++ b/canvas_sdk/tests/commands/test_change_medication.py
@@ -149,6 +149,23 @@ def test_a_medication_id_that_cannot_be_an_id_is_a_validation_error(note: Note) 
         ChangeMedicationCommand(note_uuid=str(note.id), medication_id="99999")  # type: ignore[arg-type]
 
 
+def test_a_medication_id_given_as_a_string_is_still_accepted(note: Note, patient: Patient) -> None:
+    """The field was declared `str` before this change, so its callers pass one.
+
+    Retyping it to UUID only stays compatible because commands parse leniently. Under strict
+    parsing pydantic refuses the string form outright — `Input should be an instance of UUID` —
+    which would break every plugin that passes the id the way it used to be declared.
+    """
+    medication = _medication(patient)
+
+    command = ChangeMedicationCommand(
+        note_uuid=str(note.id),
+        medication_id=str(medication.id),  # type: ignore[arg-type]
+    )
+
+    assert command.originate()
+
+
 def test_no_medication_id_means_nothing_to_check(note: Note) -> None:
     """The field is optional until commit, so an empty command originates fine."""
     assert ChangeMedicationCommand(note_uuid=str(note.id)).originate()

--- a/canvas_sdk/tests/commands/test_change_medication.py
+++ b/canvas_sdk/tests/commands/test_change_medication.py
@@ -1,0 +1,167 @@
+import datetime
+import uuid
+
+import pytest
+from pydantic_core import ValidationError
+
+from canvas_sdk.commands.commands.change_medication import ChangeMedicationCommand
+from canvas_sdk.test_utils.factories import NoteFactory, PatientFactory
+from canvas_sdk.v1.data import Command, Medication, Note, Patient
+
+
+@pytest.fixture
+def patient(db: None) -> Patient:
+    """The patient whose chart the command writes to."""
+    return PatientFactory.create()
+
+
+@pytest.fixture
+def other_patient(db: None) -> Patient:
+    """An unrelated patient, for building a medication that belongs to someone else."""
+    return PatientFactory.create()
+
+
+@pytest.fixture
+def note(patient: Patient) -> Note:
+    """A note on the target patient's chart."""
+    return NoteFactory.create(patient=patient)
+
+
+def _medication(patient: Patient, status: str = "active") -> Medication:
+    """A medication on a patient's list, as `Medication.objects.active()` defines one.
+
+    That is `committed()` — a committer, no entered-in-error — plus `status="active"`. The
+    interpreter resolves against the same queryset, so a fixture that skipped any of it would
+    prove the command accepts medications the interpreter will then fail to find.
+    """
+    return Medication.objects.create(
+        patient=patient,
+        deleted=False,
+        status=status,
+        committer_id=1,
+        entered_in_error_id=None,
+        start_date=datetime.date(2024, 1, 1),
+        end_date=datetime.date(2030, 1, 1),
+        national_drug_code="",
+        erx_quantity=0,
+        quantity_qualifier_description="",
+        clinical_quantity_description="",
+        potency_unit_code="",
+    )
+
+
+@pytest.fixture
+def stored_command(note: Note) -> Command:
+    """A persisted changeMedication command on the note, for exercising the edit path."""
+    return Command.objects.create(
+        note=note,
+        patient=note.patient,
+        state="staged",
+        schema_key="changeMedication",
+        data={},
+        origination_source="plugin",
+        anchor_object_type="",
+        anchor_object_dbid=0,
+    )
+
+
+# The medication being changed has to be one the patient actually has. The interpreter resolves
+# `medication_id` against the note's patient and stores *no medication* when nothing matches
+# (`plugin_io/interpreters/commands/change_medication.py`), so without this the command is created
+# with an empty medication instead of reporting the bad id.
+
+
+def test_a_medication_on_the_patients_list_is_accepted(note: Note, patient: Patient) -> None:
+    """The ordinary case: the id names one of this patient's active medications."""
+    medication = _medication(patient)
+
+    command = ChangeMedicationCommand(note_uuid=str(note.id), medication_id=medication.id)
+
+    assert command.originate()
+
+
+def test_a_medication_belonging_to_another_patient_is_refused(
+    note: Note, other_patient: Patient
+) -> None:
+    """The check this exists for — a valid medication, but not this patient's."""
+    foreign = _medication(other_patient)
+
+    with pytest.raises(ValidationError) as caught:
+        ChangeMedicationCommand(note_uuid=str(note.id), medication_id=foreign.id).originate()
+
+    assert "not found or not associated with the patient" in str(caught.value)
+
+
+def test_an_unknown_medication_is_refused(note: Note) -> None:
+    """A well-formed id that names nothing."""
+    with pytest.raises(ValidationError):
+        ChangeMedicationCommand(note_uuid=str(note.id), medication_id=uuid.uuid4()).originate()
+
+
+def test_an_inactive_medication_is_refused(note: Note, patient: Patient) -> None:
+    """The interpreter only resolves active medications, so this mirrors what it will accept."""
+    inactive = _medication(patient, status="inactive")
+
+    with pytest.raises(ValidationError):
+        ChangeMedicationCommand(note_uuid=str(note.id), medication_id=inactive.id).originate()
+
+
+def test_the_check_holds_on_an_edit_which_carries_no_note(
+    stored_command: Command, other_patient: Patient
+) -> None:
+    """The bug this fixes: an edit addresses a command, not a note.
+
+    Reading only ``note_uuid`` left ``note`` as None on this path, and the ownership check sat
+    behind `if self.medication_id and note:` — so editing a command to point at another patient's
+    medication was accepted, and the interpreter then quietly stored no medication at all.
+    """
+    foreign = _medication(other_patient)
+
+    with pytest.raises(ValidationError):
+        ChangeMedicationCommand(
+            command_uuid=str(stored_command.id), medication_id=foreign.id
+        ).edit()
+
+
+def test_an_edit_naming_the_patients_own_medication_is_allowed(
+    stored_command: Command, patient: Patient
+) -> None:
+    """The other half: resolving the patient from the command must not refuse a valid edit."""
+    medication = _medication(patient)
+
+    command = ChangeMedicationCommand(
+        command_uuid=str(stored_command.id), medication_id=medication.id
+    )
+
+    assert command.edit()
+
+
+def test_a_medication_id_that_cannot_be_an_id_is_a_validation_error(note: Note) -> None:
+    """`medication_id` is a UUID, so pydantic refuses a malformed one.
+
+    It matters that this is pydantic's error and not Django's: filtering an id column with an
+    unparseable value raises `django.core.exceptions.ValidationError`, which the plugin sandbox
+    cannot catch — so it would reach the caller as a 500 rather than as a refusal.
+    """
+    with pytest.raises(ValidationError):
+        # A string is what a caller actually sends; the annotation says UUID, and pydantic reads a
+        # well-formed one leniently — this asserts what happens to one that is not.
+        ChangeMedicationCommand(note_uuid=str(note.id), medication_id="99999")  # type: ignore[arg-type]
+
+
+def test_no_medication_id_means_nothing_to_check(note: Note) -> None:
+    """The field is optional until commit, so an empty command originates fine."""
+    assert ChangeMedicationCommand(note_uuid=str(note.id)).originate()
+
+
+def test_a_command_with_neither_anchor_is_not_refused() -> None:
+    """A command that cannot know its patient must not guess.
+
+    A plugin can return several effects from one handler; the note or command a later effect names
+    may not be persisted at the moment that effect is built, and refusing then would break a
+    legitimate chain. Asserted with no database available, so a lookup would raise rather than
+    return — this passing is the evidence that none happens.
+    """
+    command = ChangeMedicationCommand(medication_id=uuid.uuid4())
+
+    assert command._anchor_patient_id() is None


### PR DESCRIPTION
INTERNAL TRACKING: https://canvasmedical.atlassian.net/browse/KOALA-6684

This pull request refactors patient ownership validation for commands, centralizing the logic in the base command class and updating the `ChangeMedicationCommand` to use this shared logic. It also adds comprehensive tests to ensure medication changes are properly validated against the patient's active medications, preventing cross-patient edits and ensuring robust error handling.

**Centralization and Refactoring of Patient Ownership Logic:**

* Moved the `_anchor_patient_id` and `_is_target_patient` helper methods from individual command classes (such as `assess.py` and `change_medication.py`) into the shared base class (`_BaseCommand`), ensuring consistent and DRY patient resolution across all commands. [[1]](diffhunk://#diff-0365185fb98923e73ca31dd40505267268b09dffee4d4052eabd22f3dc6fe623R119-R149) [[2]](diffhunk://#diff-0365185fb98923e73ca31dd40505267268b09dffee4d4052eabd22f3dc6fe623R14) [[3]](diffhunk://#diff-e48351e05a48fab0279625e1cc546adcdd68390330fa9db549a8014be34eada5L32-L49) [[4]](diffhunk://#diff-958c4069e817c78c7299ed645ebcf52e9449361851809f26cf0575c006cc8b0fR2-R8)

**ChangeMedicationCommand Validation Improvements:**

* Updated the `ChangeMedicationCommand` to use the centralized patient resolution logic, and changed the type of `medication_id` to `UUID` for stricter validation. The command now checks that the medication belongs to the correct patient and is active, refusing invalid or cross-patient medication changes.
* Improved error handling in `ChangeMedicationCommand` by ensuring that missing or invalid medication IDs, or medications not associated with the patient, result in clear validation errors.

**Testing Enhancements:**

* Added a comprehensive test suite (`test_change_medication.py`) to verify correct behavior for medication changes, including acceptance of valid medications, rejection of foreign or inactive medications, validation of UUIDs, and correct handling when anchors are missing or unresolved.

**Code Cleanup:**

* Removed redundant imports and obsolete implementations from command modules now that the logic is centralized. [[1]](diffhunk://#diff-e48351e05a48fab0279625e1cc546adcdd68390330fa9db549a8014be34eada5L9-R9) [[2]](diffhunk://#diff-958c4069e817c78c7299ed645ebcf52e9449361851809f26cf0575c006cc8b0fR2-R8) [[3]](diffhunk://#diff-e48351e05a48fab0279625e1cc546adcdd68390330fa9db549a8014be34eada5L32-L49)


<!-- ## Title Guidelines

A title always has a prefix and a subject.

### Prefix
Make sure the title is prefixed with one of the following:

| Prefix | When to use |
|--------|-------------|
| `feat:`     | New feature |
| `fix:`      | Bug fix |
| `docs:`     | Documentation only changes |
| `style:`    | Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc) |
| `refactor:` | Code changes that neither fixes a bug nor adds a feature |
| `perf:`     | Code change that improves performance |
| `test:`     | Adding missing or correcting existing tests |
| `chore:`    | Changes to the build process or auxiliary tools and libraries such as documentation generation, ci, etc |

### Subject

Ensure the subject contains succinct description of the change.
* Use the imperative, present tense: "change", not "changed" nor "changes"
* Don’t capitalize first letter
* No dot (.) at the end
-->
