### PR TITLE
feat(examples): add Virtuosis voice biomarker integration

### DIFF
--- a/example-plugins/virtuosis_voice_biomarker/pyproject.toml
+++ b/example-plugins/virtuosis_voice_biomarker/pyproject.toml
@@ -1,0 +1,12 @@
+[project]
+authors = [{name = "Virtuosis Artificial Intelligence SA"}]
+dependencies = ["canvas[test-utils]"]
+description = "Consent-gated voice biomarker analysis with the Virtuosis API"
+license = "MIT"
+name = "virtuosis_voice_biomarker"
+readme = "virtuosis_voice_biomarker/README.md"
+requires-python = ">=3.11"
+version = "0.1.0"
+
+[tool.pytest.ini_options]
+python_files = ["*_tests.py", "test_*.py", "tests.py"]

--- a/example-plugins/virtuosis_voice_biomarker/pyproject.toml
+++ b/example-plugins/virtuosis_voice_biomarker/pyproject.toml
@@ -10,3 +10,4 @@ version = "0.1.0"
 
 [tool.pytest.ini_options]
 python_files = ["*_tests.py", "test_*.py", "tests.py"]
+pythonpath = ["."]

--- a/example-plugins/virtuosis_voice_biomarker/tests/test_validation.py
+++ b/example-plugins/virtuosis_voice_biomarker/tests/test_validation.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from virtuosis_voice_biomarker.validation import (
+    normalize_analysis_query,
+    validate_recording_id,
+    validate_submission,
+)
+
+ACCOUNT_ID = "00000000-0000-0000-0000-000000000000"
+
+
+def test_submission_requires_consent() -> None:
+    body, error = validate_submission({"consent_confirmed": False})
+    assert body is None
+    assert error == "Explicit recording transmission confirmation is required."
+
+
+def test_submission_is_normalized() -> None:
+    body, error = validate_submission(
+        {
+            "consent_confirmed": True,
+            "account_id": ACCOUNT_ID,
+            "recorded_at": "2026-08-23T10:00:00Z",
+            "analysis": ["wellbeing", "wellbeing"],
+            "audio_base64": "YXVkaW8=",
+        }
+    )
+    assert error is None
+    assert body is not None
+    assert body["analysis"] == ["wellbeing"]
+    assert body["audio"] == "YXVkaW8="
+
+
+def test_recording_id_and_query_validation() -> None:
+    assert validate_recording_id(ACCOUNT_ID)
+    assert not validate_recording_id("../../recording")
+    assert normalize_analysis_query("wellbeing,communication_coach,wellbeing") == [
+        "wellbeing",
+        "communication_coach",
+    ]

--- a/example-plugins/virtuosis_voice_biomarker/virtuosis_voice_biomarker/CANVAS_MANIFEST.json
+++ b/example-plugins/virtuosis_voice_biomarker/virtuosis_voice_biomarker/CANVAS_MANIFEST.json
@@ -1,0 +1,37 @@
+{
+  "sdk_version": "0.1.4",
+  "plugin_version": "0.1.0",
+  "name": "virtuosis_voice_biomarker",
+  "description": "Consent-gated Virtuosis voice biomarker analysis for clinical decision support.",
+  "components": {
+    "handlers": [
+      {
+        "class": "virtuosis_voice_biomarker.handlers.api:VirtuosisAnalysisAPI",
+        "description": "Staff-authenticated endpoints for submitting consented recordings and retrieving results.",
+        "data_access": {
+          "event": "",
+          "read": [],
+          "write": []
+        }
+      }
+    ],
+    "commands": [],
+    "content": [],
+    "effects": [],
+    "views": []
+  },
+  "variables": [
+    {
+      "name": "VIRTUOSIS_API_TOKEN",
+      "sensitive": true
+    }
+  ],
+  "tags": {},
+  "references": [
+    "https://docs.virtuosis.ai",
+    "https://www.virtuosis.ai/privacy-policy"
+  ],
+  "license": "MIT",
+  "diagram": false,
+  "readme": "./README.md"
+}

--- a/example-plugins/virtuosis_voice_biomarker/virtuosis_voice_biomarker/README.md
+++ b/example-plugins/virtuosis_voice_biomarker/virtuosis_voice_biomarker/README.md
@@ -1,0 +1,35 @@
+# Virtuosis
+
+This Canvas example integrates the Virtuosis API for consent-gated analysis of completed voice
+recordings. It exposes staff-authenticated endpoints for starting selected analyses and retrieving
+their current results.
+
+The plugin does not record audio, create patient or speaker accounts, or write results to the chart.
+Those steps depend on the customer's approved workflow, identity mapping, consent process,
+retention policy and clinical governance.
+
+## Configuration
+
+Add `VIRTUOSIS_API_TOKEN` as a sensitive plugin variable. Never include the token, patient
+identifiers, recordings or results in source control.
+
+## Endpoints
+
+`POST /plugin-io/api/virtuosis_voice_biomarker/analysis`
+
+```json
+{
+  "account_id": "pseudonymous Virtuosis account UUID",
+  "recorded_at": "2026-08-23T10:00:00Z",
+  "analysis": ["wellbeing"],
+  "audio_base64": "base64-encoded WAV, MP3, MP4 or OGG",
+  "consent_confirmed": true,
+  "isolate_oldest_speaker": false
+}
+```
+
+`GET /plugin-io/api/virtuosis_voice_biomarker/analysis/<recording_id>?analysis=wellbeing`
+
+Use only analyses enabled for the customer's contract and intended purpose. Virtuosis outputs are
+decision-support information and must not be treated as standalone diagnoses. Validate the final
+workflow and terminology mapping before writing any output to the medical record.

--- a/example-plugins/virtuosis_voice_biomarker/virtuosis_voice_biomarker/__init__.py
+++ b/example-plugins/virtuosis_voice_biomarker/virtuosis_voice_biomarker/__init__.py
@@ -1,0 +1,1 @@
+"""Virtuosis example integration for Canvas."""

--- a/example-plugins/virtuosis_voice_biomarker/virtuosis_voice_biomarker/handlers/__init__.py
+++ b/example-plugins/virtuosis_voice_biomarker/virtuosis_voice_biomarker/handlers/__init__.py
@@ -1,0 +1,1 @@
+"""Canvas handlers for the Virtuosis example plugin."""

--- a/example-plugins/virtuosis_voice_biomarker/virtuosis_voice_biomarker/handlers/api.py
+++ b/example-plugins/virtuosis_voice_biomarker/virtuosis_voice_biomarker/handlers/api.py
@@ -1,0 +1,78 @@
+"""Staff-authenticated proxy for the Virtuosis voice biomarker API."""
+
+from __future__ import annotations
+
+import json
+from http import HTTPStatus
+from urllib.parse import quote, urlencode
+
+from canvas_sdk.effects import Effect
+from canvas_sdk.effects.simple_api import JSONResponse, Response
+from canvas_sdk.handlers.simple_api import SimpleAPI, StaffSessionAuthMixin, api
+from canvas_sdk.utils import Http
+
+from virtuosis_voice_biomarker.validation import (
+    normalize_analysis_query,
+    validate_recording_id,
+    validate_submission,
+)
+
+API_BASE_URL = "https://api.virtuosis.ai/v1.3"
+
+
+class VirtuosisAnalysisAPI(StaffSessionAuthMixin, SimpleAPI):
+    """Submit consented recordings and retrieve their analysis state."""
+
+    PREFIX = "/analysis"
+
+    @api.post("/")
+    def analyze(self) -> list[Response | Effect]:
+        """Submit a completed, consented recording for selected analyses."""
+        request_body, validation_error = validate_submission(self.request.json())
+        if validation_error:
+            return [JSONResponse({"error": validation_error}, status_code=HTTPStatus.BAD_REQUEST)]
+        response = self._request("POST", "/recordings", request_body)
+        return [self._json_response(response)]
+
+    @api.get("/<recording_id>")
+    def result(self) -> list[Response | Effect]:
+        """Retrieve current results for an authorized recording."""
+        recording_id = self.request.path_params.get("recording_id")
+        if not validate_recording_id(recording_id):
+            return [
+                JSONResponse(
+                    {"error": "recording_id must be a UUID."},
+                    status_code=HTTPStatus.BAD_REQUEST,
+                )
+            ]
+        try:
+            analyses = normalize_analysis_query(self.request.query_params.get("analysis"))
+        except ValueError as error:
+            return [JSONResponse({"error": str(error)}, status_code=HTTPStatus.BAD_REQUEST)]
+
+        query = f"?{urlencode({'analysis': ','.join(analyses)})}" if analyses else ""
+        path = f"/recordings/{quote(str(recording_id), safe='')}/analysis{query}"
+        response = self._request("GET", path)
+        return [self._json_response(response)]
+
+    def _request(self, method: str, path: str, body: dict | None = None):
+        headers = {
+            "Authorization": f"Bearer {self.secrets['VIRTUOSIS_API_TOKEN']}",
+            "Accept": "application/json",
+        }
+        client = Http()
+        if method == "POST":
+            headers["Content-Type"] = "application/json"
+            return client.post(f"{API_BASE_URL}{path}", headers=headers, data=json.dumps(body))
+        return client.get(f"{API_BASE_URL}{path}", headers=headers)
+
+    @staticmethod
+    def _json_response(response) -> JSONResponse:
+        try:
+            body = response.json()
+        except (TypeError, ValueError):
+            body = {"error": "Virtuosis returned a non-JSON response."}
+        status_code = response.status_code
+        if not isinstance(status_code, int) or not 100 <= status_code <= 599:
+            status_code = HTTPStatus.BAD_GATEWAY
+        return JSONResponse(body, status_code=status_code)

--- a/example-plugins/virtuosis_voice_biomarker/virtuosis_voice_biomarker/validation.py
+++ b/example-plugins/virtuosis_voice_biomarker/virtuosis_voice_biomarker/validation.py
@@ -1,0 +1,85 @@
+"""Input validation kept separate from network and Canvas framework code."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+from uuid import UUID
+
+ALLOWED_ANALYSES = frozenset(
+    {"wellbeing", "parkinsons", "alzheimers", "communication_coach"}
+)
+MAX_BASE64_CHARACTERS = 67_000_000
+
+
+def validate_submission(payload: dict[str, Any]) -> tuple[dict[str, Any] | None, str | None]:
+    """Return a normalized Virtuosis request body or a safe validation message."""
+    if payload.get("consent_confirmed") is not True:
+        return None, "Explicit recording transmission confirmation is required."
+
+    account_id = payload.get("account_id")
+    if not _is_uuid(account_id):
+        return None, "account_id must be a UUID."
+
+    recorded_at = payload.get("recorded_at")
+    if not _is_timezone_aware_datetime(recorded_at):
+        return None, "recorded_at must be an ISO 8601 timestamp with a timezone."
+
+    analyses = payload.get("analysis")
+    if not isinstance(analyses, list) or not analyses:
+        return None, "Select at least one supported analysis."
+    normalized_analyses = list(dict.fromkeys(analyses))
+    if any(not isinstance(value, str) or value not in ALLOWED_ANALYSES for value in analyses):
+        return None, "Select at least one supported analysis."
+
+    audio = payload.get("audio_base64")
+    if not isinstance(audio, str) or not audio or len(audio) > MAX_BASE64_CHARACTERS:
+        return None, "audio_base64 is missing or exceeds the 50 MB recording limit."
+
+    return (
+        {
+            "account_id": account_id,
+            "recorded_at": recorded_at,
+            "analysis": normalized_analyses,
+            "audio": audio,
+            "isolate_oldest_speaker": bool(payload.get("isolate_oldest_speaker", False)),
+        },
+        None,
+    )
+
+
+def validate_recording_id(value: object) -> bool:
+    """Return whether the external recording identifier is a UUID."""
+    return _is_uuid(value)
+
+
+def normalize_analysis_query(value: object) -> list[str] | None:
+    """Validate an optional comma-separated analysis query."""
+    if value in (None, ""):
+        return None
+    if not isinstance(value, str):
+        raise ValueError("analysis query must be a comma-separated string")
+    normalized = list(dict.fromkeys(part.strip() for part in value.split(",") if part.strip()))
+    if not normalized or any(part not in ALLOWED_ANALYSES for part in normalized):
+        raise ValueError("analysis query contains an unsupported value")
+    return normalized
+
+
+def _is_uuid(value: object) -> bool:
+    if not isinstance(value, str):
+        return False
+    try:
+        UUID(value)
+    except ValueError:
+        return False
+    return True
+
+
+def _is_timezone_aware_datetime(value: object) -> bool:
+    if not isinstance(value, str):
+        return False
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return False
+    return parsed.tzinfo is not None


### PR DESCRIPTION
Adds a Canvas example plugin for consent-gated voice biomarker analysis with the Virtuosis API.

The example provides staff-authenticated endpoints to:

- submit a completed, explicitly authorized recording for selected analyses; and
- retrieve the current analysis state for a recording.

The API token is a sensitive Canvas variable. Input validation happens before network access, and
the plugin does not create accounts, capture audio, persist results or write to the chart. Those
steps remain customer-specific because they depend on identity mapping, the approved clinical
workflow, terminology, consent, retention and governance.

Validation performed:

- manifest validation and sandbox handler load;
- unit tests for consent, UUID, timestamp, analysis allow-list and query normalization; and
- Python compilation and whitespace checks.
