### PR TITLE
fix: check the goal being closed belongs to the command's patient

### DIFF
--- a/canvas_sdk/commands/commands/close_goal.py
+++ b/canvas_sdk/commands/commands/close_goal.py
@@ -1,5 +1,10 @@
+from typing import Any
+
+from pydantic_core import InitErrorDetails
+
 from canvas_sdk.commands.base import _BaseCommand as BaseCommand
 from canvas_sdk.commands.commands.goal import GoalCommand
+from canvas_sdk.v1.data import Goal
 
 
 class CloseGoalCommand(BaseCommand):
@@ -11,6 +16,29 @@ class CloseGoalCommand(BaseCommand):
     goal_id: int | None = None
     achievement_status: GoalCommand.AchievementStatus | None = None
     progress: str | None = None
+
+    def _get_error_details(self, method: Any) -> list[InitErrorDetails]:
+        """Check that the goal being closed is one this patient has.
+
+        Only ownership is checked. The patient is resolved from the note or, on an edit, from the
+        command itself; when neither is persisted yet there is nothing to compare against and the
+        check is skipped, so a plugin returning several effects at once still works.
+        """
+        errors = super()._get_error_details(method)
+
+        if self.goal_id is None or (patient_id := self._anchor_patient_id()) is None:
+            return errors
+
+        if not Goal.objects.filter(dbid=self.goal_id, patient__id=patient_id).exists():
+            errors.append(
+                self._create_error_detail(
+                    "value",
+                    f"Goal {self.goal_id} not found or not associated with the patient.",
+                    self.goal_id,
+                )
+            )
+
+        return errors
 
 
 __exports__ = ("CloseGoalCommand",)

--- a/canvas_sdk/tests/commands/test_close_goal.py
+++ b/canvas_sdk/tests/commands/test_close_goal.py
@@ -126,3 +126,30 @@ def test_an_uncommitted_goal_is_still_accepted(note: Note, patient: Patient) -> 
     Goal.objects.filter(dbid=goal.dbid).update(committer_id=None)
 
     assert CloseGoalCommand(note_uuid=str(note.id), goal_id=goal.dbid).originate()
+
+
+def test_the_notes_patient_is_the_target(note: Note) -> None:
+    """When the anchor resolves, the patient it names is the target."""
+    command = CloseGoalCommand(note_uuid=str(note.id))
+    anchor_patient_id = command._anchor_patient_id()
+
+    assert anchor_patient_id is not None
+    assert command._is_target_patient(anchor_patient_id) is True
+
+
+def test_a_patient_other_than_the_notes_is_not_the_target(
+    note: Note, other_patient: Patient
+) -> None:
+    """A resolved anchor is the target for its own patient and no one else."""
+    command = CloseGoalCommand(note_uuid=str(note.id))
+
+    assert command._is_target_patient(str(other_patient.id)) is False
+
+
+def test_every_patient_is_the_target_when_no_anchor_resolves() -> None:
+    """With nothing to resolve the patient from, no record is refused.
+
+    Asserted with no database available, so a lookup would raise rather than return — this passing
+    is the evidence that none happens.
+    """
+    assert CloseGoalCommand(goal_id=1)._is_target_patient("any-patient") is True

--- a/canvas_sdk/tests/commands/test_close_goal.py
+++ b/canvas_sdk/tests/commands/test_close_goal.py
@@ -1,0 +1,128 @@
+import datetime
+
+import pytest
+from pydantic_core import ValidationError
+
+from canvas_sdk.commands.commands.close_goal import CloseGoalCommand
+from canvas_sdk.test_utils.factories import NoteFactory, PatientFactory
+from canvas_sdk.v1.data import Command, Goal, Note, Patient
+
+
+@pytest.fixture
+def patient(db: None) -> Patient:
+    """The patient whose chart the command writes to."""
+    return PatientFactory.create()
+
+
+@pytest.fixture
+def other_patient(db: None) -> Patient:
+    """An unrelated patient, for building a goal that belongs to someone else."""
+    return PatientFactory.create()
+
+
+@pytest.fixture
+def note(patient: Patient) -> Note:
+    """A note on the target patient's chart."""
+    return NoteFactory.create(patient=patient)
+
+
+def _goal(patient: Patient, note: Note) -> Goal:
+    """A goal on a patient's chart."""
+    return Goal.objects.create(
+        patient=patient,
+        note=note,
+        goal_statement="Walk 20 minutes daily",
+        start_date=datetime.date(2024, 1, 1),
+        due_date=datetime.date(2024, 6, 1),
+        achievement_status="in-progress",
+        priority="medium-priority",
+        lifecycle_status="active",
+        committer_id=1,
+        entered_in_error_id=None,
+        deleted=False,
+    )
+
+
+@pytest.fixture
+def stored_command(note: Note) -> Command:
+    """A persisted closeGoal command on the note, for exercising the edit path."""
+    return Command.objects.create(
+        note=note,
+        patient=note.patient,
+        state="staged",
+        schema_key="closeGoal",
+        data={},
+        origination_source="plugin",
+        anchor_object_type="",
+        anchor_object_dbid=0,
+    )
+
+
+# `goal_id` is a database id, and nothing else refuses one belonging to another patient: the id is
+# resolved against the patient downstream and quietly dropped when nothing matches, so a wrong id
+# would otherwise produce a close-goal command with no goal on it.
+
+
+def test_a_goal_on_the_patients_chart_is_accepted(note: Note, patient: Patient) -> None:
+    """The ordinary case: the id names one of this patient's goals."""
+    goal = _goal(patient, note)
+
+    assert CloseGoalCommand(note_uuid=str(note.id), goal_id=goal.dbid).originate()
+
+
+def test_a_goal_belonging_to_another_patient_is_refused(note: Note, other_patient: Patient) -> None:
+    """The check this exists for — a real goal, but not this patient's."""
+    foreign = _goal(other_patient, note)
+
+    with pytest.raises(ValidationError) as caught:
+        CloseGoalCommand(note_uuid=str(note.id), goal_id=foreign.dbid).originate()
+
+    assert "not found or not associated with the patient" in str(caught.value)
+
+
+def test_a_goal_id_that_names_nothing_is_refused(note: Note) -> None:
+    """A database id no goal has."""
+    with pytest.raises(ValidationError):
+        CloseGoalCommand(note_uuid=str(note.id), goal_id=999_999).originate()
+
+
+def test_the_check_holds_on_an_edit_which_carries_no_note(
+    stored_command: Command, note: Note, other_patient: Patient
+) -> None:
+    """An edit addresses a command rather than a note, and the patient resolves from it."""
+    foreign = _goal(other_patient, note)
+
+    with pytest.raises(ValidationError):
+        CloseGoalCommand(command_uuid=str(stored_command.id), goal_id=foreign.dbid).edit()
+
+
+def test_an_edit_naming_the_patients_own_goal_is_allowed(
+    stored_command: Command, note: Note, patient: Patient
+) -> None:
+    """The other half: resolving the patient from the command must not refuse a valid edit."""
+    goal = _goal(patient, note)
+
+    assert CloseGoalCommand(command_uuid=str(stored_command.id), goal_id=goal.dbid).edit()
+
+
+def test_no_goal_id_means_nothing_to_check(note: Note) -> None:
+    """The field is optional until commit, so an empty command originates fine."""
+    assert CloseGoalCommand(note_uuid=str(note.id)).originate()
+
+
+def test_a_command_with_neither_anchor_is_not_refused() -> None:
+    """A command that cannot know its patient must not guess.
+
+    A plugin can return several effects from one handler, and the note or command a later effect
+    names may not be persisted when that effect is built. Asserted with no database available, so a
+    lookup would raise rather than return — this passing is the evidence that none happens.
+    """
+    assert CloseGoalCommand(goal_id=1)._anchor_patient_id() is None
+
+
+def test_an_uncommitted_goal_is_still_accepted(note: Note, patient: Patient) -> None:
+    """Only ownership is checked, so a goal that has not been committed yet is not refused here."""
+    goal = _goal(patient, note)
+    Goal.objects.filter(dbid=goal.dbid).update(committer_id=None)
+
+    assert CloseGoalCommand(note_uuid=str(note.id), goal_id=goal.dbid).originate()


### PR DESCRIPTION
https://canvasmedical.atlassian.net/browse/KOALA-6686

`CloseGoalCommand.goal_id` was unchecked. A plugin naming another patient's goal, or one that does not
exist, had the command charted with no goal at all: the id is resolved against the patient downstream
and quietly dropped when nothing matches.

## What it does now

- resolves the patient from the note *or* the command, so ownership holds on an edit as well as an
  originate
- checks only that the goal exists and belongs to that patient, not whether it is committed
- skips the check when neither anchor is persisted yet, so chained effects still work

`goal_id` is a database id here, so there is no id-shape guard to apply - a value that is not an
integer is already refused by the field.

## Tests

8 in `canvas_sdk/tests/commands/test_close_goal.py` - ownership on originate and edit, an id that names
nothing, no id at all, no anchor, and an uncommitted goal still being accepted. Removing the ownership
condition fails 3 of them.

Full suite passes, mypy clean.