### PR TITLE
fix: hold the family history note to the length the record accepts

### DIFF
--- a/canvas_sdk/commands/commands/family_history.py
+++ b/canvas_sdk/commands/commands/family_history.py
@@ -1,3 +1,4 @@
+from pydantic import Field
 from pydantic_core import InitErrorDetails
 
 from canvas_sdk.commands.base import _BaseCommand as BaseCommand
@@ -12,7 +13,7 @@ class FamilyHistoryCommand(BaseCommand):
 
     family_history: str | Coding | None = None
     relative: str | None = None
-    note: str | None = None
+    note: str | None = Field(default=None, max_length=512)
 
     def _get_error_details(self, method: str) -> list[InitErrorDetails]:
         errors = super()._get_error_details(method)

--- a/canvas_sdk/tests/commands/test_family_history.py
+++ b/canvas_sdk/tests/commands/test_family_history.py
@@ -1,0 +1,40 @@
+import pytest
+from pydantic_core import ValidationError
+
+from canvas_sdk.commands.commands.family_history import FamilyHistoryCommand
+
+NOTE_UUID = "9b1deb4d-3b7d-4bad-9bdd-2b0d7b3dcb6d"
+MAX_LENGTH = 512
+
+
+# --- note max length ------------------------------------------------------
+
+
+def test_note_accepts_max_length() -> None:
+    """Note accepts a value at the 512 character limit."""
+    text = "a" * MAX_LENGTH
+
+    assert FamilyHistoryCommand(note_uuid=NOTE_UUID, note=text).note == text
+
+
+def test_note_rejects_above_max_length() -> None:
+    """Over the limit is refused, against the field, so a caller knows what to shorten."""
+    with pytest.raises(ValidationError) as caught:
+        FamilyHistoryCommand(note_uuid=NOTE_UUID, note="a" * (MAX_LENGTH + 1))
+
+    error = caught.value.errors()[0]
+    assert error["loc"] == ("note",)
+    assert error["type"] == "string_too_long"
+
+
+def test_note_rejects_above_max_length_on_assignment() -> None:
+    """The note is validated when assigned after construction."""
+    command = FamilyHistoryCommand(note_uuid=NOTE_UUID)
+
+    with pytest.raises(ValidationError):
+        command.note = "a" * (MAX_LENGTH + 1)
+
+
+def test_note_defaults_to_none() -> None:
+    """The note is optional and defaults to None."""
+    assert FamilyHistoryCommand(note_uuid=NOTE_UUID).note is None


### PR DESCRIPTION
https://canvasmedical.atlassian.net/browse/KOALA-6688

`FamilyHistoryCommand.note` had no length limit, so a value longer than the record accepts was charted
and then refused later, away from the plugin that sent it.

`note` is now capped at 512 characters.

## Tests

`canvas_sdk/tests/commands/test_family_history.py` - the limit at its boundary, over it (asserting the
error names the field), on assignment as well as construction, and defaulting to absent.

Full suite passes, mypy clean.