### PR TITLE
fix: hold the allergy narrative to the length the record accepts

### DIFF
--- a/canvas_sdk/commands/commands/allergy.py
+++ b/canvas_sdk/commands/commands/allergy.py
@@ -1,6 +1,7 @@
 from datetime import date
 from enum import Enum, IntEnum
 
+from pydantic import Field
 from typing_extensions import TypedDict
 
 from canvas_sdk.commands.base import _BaseCommand as BaseCommand
@@ -34,7 +35,7 @@ class AllergyCommand(BaseCommand):
 
     allergy: Allergen | None = None
     severity: Severity | None = None
-    narrative: str | None = None
+    narrative: str | None = Field(default=None, max_length=512)
     approximate_date: date | None = None
 
 

--- a/canvas_sdk/tests/commands/test_allergy.py
+++ b/canvas_sdk/tests/commands/test_allergy.py
@@ -1,0 +1,59 @@
+import json
+
+import pytest
+from pydantic_core import ValidationError
+
+from canvas_generated.messages.effects_pb2 import EffectType
+from canvas_sdk.commands.commands.allergy import AllergyCommand
+
+NOTE_UUID = "9b1deb4d-3b7d-4bad-9bdd-2b0d7b3dcb6d"
+COMMAND_UUID = "1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed"
+
+
+# --- narrative max length -------------------------------------------------
+
+
+def test_narrative_accepts_max_length() -> None:
+    """Narrative accepts a value at the 512 character limit."""
+    assert AllergyCommand(note_uuid=NOTE_UUID, narrative="a" * 512).narrative == "a" * 512
+
+
+def test_narrative_rejects_above_max_length() -> None:
+    """Narrative rejects a value over the 512 character limit, against the field."""
+    with pytest.raises(ValidationError) as caught:
+        AllergyCommand(note_uuid=NOTE_UUID, narrative="a" * 513)
+
+    error = caught.value.errors()[0]
+    assert error["loc"] == ("narrative",)
+    assert error["type"] == "string_too_long"
+
+
+def test_narrative_rejects_above_max_length_on_assignment() -> None:
+    """Narrative is validated when assigned after construction."""
+    allergy = AllergyCommand(note_uuid=NOTE_UUID)
+
+    with pytest.raises(ValidationError):
+        allergy.narrative = "a" * 513
+
+
+@pytest.mark.parametrize("narrative", [None, ""])
+def test_narrative_is_optional(narrative: str | None) -> None:
+    """An allergy can be recorded without describing the reaction."""
+    assert AllergyCommand(note_uuid=NOTE_UUID, narrative=narrative).narrative == narrative
+
+
+def test_narrative_defaults_to_none() -> None:
+    """Narrative defaults to None."""
+    assert AllergyCommand(note_uuid=NOTE_UUID).narrative is None
+
+
+def test_narrative_reaches_the_originate_payload() -> None:
+    """The limit guards a value that is actually sent, not one dropped on the way out."""
+    command = AllergyCommand(
+        note_uuid=NOTE_UUID, command_uuid=COMMAND_UUID, narrative="Hives within an hour"
+    )
+
+    effect = command.originate()
+
+    assert effect.type == EffectType.ORIGINATE_ALLERGY_COMMAND
+    assert json.loads(effect.payload)["data"]["narrative"] == "Hives within an hour"


### PR DESCRIPTION
https://canvasmedical.atlassian.net/browse/KOALA-6682

`AllergyCommand.narrative` had no length limit, so a value longer than the record accepts was
charted and then refused later, away from the plugin that sent it.

`narrative` is now capped at 512 characters, which is what the reaction field stores.

## Tests

`canvas_sdk/tests/commands/test_allergy.py` - the limit at its boundary, over it (asserting the error
names the field so a caller knows what to shorten), on assignment as well as construction, empty and
absent values, and the narrative reaching the originate payload.

Full suite passes, mypy clean.