### PR TITLE
fix: bound the lab order comment when an effect is built

### DIFF
--- a/canvas_sdk/commands/commands/lab_order.py
+++ b/canvas_sdk/commands/commands/lab_order.py
@@ -9,6 +9,8 @@ from canvas_sdk.commands.base import _BaseCommand as BaseCommand
 from canvas_sdk.commands.base import _SendableCommandMixin
 from canvas_sdk.v1.data.lab import LabPartner, LabPartnerTest
 
+_COMMENT_MAX_LENGTH = 128
+
 
 class LabOrderCommand(_SendableCommandMixin, BaseCommand):
     """A class for managing a Lab Order command within a specific note."""
@@ -98,6 +100,15 @@ class LabOrderCommand(_SendableCommandMixin, BaseCommand):
                             self.tests_order_codes,
                         )
                     )
+
+        if self.comment and len(self.comment) > _COMMENT_MAX_LENGTH:
+            errors.append(
+                self._create_error_detail(
+                    "value",
+                    f"comment cannot be longer than {_COMMENT_MAX_LENGTH} characters",
+                    self.comment,
+                )
+            )
 
         return errors
 

--- a/canvas_sdk/tests/commands/test_lab_order.py
+++ b/canvas_sdk/tests/commands/test_lab_order.py
@@ -1,0 +1,58 @@
+import pytest
+from pydantic_core import ValidationError
+
+from canvas_sdk.commands.commands.lab_order import LabOrderCommand
+
+NOTE_UUID = "9b1deb4d-3b7d-4bad-9bdd-2b0d7b3dcb6d"
+COMMAND_UUID = "1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed"
+MAX_LENGTH = 128
+
+
+# --- comment max length ---------------------------------------------------
+#
+# Checked when an effect is built rather than when the field is set, so a plugin assembling the
+# comment part-way through a handler is told when the command is written instead of crashing where
+# the value is assigned.
+
+
+def test_comment_at_the_limit_is_accepted() -> None:
+    """The boundary belongs on the allowed side."""
+    text = "a" * MAX_LENGTH
+
+    command = LabOrderCommand(note_uuid=NOTE_UUID, comment=text)
+
+    assert command.comment == text
+    assert command.originate()
+
+
+def test_an_over_long_comment_can_be_set_without_raising() -> None:
+    """The regression this shape exists to prevent: assignment stays quiet."""
+    text = "a" * (MAX_LENGTH + 500)
+    command = LabOrderCommand(note_uuid=NOTE_UUID)
+
+    command.comment = text
+
+    assert command.comment == text
+
+
+def test_an_over_long_comment_is_refused_when_the_effect_is_built() -> None:
+    """Refused at the boundary instead, so it never reaches the chart."""
+    command = LabOrderCommand(note_uuid=NOTE_UUID, comment="a" * (MAX_LENGTH + 1))
+
+    with pytest.raises(ValidationError) as caught:
+        command.originate()
+
+    assert "comment cannot be longer than 128 characters" in str(caught.value)
+
+
+def test_an_over_long_comment_is_refused_on_an_edit_too() -> None:
+    """An edit carries the data as well, so the same limit applies."""
+    command = LabOrderCommand(command_uuid=COMMAND_UUID, comment="a" * (MAX_LENGTH + 1))
+
+    with pytest.raises(ValidationError):
+        command.edit()
+
+
+def test_comment_defaults_to_none() -> None:
+    """The comment is optional and defaults to None."""
+    assert LabOrderCommand(note_uuid=NOTE_UUID).comment is None


### PR DESCRIPTION
https://canvasmedical.atlassian.net/browse/KOALA-6696

`LabOrderCommand.comment` had no length limit, so a value longer than the record accepts was charted and
then refused later, away from the plugin that sent it.

`comment` is now bounded at 128 characters - shorter than the free-text limits on the other commands,
because the comment is stored on the lab order itself rather than in a note field, so it is the one a
caller is most likely to overrun.

## Why at the effect and not on the field

The bound is checked when the command is turned into an effect rather than when the field is set. On the
field it would raise at the assigning line, part-way through a handler, which risks breaking plugins that
already set a longer comment. Deferring keeps the over-long value off the chart without moving where the
failure happens.

The rest of this command was already validated: `lab_partner` is resolved by id or name and refused if
unknown, and the tests are checked against that partner with any missing order codes named. Nothing on
this command references a patient's records, so there is no ownership check to add.

## Tests

5 in `canvas_sdk/tests/commands/test_lab_order.py` - the limit at its boundary, over it refused at
`originate()` and at `edit()`, assignment staying quiet, and defaulting to absent.

Removing the check fails 2 of them. Full suite passes, mypy clean.