### PR TITLE
fix: hold the medication statement sig to the length the record accepts

### DIFF
--- a/canvas_sdk/commands/commands/medication_statement.py
+++ b/canvas_sdk/commands/commands/medication_statement.py
@@ -14,7 +14,7 @@ class MedicationStatementCommand(_BaseCommand):
     fdb_code: str | Coding | None = Field(
         default=None, json_schema_extra={"commands_api_name": "medication"}
     )
-    sig: str | None = None
+    sig: str | None = Field(default=None, max_length=1000)
 
     def _get_error_details(self, method: str) -> list[InitErrorDetails]:
         errors = super()._get_error_details(method)

--- a/canvas_sdk/tests/commands/test_medication_statement.py
+++ b/canvas_sdk/tests/commands/test_medication_statement.py
@@ -1,0 +1,40 @@
+import pytest
+from pydantic_core import ValidationError
+
+from canvas_sdk.commands.commands.medication_statement import MedicationStatementCommand
+
+NOTE_UUID = "9b1deb4d-3b7d-4bad-9bdd-2b0d7b3dcb6d"
+MAX_LENGTH = 1000
+
+
+# --- sig max length -------------------------------------------------------
+
+
+def test_sig_accepts_max_length() -> None:
+    """Sig accepts a value at the 1000 character limit."""
+    text = "a" * MAX_LENGTH
+
+    assert MedicationStatementCommand(note_uuid=NOTE_UUID, sig=text).sig == text
+
+
+def test_sig_rejects_above_max_length() -> None:
+    """Over the limit is refused, against the field, so a caller knows what to shorten."""
+    with pytest.raises(ValidationError) as caught:
+        MedicationStatementCommand(note_uuid=NOTE_UUID, sig="a" * (MAX_LENGTH + 1))
+
+    error = caught.value.errors()[0]
+    assert error["loc"] == ("sig",)
+    assert error["type"] == "string_too_long"
+
+
+def test_sig_rejects_above_max_length_on_assignment() -> None:
+    """The sig is validated when assigned after construction."""
+    command = MedicationStatementCommand(note_uuid=NOTE_UUID)
+
+    with pytest.raises(ValidationError):
+        command.sig = "a" * (MAX_LENGTH + 1)
+
+
+def test_sig_defaults_to_none() -> None:
+    """The sig is optional and defaults to None."""
+    assert MedicationStatementCommand(note_uuid=NOTE_UUID).sig is None


### PR DESCRIPTION
https://canvasmedical.atlassian.net/browse/KOALA-6699

`MedicationStatementCommand.sig` had no length limit, so a value longer than the record accepts was
charted and then refused later, away from the plugin that sent it.

`sig` is now capped at 1000 characters.

## Tests

`canvas_sdk/tests/commands/test_medication_statement.py` - the limit at its boundary, over it
(asserting the error names the field), on assignment as well as construction, and defaulting to
absent.

Full suite passes, mypy clean.