### PR TITLE
fix: add optional id to allergy and update goal command ids

### DIFF
--- a/canvas_sdk/commands/commands/remove_allergy.py
+++ b/canvas_sdk/commands/commands/remove_allergy.py
@@ -1,9 +1,8 @@
-from uuid import UUID
-
 from pydantic import Field
 from pydantic_core import InitErrorDetails
 
 from canvas_sdk.commands.base import _BaseCommand as BaseCommand
+from canvas_sdk.commands.base import _OptionalId
 from canvas_sdk.v1.data import AllergyIntolerance
 
 
@@ -13,7 +12,7 @@ class RemoveAllergyCommand(BaseCommand):
     class Meta:
         key = "removeAllergy"
 
-    allergy_id: UUID | None = Field(
+    allergy_id: _OptionalId = Field(
         description="The external ID of the allergy to remove.",
         default=None,
         json_schema_extra={"commands_api_name": "allergy"},

--- a/canvas_sdk/commands/commands/resolve_condition.py
+++ b/canvas_sdk/commands/commands/resolve_condition.py
@@ -25,7 +25,8 @@ class ResolveConditionCommand(BaseCommand):
             return errors
 
         condition_patient_id = (
-            Condition.objects.filter(id=self.condition_id)
+            Condition.objects.active()
+            .filter(id=self.condition_id)
             .values_list("patient__id", flat=True)
             .first()
         )

--- a/canvas_sdk/commands/commands/update_goal.py
+++ b/canvas_sdk/commands/commands/update_goal.py
@@ -1,12 +1,11 @@
 from datetime import datetime
 from enum import Enum
 from typing import Any
-from uuid import UUID
 
 from pydantic import Field
 from pydantic_core import InitErrorDetails
 
-from canvas_sdk.commands.base import _BaseCommand
+from canvas_sdk.commands.base import _BaseCommand, _OptionalId
 from canvas_sdk.v1.data import Goal
 
 
@@ -32,7 +31,7 @@ class UpdateGoalCommand(_BaseCommand):
         MEDIUM = "medium-priority"
         LOW = "low-priority"
 
-    goal_id: UUID | None = Field(
+    goal_id: _OptionalId = Field(
         default=None, json_schema_extra={"commands_api_name": "goal_statement"}
     )
     due_date: datetime | None = None

--- a/canvas_sdk/tests/commands/test_base_command.py
+++ b/canvas_sdk/tests/commands/test_base_command.py
@@ -8,6 +8,12 @@ from django.core.exceptions import ImproperlyConfigured
 from pydantic_core import ValidationError
 
 from canvas_generated.messages.effects_pb2 import EffectType
+from canvas_sdk.commands import (
+    RemoveAllergyCommand,
+    ResolveConditionCommand,
+    StopMedicationCommand,
+    UpdateGoalCommand,
+)
 from canvas_sdk.commands.base import _BaseCommand, _OptionalId
 from canvas_sdk.test_utils.factories import NoteFactory, PatientFactory
 from canvas_sdk.v1.data import Note, Patient
@@ -406,3 +412,25 @@ def test_an_optional_id_reads_a_blank_value_assigned_later_as_absent() -> None:
     command.record_id = ""  # type: ignore[assignment]
 
     assert command.record_id is None
+
+
+@pytest.mark.parametrize(
+    ("command_class", "field"),
+    [
+        (RemoveAllergyCommand, "allergy_id"),
+        (ResolveConditionCommand, "condition_id"),
+        (StopMedicationCommand, "medication_id"),
+        (UpdateGoalCommand, "goal_id"),
+    ],
+)
+def test_a_command_that_names_a_record_reads_a_blank_id_as_absent(
+    command_class: type[_BaseCommand], field: str
+) -> None:
+    """Every id field a caller may leave blank has to be `_OptionalId`, not a bare `UUID | None`.
+
+    The reading itself is asserted above; what this adds is that these four fields carry the
+    annotation. Under `UUID | None` a blank is a `uuid_parsing` error instead.
+    """
+    command = command_class.model_validate({field: ""})
+
+    assert getattr(command, field) is None

--- a/canvas_sdk/tests/commands/test_resolve_condition.py
+++ b/canvas_sdk/tests/commands/test_resolve_condition.py
@@ -27,14 +27,25 @@ def note(patient: Patient) -> Note:
     return NoteFactory.create(patient=patient)
 
 
-def _condition(patient: Patient, clinical_status: str = "active") -> Condition:
-    """Create a minimal condition for the given patient."""
+def _condition(
+    patient: Patient,
+    clinical_status: str = "active",
+    committer_id: int | None = 1,
+) -> Condition:
+    """A condition on a patient's chart, as `Condition.objects.active()` defines one.
+
+    That is `committed()` — a committer, no entered-in-error — plus `clinical_status="active"`.
+    The interpreter resolves against the same queryset, so a fixture that skipped any of it would
+    prove the command accepts conditions the interpreter will then fail to find.
+    """
     return Condition.objects.create(
         patient=patient,
         deleted=False,
         onset_date=datetime.date(2024, 1, 1),
         resolution_date=datetime.date(2024, 1, 1),
         clinical_status=clinical_status,
+        committer_id=committer_id,
+        entered_in_error_id=None,
         notes="",
         surgical=False,
     )
@@ -99,16 +110,24 @@ def test_originate_rejects_an_unknown_condition(note: Note) -> None:
         command.originate()
 
 
-def test_a_resolved_condition_is_still_accepted(note: Note, patient: Patient) -> None:
-    """Only ownership is checked, not the condition's clinical status.
+def test_a_resolved_condition_is_refused(note: Note, patient: Patient) -> None:
+    """A condition that is already resolved is not one this command can resolve.
 
-    Narrowing to active conditions would refuse ones that can be stored, so the check stays at
-    what the record itself requires: it exists, and it is this patient's.
+    Applying the effect resolves the id with `Condition.objects.active().get(...)`, so a resolved
+    condition raises `DoesNotExist` there. Refusing it here reports the id to the plugin instead.
     """
     resolved = _condition(patient, clinical_status="resolved")
-    command = ResolveConditionCommand(note_uuid=str(note.id), condition_id=resolved.id)
 
-    assert command.originate()
+    with pytest.raises(ValidationError):
+        ResolveConditionCommand(note_uuid=str(note.id), condition_id=resolved.id).originate()
+
+
+def test_an_uncommitted_condition_is_refused(note: Note, patient: Patient) -> None:
+    """`active()` is `committed()` plus the status, and the interpreter reads both."""
+    uncommitted = _condition(patient, committer_id=None)
+
+    with pytest.raises(ValidationError):
+        ResolveConditionCommand(note_uuid=str(note.id), condition_id=uncommitted.id).originate()
 
 
 # --- condition ownership on edit ------------------------------------------


### PR DESCRIPTION
INTERNAL TRACKING: https://canvasmedical.atlassian.net/browse/KOALA-7032

This pull request updates several command classes to use a shared `_OptionalId` type for identifier fields, ensuring that blank string IDs are handled as absent rather than causing validation errors. It also strengthens validation logic for resolving conditions and improves test coverage for these behaviors.

Identifier handling improvements:

* Refactored `RemoveAllergyCommand` and `UpdateGoalCommand` to use `_OptionalId` for `allergy_id` and `goal_id` fields, replacing the previous use of `UUID | None`. This ensures blank string values are treated as absent IDs. [[1]](diffhunk://#diff-d2a3721c02bbd999fb82f6811e9fa2ecbae060c4bfa1bb570ca573b89809f7e0L1-R5) [[2]](diffhunk://#diff-d2a3721c02bbd999fb82f6811e9fa2ecbae060c4bfa1bb570ca573b89809f7e0L16-R15) [[3]](diffhunk://#diff-975b45fe42223e989091f0ba93ead7f2a0f12d2aabb48eb69b264aeb6061d900L4-R8) [[4]](diffhunk://#diff-975b45fe42223e989091f0ba93ead7f2a0f12d2aabb48eb69b264aeb6061d900L35-R34)
* Added a parameterized test to confirm that all relevant command classes (`RemoveAllergyCommand`, `ResolveConditionCommand`, `StopMedicationCommand`, `UpdateGoalCommand`) treat blank ID fields as absent, not as validation errors.

Condition resolution validation:

* Updated `ResolveConditionCommand` to filter conditions using `Condition.objects.active()` when resolving a condition, ensuring only active and committed conditions are considered.
* Improved tests for `ResolveConditionCommand` to verify that resolved or uncommitted conditions are refused, raising validation errors as expected.

Test fixture enhancements:

* Enhanced the `_condition` test fixture to create conditions that fully match the criteria for active and committed status, ensuring tests accurately reflect production logic.

<!-- ## Title Guidelines

A title always has a prefix and a subject.

### Prefix
Make sure the title is prefixed with one of the following:

| Prefix | When to use |
|--------|-------------|
| `feat:`     | New feature |
| `fix:`      | Bug fix |
| `docs:`     | Documentation only changes |
| `style:`    | Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc) |
| `refactor:` | Code changes that neither fixes a bug nor adds a feature |
| `perf:`     | Code change that improves performance |
| `test:`     | Adding missing or correcting existing tests |
| `chore:`    | Changes to the build process or auxiliary tools and libraries such as documentation generation, ci, etc |

### Subject

Ensure the subject contains succinct description of the change.
* Use the imperative, present tense: "change", not "changed" nor "changes"
* Don’t capitalize first letter
* No dot (.) at the end
-->
