### PR TITLE
fix: hold the immunization statement comments to the length the record accepts

### DIFF
--- a/canvas_sdk/commands/commands/immunization_statement.py
+++ b/canvas_sdk/commands/commands/immunization_statement.py
@@ -1,5 +1,6 @@
 from datetime import date
 
+from pydantic import Field
 from pydantic_core import InitErrorDetails
 
 from canvas_sdk.commands.base import _BaseCommand as BaseCommand
@@ -16,7 +17,7 @@ class ImmunizationStatementCommand(BaseCommand):
     cvx_code: str | Coding | None = None
     unstructured: Coding | None = None
     approximate_date: date | None = None
-    comments: str | None = None
+    comments: str | None = Field(default=None, max_length=255)
 
     def _has_value(self, value: str | Coding | None) -> bool:
         """Check if a value is set."""

--- a/canvas_sdk/tests/commands/test_immunization_statement.py
+++ b/canvas_sdk/tests/commands/test_immunization_statement.py
@@ -1,0 +1,40 @@
+import pytest
+from pydantic_core import ValidationError
+
+from canvas_sdk.commands.commands.immunization_statement import ImmunizationStatementCommand
+
+NOTE_UUID = "9b1deb4d-3b7d-4bad-9bdd-2b0d7b3dcb6d"
+MAX_LENGTH = 255
+
+
+# --- comments max length --------------------------------------------------
+
+
+def test_comments_accepts_max_length() -> None:
+    """Comments accepts a value at the 255 character limit."""
+    text = "a" * MAX_LENGTH
+
+    assert ImmunizationStatementCommand(note_uuid=NOTE_UUID, comments=text).comments == text
+
+
+def test_comments_rejects_above_max_length() -> None:
+    """Over the limit is refused, against the field, so a caller knows what to shorten."""
+    with pytest.raises(ValidationError) as caught:
+        ImmunizationStatementCommand(note_uuid=NOTE_UUID, comments="a" * (MAX_LENGTH + 1))
+
+    error = caught.value.errors()[0]
+    assert error["loc"] == ("comments",)
+    assert error["type"] == "string_too_long"
+
+
+def test_comments_rejects_above_max_length_on_assignment() -> None:
+    """Comments is validated when assigned after construction."""
+    command = ImmunizationStatementCommand(note_uuid=NOTE_UUID)
+
+    with pytest.raises(ValidationError):
+        command.comments = "a" * (MAX_LENGTH + 1)
+
+
+def test_comments_defaults_to_none() -> None:
+    """Comments is optional and defaults to None."""
+    assert ImmunizationStatementCommand(note_uuid=NOTE_UUID).comments is None


### PR DESCRIPTION
https://canvasmedical.atlassian.net/browse/KOALA-6694

`ImmunizationStatementCommand.comments` had no length limit, so a value longer than the record accepts
was charted and then refused later, away from the plugin that sent it.

`comments` is now capped at 255 characters.

Worth noting separately: the record also carries a `date` that this command has no field for, so it
cannot be set from a plugin at all. That is a missing field rather than a missing limit, and is not
addressed here.

## Tests

`canvas_sdk/tests/commands/test_immunization_statement.py` - the limit at its boundary, over it
(asserting the error names the field), on assignment as well as construction, and defaulting to
absent.

Full suite passes, mypy clean.