### PR TITLE
fix: bound the update diagnosis text fields when an effect is built

### DIFF
--- a/canvas_sdk/commands/commands/update_diagnosis.py
+++ b/canvas_sdk/commands/commands/update_diagnosis.py
@@ -1,6 +1,11 @@
+from typing import Any
+
 from pydantic import Field
+from pydantic_core import InitErrorDetails
 
 from canvas_sdk.commands.base import _BaseCommand as BaseCommand
+
+_TEXT_MAX_LENGTH = 2048
 
 
 class UpdateDiagnosisCommand(BaseCommand):
@@ -17,6 +22,29 @@ class UpdateDiagnosisCommand(BaseCommand):
     )
     background: str | None = None
     narrative: str | None = None
+
+    def _get_error_details(self, method: Any) -> list[InitErrorDetails]:
+        """Check the text fields against the length the record accepts.
+
+        Checked when an effect is built rather than declared on the fields: `validate_assignment` is
+        on, so a bound on the field raises at the line that assigns it, part-way through a handler.
+        A caller assembling this text from a longer source would crash where it is set instead of
+        being told when the command is written.
+        """
+        errors = super()._get_error_details(method)
+
+        for name in ("background", "narrative"):
+            value = getattr(self, name)
+            if value is not None and len(value) > _TEXT_MAX_LENGTH:
+                errors.append(
+                    self._create_error_detail(
+                        "value",
+                        f"{name} cannot be longer than {_TEXT_MAX_LENGTH} characters",
+                        value,
+                    )
+                )
+
+        return errors
 
 
 __exports__ = ("UpdateDiagnosisCommand",)

--- a/canvas_sdk/tests/commands/test_update_diagnosis.py
+++ b/canvas_sdk/tests/commands/test_update_diagnosis.py
@@ -1,0 +1,77 @@
+import pytest
+from pydantic_core import ValidationError
+
+from canvas_sdk.commands.commands.update_diagnosis import UpdateDiagnosisCommand
+
+NOTE_UUID = "9b1deb4d-3b7d-4bad-9bdd-2b0d7b3dcb6d"
+COMMAND_UUID = "1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed"
+MAX_LENGTH = 2048
+
+
+# --- background and narrative max length ----------------------------------
+#
+# Checked when an effect is built rather than when the field is set. On the field it raised at the
+# assigning line, which breaks a plugin assembling this text part-way through a handler. Deferring
+# keeps the over-long value off the chart without crashing the handler that produced it.
+
+
+@pytest.mark.parametrize("field", ["background", "narrative"])
+def test_accepts_max_length(field: str) -> None:
+    """The boundary belongs on the allowed side, and the value is not rewritten."""
+    text = "a" * MAX_LENGTH
+
+    command = UpdateDiagnosisCommand(note_uuid=NOTE_UUID, **{field: text})
+
+    assert getattr(command, field) == text
+    assert command.originate()
+
+
+@pytest.mark.parametrize("field", ["background", "narrative"])
+def test_over_long_text_can_be_set_without_raising(field: str) -> None:
+    """The regression this shape exists to prevent: assignment stays quiet."""
+    text = "a" * (MAX_LENGTH + 500)
+    command = UpdateDiagnosisCommand(note_uuid=NOTE_UUID)
+
+    setattr(command, field, text)
+
+    assert getattr(command, field) == text
+
+
+@pytest.mark.parametrize("field", ["background", "narrative"])
+def test_over_long_text_is_refused_when_the_effect_is_built(field: str) -> None:
+    """Refused at the boundary instead, so it never reaches the chart."""
+    command = UpdateDiagnosisCommand(note_uuid=NOTE_UUID, **{field: "a" * (MAX_LENGTH + 1)})
+
+    with pytest.raises(ValidationError) as caught:
+        command.originate()
+
+    assert f"{field} cannot be longer than {MAX_LENGTH} characters" in str(caught.value)
+
+
+@pytest.mark.parametrize("field", ["background", "narrative"])
+def test_over_long_text_is_refused_on_an_edit_too(field: str) -> None:
+    """An edit carries the data as well, so the same limit applies."""
+    command = UpdateDiagnosisCommand(command_uuid=COMMAND_UUID, **{field: "a" * (MAX_LENGTH + 1)})
+
+    with pytest.raises(ValidationError):
+        command.edit()
+
+
+def test_both_fields_are_reported_together() -> None:
+    """Deferring to the effect means a caller is told about every value at once."""
+    command = UpdateDiagnosisCommand(
+        note_uuid=NOTE_UUID,
+        background="a" * (MAX_LENGTH + 1),
+        narrative="a" * (MAX_LENGTH + 1),
+    )
+
+    with pytest.raises(ValidationError) as caught:
+        command.originate()
+
+    assert len(caught.value.errors()) == 2
+
+
+@pytest.mark.parametrize("field", ["background", "narrative"])
+def test_defaults_to_none(field: str) -> None:
+    """Both fields are optional and default to None."""
+    assert getattr(UpdateDiagnosisCommand(note_uuid=NOTE_UUID), field) is None


### PR DESCRIPTION
https://canvasmedical.atlassian.net/browse/KOALA-6719

`UpdateDiagnosisCommand.background` and `narrative` had no length limit, so a value longer than the
record accepts was charted and then refused later, away from the plugin that sent it.

Both are now bounded at 2048 characters, **when the command is turned into an effect**.

## Why at the effect and not on the field

These validators would otherwise run eagerly - `validate_assignment` is on - so a bound on the field
raises at the line that assigns it, part-way through a handler. A caller assembling this text from a
longer source would crash where it is set rather than being told when the command is written, which
turns working plugins into crashing ones. Deferring keeps the over-long value off the chart without
moving where the failure happens, and reports both fields at once rather than only the first.

`condition_code` and `new_condition_code` identify the condition by code rather than by id, so there is
no record to check ownership of on this command.

## Tests

11 in `canvas_sdk/tests/commands/test_update_diagnosis.py` - each field at its boundary, over it,
refused on an edit as well as an originate, assignment staying quiet, both fields reported together, and
defaulting to absent.

Neutering the check fails 5 of them. Full suite passes, mypy clean.