### PR TITLE
feat: add alternative way to add answers to questionnaires

### DIFF
--- a/canvas_sdk/commands/commands/questionnaire/__init__.py
+++ b/canvas_sdk/commands/commands/questionnaire/__init__.py
@@ -1,7 +1,7 @@
 from functools import cached_property
 from typing import Any
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 from canvas_sdk.commands.base import _BaseCommand
 from canvas_sdk.commands.commands.questionnaire.question import (
@@ -22,16 +22,32 @@ QUESTION_CLASSES: dict[str, type[BaseQuestion]] = {
 }
 
 
+class Selection(BaseModel):
+    """One option ticked on a checkbox question."""
+
+    # A key this model does not know is a caller's mistake, not something to drop quietly.
+    model_config = ConfigDict(extra="forbid")
+
+    # The option's id, as the question's options report it in dbid.
+    option_id: int
+    # What this selection is qualified with. A checkbox question is the only kind that takes a
+    # comment, and each of its selections carries its own.
+    comment: str = ""
+    # False unticks the option instead. An option a payload says nothing about keeps the state
+    # it already had.
+    selected: bool = True
+
+
 class Answer(BaseModel):
     """One question's response."""
 
-    #: The question's id, as :attr:`QuestionnaireCommand.questions` reports it.
+    model_config = ConfigDict(extra="forbid")
+
+    # The question's id, as the command's questions report it.
     question_id: int
-    #: The answer, in the form the question takes: text, a number, an option's id, or a list of
-    #: option ids for a checkbox.
-    response: str | int | list[int]
-    #: Carried onto a checkbox selection; ignored by every other question type.
-    comment: str = ""
+    # The answer, in the form the question takes: text, a number, an option's id, or the
+    # list of selections a checkbox question takes.
+    response: str | int | list[Selection]
 
 
 class QuestionnaireCommand(_BaseCommand):
@@ -45,8 +61,8 @@ class QuestionnaireCommand(_BaseCommand):
         default=None, json_schema_extra={"commands_api_name": "questionnaire"}
     )
     result: str | None = None
-    #: The answers this command records, one per question. Read into :attr:`values` as responses
-    #: on the matching :attr:`questions`.
+    # The answers this command records, one per question. Read into `values` as responses on
+    # the matching questions.
     answers: list[Answer] = Field(default_factory=list)
 
     @cached_property
@@ -124,8 +140,8 @@ class QuestionnaireCommand(_BaseCommand):
     def _apply_answers(self) -> None:
         """Set each answer as a response on its question, dispatching on the question's type.
 
-        Clears the questions :attr:`answers` names before setting them, so reading twice gives
-        the same result and a response set directly on any other question is left alone.
+        Clears the questions `answers` names before setting them, so reading twice gives the
+        same result and a response set directly on any other question is left alone.
         """
         questions = {str(question.id): question for question in self.questions}
 
@@ -146,14 +162,16 @@ class QuestionnaireCommand(_BaseCommand):
             elif question.type == ResponseOption.TYPE_RADIO:
                 question.add_response(option=self._option(question, str(answer.response)))
             else:
-                option_ids = (
-                    [str(option_id) for option_id in answer.response]
-                    if isinstance(answer.response, list)
-                    else [str(answer.response)]
-                )
-                for option_id in option_ids:
+                if not isinstance(answer.response, list):
+                    raise ValueError(
+                        f"Question '{question.label}' is answered with a list of selections"
+                    )
+
+                for selection in answer.response:
                     question.add_response(
-                        option=self._option(question, option_id), comment=answer.comment
+                        option=self._option(question, str(selection.option_id)),
+                        selected=selection.selected,
+                        comment=selection.comment,
                     )
 
     @property
@@ -174,4 +192,4 @@ class QuestionnaireCommand(_BaseCommand):
         return values
 
 
-__exports__ = ("QUESTION_CLASSES", "Answer", "QuestionnaireCommand")
+__exports__ = ("QUESTION_CLASSES", "Answer", "QuestionnaireCommand", "Selection")

--- a/canvas_sdk/commands/commands/questionnaire/__init__.py
+++ b/canvas_sdk/commands/commands/questionnaire/__init__.py
@@ -1,7 +1,7 @@
 from functools import cached_property
 from typing import Any
 
-from pydantic import Field
+from pydantic import BaseModel, Field
 
 from canvas_sdk.commands.base import _BaseCommand
 from canvas_sdk.commands.commands.questionnaire.question import (
@@ -22,6 +22,18 @@ QUESTION_CLASSES: dict[str, type[BaseQuestion]] = {
 }
 
 
+class Answer(BaseModel):
+    """One question's response."""
+
+    #: The question's id, as :attr:`QuestionnaireCommand.questions` reports it.
+    question_id: int
+    #: The answer, in the form the question takes: text, a number, an option's id, or a list of
+    #: option ids for a checkbox.
+    response: str | int | list[int]
+    #: Carried onto a checkbox selection; ignored by every other question type.
+    comment: str = ""
+
+
 class QuestionnaireCommand(_BaseCommand):
     """A class for managing a Questionnaire command within a specific note."""
 
@@ -33,6 +45,9 @@ class QuestionnaireCommand(_BaseCommand):
         default=None, json_schema_extra={"commands_api_name": "questionnaire"}
     )
     result: str | None = None
+    #: The answers this command records, one per question. Read into :attr:`values` as responses
+    #: on the matching :attr:`questions`.
+    answers: list[Answer] = Field(default_factory=list)
 
     @cached_property
     def _questionnaire(self) -> Questionnaire | None:
@@ -91,17 +106,72 @@ class QuestionnaireCommand(_BaseCommand):
                 raise ValueError(f"Unsupported question type: {q_type}")
         return question_objs
 
+    def _option(self, question: BaseQuestion, option_id: str) -> ResponseOption:
+        """The option this question offers under this id.
+
+        Ids are compared as text so a lone one that arrived as a string still matches.
+        """
+        for option in question.options:
+            if str(option.dbid) == option_id:
+                return option
+
+        allowed = ", ".join(f"{option.dbid} ({option.name})" for option in question.options)
+        raise ValueError(
+            f"{option_id!r} is not an option for question '{question.label}'. "
+            f"Allowed options: {allowed or 'none'}"
+        )
+
+    def _apply_answers(self) -> None:
+        """Set each answer as a response on its question, dispatching on the question's type.
+
+        Clears the questions :attr:`answers` names before setting them, so reading twice gives
+        the same result and a response set directly on any other question is left alone.
+        """
+        questions = {str(question.id): question for question in self.questions}
+
+        for answer in self.answers:
+            question = questions.get(str(answer.question_id))
+            if question is None:
+                raise ValueError(
+                    f"{answer.question_id} is not a question in questionnaire "
+                    f"{self.questionnaire_id}"
+                )
+
+            question.response = None
+
+            if question.type == ResponseOption.TYPE_TEXT:
+                question.add_response(text=str(answer.response))
+            elif question.type == ResponseOption.TYPE_INTEGER:
+                question.add_response(integer=answer.response)
+            elif question.type == ResponseOption.TYPE_RADIO:
+                question.add_response(option=self._option(question, str(answer.response)))
+            else:
+                option_ids = (
+                    [str(option_id) for option_id in answer.response]
+                    if isinstance(answer.response, list)
+                    else [str(answer.response)]
+                )
+                for option_id in option_ids:
+                    question.add_response(
+                        option=self._option(question, option_id), comment=answer.comment
+                    )
+
     @property
     def values(self) -> dict:
         """Return the values for the command.
 
         For questionnaire-related commands, this includes the responses to the questions.
         """
+        if self.answers:
+            self._apply_answers()
+
         values = super().values
+        # answers do not carry over the effect.
+        values.pop("answers", None)
 
         values["questions"] = {q.name: q.response for q in self.questions if q.response is not None}
 
         return values
 
 
-__exports__ = ("QUESTION_CLASSES", "QuestionnaireCommand")
+__exports__ = ("QUESTION_CLASSES", "Answer", "QuestionnaireCommand")

--- a/canvas_sdk/tests/commands/test_questionnaire_answers.py
+++ b/canvas_sdk/tests/commands/test_questionnaire_answers.py
@@ -11,7 +11,11 @@ from unittest.mock import PropertyMock, patch
 import pytest
 
 from canvas_sdk.commands import PhysicalExamCommand
-from canvas_sdk.commands.commands.questionnaire import Answer, QuestionnaireCommand
+from canvas_sdk.commands.commands.questionnaire import (
+    Answer,
+    QuestionnaireCommand,
+    Selection,
+)
 from canvas_sdk.commands.commands.questionnaire.question import (
     CheckboxQuestion,
     IntegerQuestion,
@@ -84,7 +88,7 @@ def test_the_caller_never_branches_on_the_question_type(command: QuestionnaireCo
     """One call shape answers a radio, a checkbox and a text question."""
     command.answers = [
         Answer(question_id=9, response=102),
-        Answer(question_id=10, response=[201]),
+        Answer(question_id=10, response=[Selection(option_id=201)]),
         Answer(question_id=11, response="Half a pack a day"),
     ]
 
@@ -104,13 +108,23 @@ def test_an_id_arriving_as_a_string_still_lands_on_its_option(
     assert command.values["questions"] == {"question-9": 102, "question-12": 2}
 
 
-def test_a_checkbox_takes_several_ids(command: QuestionnaireCommand) -> None:
-    """A checkbox answer is a list of ids, recorded as one selection each."""
-    command.answers = [Answer(question_id=10, response=[201, 202])]
+def test_a_checkbox_takes_several_selections(command: QuestionnaireCommand) -> None:
+    """A checkbox answer is a list of selections, recorded as one option each."""
+    command.answers = [
+        Answer(question_id=10, response=[Selection(option_id=201), Selection(option_id=202)])
+    ]
 
     selected = command.values["questions"]["question-10"]
 
     assert [entry["value"] for entry in selected] == [201, 202]
+
+
+def test_a_checkbox_answered_with_a_bare_id_is_refused(command: QuestionnaireCommand) -> None:
+    """A checkbox question takes selections, so a lone id is a mistake rather than one of them."""
+    command.answers = [Answer(question_id=10, response=201)]
+
+    with pytest.raises(ValueError, match="answered with a list of selections"):
+        _ = command.values
 
 
 def test_a_text_question_takes_what_was_written(command: QuestionnaireCommand) -> None:
@@ -138,14 +152,31 @@ def test_an_integer_question_refuses_what_is_not_a_number(command: Questionnaire
         _ = command.values
 
 
-def test_a_comment_rides_on_every_selection(command: QuestionnaireCommand) -> None:
-    """An answer's comment is carried onto each selection it makes."""
-    command.answers = [Answer(question_id=10, response=[201, 202], comment="both")]
+def test_each_selection_carries_its_own_comment(command: QuestionnaireCommand) -> None:
+    """Two options ticked on one question are qualified separately."""
+    command.answers = [
+        Answer(
+            question_id=10,
+            response=[
+                Selection(option_id=201, comment="a pack a day"),
+                Selection(option_id=202, comment="socially"),
+            ],
+        )
+    ]
 
     selected = command.values["questions"]["question-10"]
 
     assert [entry["text"] for entry in selected] == ["Cigarettes", "Cigar/Pipe"]
-    assert {entry["comment"] for entry in selected} == {"both"}
+    assert [entry["comment"] for entry in selected] == ["a pack a day", "socially"]
+
+
+def test_a_selection_can_untick_an_option(command: QuestionnaireCommand) -> None:
+    """An option left out of a payload keeps its state, so unticking has to be said."""
+    command.answers = [Answer(question_id=10, response=[Selection(option_id=201, selected=False)])]
+
+    selected = command.values["questions"]["question-10"]
+
+    assert [entry["selected"] for entry in selected] == [False]
 
 
 def test_an_option_the_question_does_not_offer_is_refused(command: QuestionnaireCommand) -> None:
@@ -169,7 +200,7 @@ def test_originating_and_editing_does_not_tick_the_box_twice(
 ) -> None:
     """Reading ``values`` twice records each checkbox selection once, not twice."""
     command.command_uuid = "9f1d3b6a-0000-4000-8000-00000000000a"
-    command.answers = [Answer(question_id=10, response=201)]
+    command.answers = [Answer(question_id=10, response=[Selection(option_id=201)])]
 
     originate, edit = json.loads(command.originate().payload), json.loads(command.edit().payload)
 

--- a/canvas_sdk/tests/commands/test_questionnaire_answers.py
+++ b/canvas_sdk/tests/commands/test_questionnaire_answers.py
@@ -1,0 +1,216 @@
+"""Tests for :attr:`QuestionnaireCommand.answers`.
+
+Each answer is a question id, a response and an optional comment; the command resolves it
+against that question's type and options.
+"""
+
+import json
+from collections.abc import Generator
+from unittest.mock import PropertyMock, patch
+
+import pytest
+
+from canvas_sdk.commands import PhysicalExamCommand
+from canvas_sdk.commands.commands.questionnaire import Answer, QuestionnaireCommand
+from canvas_sdk.commands.commands.questionnaire.question import (
+    CheckboxQuestion,
+    IntegerQuestion,
+    RadioQuestion,
+    ResponseOption,
+    TextQuestion,
+)
+
+QUESTIONNAIRE_ID = "3f1a5d0e-0000-4000-8000-000000000001"
+
+STATUS_OPTIONS = [
+    ResponseOption(dbid=101, name="Never user", code="LA18978-9", value="never"),
+    ResponseOption(dbid=102, name="Former user", code="LA15920-4", value="former"),
+]
+TYPE_OPTIONS = [
+    ResponseOption(dbid=201, name="Cigarettes", code="C1", value="cigarettes"),
+    ResponseOption(dbid=202, name="Cigar/Pipe", code="C2", value="cigar"),
+]
+#: Options named for numbers, with ids chosen to collide with those names.
+COUNT_OPTIONS = [
+    ResponseOption(dbid=1, name="2", code="N2", value="2"),
+    ResponseOption(dbid=2, name="5", code="N5", value="5"),
+]
+
+
+def questions() -> list[object]:
+    """One question of each type: radio, checkbox, text, number-named radio, integer."""
+    return [
+        RadioQuestion(
+            id="9", name="question-9", label="Status", coding={}, options=list(STATUS_OPTIONS)
+        ),
+        CheckboxQuestion(
+            id="10", name="question-10", label="Type", coding={}, options=list(TYPE_OPTIONS)
+        ),
+        TextQuestion(id="11", name="question-11", label="Comment", coding={}, options=[]),
+        RadioQuestion(
+            id="12", name="question-12", label="Days", coding={}, options=list(COUNT_OPTIONS)
+        ),
+        IntegerQuestion(id="13", name="question-13", label="Packs", coding={}, options=[]),
+    ]
+
+
+@pytest.fixture
+def command() -> Generator[QuestionnaireCommand, None, None]:
+    """A command whose questionnaire is the questions above."""
+    cmd = QuestionnaireCommand(questionnaire_id=QUESTIONNAIRE_ID, note_uuid="note-1")
+    patcher = patch.object(
+        QuestionnaireCommand, "questions", new_callable=PropertyMock, return_value=questions()
+    )
+    patcher.start()
+    yield cmd
+    patcher.stop()
+
+
+def test_a_choice_is_answered_by_option_id(command: QuestionnaireCommand) -> None:
+    """A radio answer is an option's id, recorded as that option."""
+    command.answers = [Answer(question_id=9, response=102)]
+
+    assert command.values["questions"] == {"question-9": 102}
+
+
+def test_two_answers_for_one_question_keeps_the_last(command: QuestionnaireCommand) -> None:
+    """Where a question is answered twice, the last answer is the one recorded."""
+    command.answers = [Answer(question_id=9, response=101), Answer(question_id=9, response=102)]
+
+    assert command.values["questions"] == {"question-9": 102}
+
+
+def test_the_caller_never_branches_on_the_question_type(command: QuestionnaireCommand) -> None:
+    """One call shape answers a radio, a checkbox and a text question."""
+    command.answers = [
+        Answer(question_id=9, response=102),
+        Answer(question_id=10, response=[201]),
+        Answer(question_id=11, response="Half a pack a day"),
+    ]
+
+    answered = command.values["questions"]
+
+    assert answered["question-9"] == 102
+    assert [entry["text"] for entry in answered["question-10"]] == ["Cigarettes"]
+    assert answered["question-11"] == "Half a pack a day"
+
+
+def test_an_id_arriving_as_a_string_still_lands_on_its_option(
+    command: QuestionnaireCommand,
+) -> None:
+    """A numeric string resolves to the option with that id, not the one with that name."""
+    command.answers = [Answer(question_id=9, response="102"), Answer(question_id=12, response="2")]
+
+    assert command.values["questions"] == {"question-9": 102, "question-12": 2}
+
+
+def test_a_checkbox_takes_several_ids(command: QuestionnaireCommand) -> None:
+    """A checkbox answer is a list of ids, recorded as one selection each."""
+    command.answers = [Answer(question_id=10, response=[201, 202])]
+
+    selected = command.values["questions"]["question-10"]
+
+    assert [entry["value"] for entry in selected] == [201, 202]
+
+
+def test_a_text_question_takes_what_was_written(command: QuestionnaireCommand) -> None:
+    """A text answer is recorded as written."""
+    command.answers = [Answer(question_id=11, response="Half a pack a day")]
+
+    assert command.values["questions"] == {"question-11": "Half a pack a day"}
+
+
+def test_an_integer_question_takes_a_number(command: QuestionnaireCommand) -> None:
+    """An integer answer is recorded as an int, given a number or a numeric string."""
+    command.answers = [Answer(question_id=13, response=3)]
+    assert command.values["questions"] == {"question-13": 3}
+
+    fresh = command.model_copy()
+    fresh.answers = [Answer(question_id=13, response="4")]
+    assert fresh.values["questions"] == {"question-13": 4}
+
+
+def test_an_integer_question_refuses_what_is_not_a_number(command: QuestionnaireCommand) -> None:
+    """An integer answer that is not a number raises."""
+    command.answers = [Answer(question_id=13, response="a few")]
+
+    with pytest.raises(ValueError, match="convertible to an integer"):
+        _ = command.values
+
+
+def test_a_comment_rides_on_every_selection(command: QuestionnaireCommand) -> None:
+    """An answer's comment is carried onto each selection it makes."""
+    command.answers = [Answer(question_id=10, response=[201, 202], comment="both")]
+
+    selected = command.values["questions"]["question-10"]
+
+    assert [entry["text"] for entry in selected] == ["Cigarettes", "Cigar/Pipe"]
+    assert {entry["comment"] for entry in selected} == {"both"}
+
+
+def test_an_option_the_question_does_not_offer_is_refused(command: QuestionnaireCommand) -> None:
+    """An id the question does not offer raises, naming the question and its options."""
+    command.answers = [Answer(question_id=9, response=999999)]
+
+    with pytest.raises(ValueError, match="not an option for question 'Status'"):
+        _ = command.values
+
+
+def test_a_question_from_another_questionnaire_is_refused(command: QuestionnaireCommand) -> None:
+    """An id that names no question in the questionnaire raises."""
+    command.answers = [Answer(question_id=999, response=102)]
+
+    with pytest.raises(ValueError, match="not a question in questionnaire"):
+        _ = command.values
+
+
+def test_originating_and_editing_does_not_tick_the_box_twice(
+    command: QuestionnaireCommand,
+) -> None:
+    """Reading ``values`` twice records each checkbox selection once, not twice."""
+    command.command_uuid = "9f1d3b6a-0000-4000-8000-00000000000a"
+    command.answers = [Answer(question_id=10, response=201)]
+
+    originate, edit = json.loads(command.originate().payload), json.loads(command.edit().payload)
+
+    assert originate["data"]["questions"]["question-10"] == edit["data"]["questions"]["question-10"]
+    assert len(edit["data"]["questions"]["question-10"]) == 1
+
+
+def test_a_response_set_directly_on_another_question_survives(
+    command: QuestionnaireCommand,
+) -> None:
+    """A response set directly on a question ``answers`` does not name is kept."""
+    text_question = next(q for q in command.questions if q.type == "TXT")
+    text_question.add_response(text="Set by hand")
+    command.answers = [Answer(question_id=9, response=102)]
+
+    answered = command.values["questions"]
+
+    assert answered["question-11"] == "Set by hand"
+    assert answered["question-9"] == 102
+
+
+def test_answers_apply_to_the_commands_that_subclass_this_one(
+    command: QuestionnaireCommand,
+) -> None:
+    """A physical exam, a review of systems and a structured assessment answer the same way."""
+    exam = PhysicalExamCommand(
+        note_uuid="note-1",
+        questionnaire_id=QUESTIONNAIRE_ID,
+        answers=[Answer(question_id=9, response=102)],
+    )
+
+    assert exam.values["questions"] == {"question-9": 102}
+
+
+def test_the_effect_does_not_carry_the_answers_field(command: QuestionnaireCommand) -> None:
+    """``values`` carries responses under ``questions`` and drops ``answers``."""
+    command.answers = [Answer(question_id=11, response="Half a pack a day")]
+
+    assert "answers" not in command.values
+
+
+def test_a_command_with_no_answers_is_unchanged(command: QuestionnaireCommand) -> None:
+    """A command with no answers carries no questions."""
+    assert command.values["questions"] == {}

--- a/plugin_runner/allowed-module-imports.json
+++ b/plugin_runner/allowed-module-imports.json
@@ -333,7 +333,8 @@
   "canvas_sdk.commands.commands.questionnaire": [
     "Answer",
     "QUESTION_CLASSES",
-    "QuestionnaireCommand"
+    "QuestionnaireCommand",
+    "Selection"
   ],
   "canvas_sdk.commands.commands.questionnaire.question": [
     "BaseQuestion",

--- a/plugin_runner/allowed-module-imports.json
+++ b/plugin_runner/allowed-module-imports.json
@@ -331,6 +331,7 @@
     "PrescribeCommand"
   ],
   "canvas_sdk.commands.commands.questionnaire": [
+    "Answer",
     "QUESTION_CLASSES",
     "QuestionnaireCommand"
   ],


### PR DESCRIPTION
INTERNAL TRACKING: https://canvasmedical.atlassian.net/browse/KOALA-6706


This pull request introduces support for programmatically answering questionnaire commands by adding an `answers` field to `QuestionnaireCommand`, along with a new `Answer` model. The implementation includes robust logic for applying answers to questions, handling different question types, and ensuring answers are correctly validated and recorded. Comprehensive tests are added to verify this new functionality.

**Support for programmatic questionnaire answers:**

* Added an `Answer` class (a Pydantic model) to represent a response to a specific question, including support for comments on checkbox selections. (`canvas_sdk/commands/commands/questionnaire/__init__.py`)
* Added an `answers` field to `QuestionnaireCommand`, which allows setting responses in a structured way; answers are applied to questions when `values` is accessed. (`canvas_sdk/commands/commands/questionnaire/__init__.py`)
* Implemented `_apply_answers` and `_option` methods to resolve and validate answers against question types and options, ensuring type safety and correct mapping of responses. (`canvas_sdk/commands/commands/questionnaire/__init__.py`)

**Testing and API changes:**

* Added a comprehensive test suite for the new answers functionality, covering various question types, error cases, and integration with command subclasses. (`canvas_sdk/tests/commands/test_questionnaire_answers.py`)
* Updated the allowed imports and module exports to include the new `Answer` class. (`plugin_runner/allowed-module-imports.json`, `canvas_sdk/commands/commands/questionnaire/__init__.py`) [[1]](diffhunk://#diff-a40dcade76413e693e0a9fefc6afe070adb5765f6ca17ff86b3982eef6df5c32R329) [[2]](diffhunk://#diff-d6d0878221db23cd27b32d83da9e85dd8a2d2969c9194551eab2f60b8b68b93cR109-R177)

<!-- ## Title Guidelines

A title always has a prefix and a subject.

### Prefix
Make sure the title is prefixed with one of the following:

| Prefix | When to use |
|--------|-------------|
| `feat:`     | New feature |
| `fix:`      | Bug fix |
| `docs:`     | Documentation only changes |
| `style:`    | Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc) |
| `refactor:` | Code changes that neither fixes a bug nor adds a feature |
| `perf:`     | Code change that improves performance |
| `test:`     | Adding missing or correcting existing tests |
| `chore:`    | Changes to the build process or auxiliary tools and libraries such as documentation generation, ci, etc |

### Subject

Ensure the subject contains succinct description of the change.
* Use the imperative, present tense: "change", not "changed" nor "changes"
* Don’t capitalize first letter
* No dot (.) at the end
-->
