### PR TITLE
feat: add support for note v2

### DIFF
--- a/canvas_sdk/tests/v1/data/test_note.py
+++ b/canvas_sdk/tests/v1/data/test_note.py
@@ -1,5 +1,6 @@
 import hashlib
 import json
+import uuid
 
 from canvas_sdk.v1.data.note import CurrentNoteStateEvent, Note, NoteStates
 
@@ -40,10 +41,90 @@ def test_current_note_state_event_editable() -> None:
         assert current_note_state_event.editable() == should_be_considered_editable
 
 
+def test_body_returns_stored_body_for_legacy_notes() -> None:
+    """For notes without version 2, body returns the stored _body unchanged."""
+    body = [{"type": "text", "value": "hello"}]
+    note = Note(_body=body)
+
+    assert note._version is None
+    assert note.body == body
+
+
+def test_body_v2_empty_lines() -> None:
+    """UUIDs in _body_order without a _body_content entry become empty text nodes."""
+    uuid1 = uuid.uuid4()
+    uuid2 = uuid.uuid4()
+    note = Note(_version=2, _body_order=[uuid1, uuid2], _body_content={})
+
+    assert note.body == [
+        {"type": "text", "value": ""},
+        {"type": "text", "value": ""},
+    ]
+
+
+def test_body_v2_text_lines() -> None:
+    """Text entries in _body_content are converted to text nodes with their values."""
+    uuid1 = uuid.uuid4()
+    uuid2 = uuid.uuid4()
+    note = Note(
+        _version=2,
+        _body_order=[uuid1, uuid2],
+        _body_content={
+            str(uuid1): {"type": "text", "value": "hello"},
+            str(uuid2): {"type": "text", "value": "world"},
+        },
+    )
+
+    assert note.body == [
+        {"type": "text", "value": "hello"},
+        {"type": "text", "value": "world"},
+    ]
+
+
+def test_body_v2_command_lines() -> None:
+    """Command entries are converted to command nodes preserving their value."""
+    line_uuid = uuid.uuid4()
+    note = Note(
+        _version=2,
+        _body_order=[line_uuid],
+        _body_content={str(line_uuid): {"type": "command", "value": "plan"}},
+    )
+
+    assert note.body == [{"type": "command", "value": "plan"}]
+
+
+def test_body_v2_mixed_content_preserves_order() -> None:
+    """Empty lines, commands, and text are converted maintaining _body_order."""
+    empty_uuid = uuid.uuid4()
+    command_uuid = uuid.uuid4()
+    text_uuid = uuid.uuid4()
+    note = Note(
+        _version=2,
+        _body_order=[empty_uuid, command_uuid, text_uuid],
+        _body_content={
+            str(command_uuid): {"type": "command", "value": "plan"},
+            str(text_uuid): {"type": "text", "value": "some note text"},
+        },
+    )
+
+    assert note.body == [
+        {"type": "text", "value": ""},
+        {"type": "command", "value": "plan"},
+        {"type": "text", "value": "some note text"},
+    ]
+
+
+def test_body_v2_empty_order_returns_empty_list() -> None:
+    """A version 2 note with no ordered lines produces an empty body."""
+    note = Note(_version=2, _body_order=[], _body_content={})
+
+    assert note.body == []
+
+
 def test_body_checksum_returns_md5_of_body() -> None:
     """body_checksum produces an MD5 hex digest of the sorted JSON body."""
     body = [{"type": "text", "value": "hello"}]
-    note = Note(body=body)
+    note = Note(_body=body)
     expected = hashlib.md5(json.dumps(body, sort_keys=True).encode("utf-8")).hexdigest()
     assert note.body_checksum() == expected
 
@@ -51,12 +132,12 @@ def test_body_checksum_returns_md5_of_body() -> None:
 def test_body_checksum_is_stable_for_same_body() -> None:
     """The same body always produces the same checksum."""
     body = [{"type": "command", "data": {"id": 1}}]
-    note = Note(body=body)
+    note = Note(_body=body)
     assert note.body_checksum() == note.body_checksum()
 
 
 def test_body_checksum_differs_for_different_bodies() -> None:
     """Different body content produces different checksums."""
-    note_a = Note(body=[{"type": "text", "value": "a"}])
-    note_b = Note(body=[{"type": "text", "value": "b"}])
+    note_a = Note(_body=[{"type": "text", "value": "a"}])
+    note_b = Note(_body=[{"type": "text", "value": "b"}])
     assert note_a.body_checksum() != note_b.body_checksum()

--- a/canvas_sdk/tests/v1/data/test_note.py
+++ b/canvas_sdk/tests/v1/data/test_note.py
@@ -1,8 +1,45 @@
 import hashlib
 import json
 import uuid
+from typing import Any
 
-from canvas_sdk.v1.data.note import CurrentNoteStateEvent, Note, NoteStates
+import pytest
+from django.core.exceptions import FieldError
+from django.db import models
+from django.db.models import Q
+
+from canvas_sdk.test_utils.factories import NoteFactory
+from canvas_sdk.v1.data.command import Command
+from canvas_sdk.v1.data.note import (
+    NOTE_BODY_FIELDS,
+    NOTE_BODY_READ_FIELDS,
+    CurrentNoteStateEvent,
+    Note,
+    NoteStates,
+)
+
+
+def _selected_columns(queryset: models.QuerySet[Any]) -> str:
+    """Return the SELECT clause of a queryset's compiled SQL."""
+    return str(queryset.query).split(" FROM ")[0]
+
+
+def _quoted_column(field_name: str) -> str:
+    """Return a Note field's database column as it appears in compiled SQL.
+
+    Read off the model rather than hardcoded, because the sqlite test backend
+    rewrites ArrayField and drops its `db_column`.
+    """
+    field = Note._meta.get_field(field_name)
+    assert isinstance(field, models.Field)
+    return f'"{field.column}"'
+
+
+def _where_clause(queryset: models.QuerySet[Any]) -> str:
+    """Return the WHERE clause of a queryset's compiled SQL."""
+    sql = str(queryset.query)
+    assert " WHERE " in sql, "query has no WHERE clause"
+    return sql.split(" WHERE ")[1]
 
 
 def test_current_note_state_event_editable() -> None:
@@ -141,3 +178,259 @@ def test_body_checksum_differs_for_different_bodies() -> None:
     note_a = Note(_body=[{"type": "text", "value": "a"}])
     note_b = Note(_body=[{"type": "text", "value": "b"}])
     assert note_a.body_checksum() != note_b.body_checksum()
+
+
+def test_note_body_fields_are_concrete_note_columns() -> None:
+    """Every name in NOTE_BODY_FIELDS resolves to a real column on Note.
+
+    Guards against the constant drifting away from the model, which would make
+    deferring `body` silently defer nothing or raise FieldDoesNotExist.
+    """
+    for field_name in NOTE_BODY_FIELDS:
+        assert Note._meta.get_field(field_name).concrete
+
+
+def test_defer_body_defers_every_backing_field() -> None:
+    """Deferring `body` marks all the fields behind it as deferred."""
+    deferred, is_defer = Note.objects.defer("body").query.deferred_loading
+
+    assert is_defer is True
+    assert deferred == set(NOTE_BODY_FIELDS)
+
+
+def test_defer_body_omits_body_columns_from_the_query() -> None:
+    """The body columns are absent from the SELECT that defer('body') produces."""
+    body_columns = [_quoted_column(name) for name in NOTE_BODY_FIELDS]
+
+    # An undeferred query selects all of them, which proves the assertion below
+    # can fail rather than passing on an empty or malformed SELECT clause.
+    default = _selected_columns(Note.objects.all())
+    assert all(column in default for column in body_columns)
+
+    selected = _selected_columns(Note.objects.defer("body"))
+    assert not any(column in selected for column in body_columns)
+
+
+def test_defer_body_keeps_version_loaded() -> None:
+    """`body` reads _version to pick a shape, so deferring it leaves that loaded."""
+    assert _quoted_column("_version") in _selected_columns(Note.objects.defer("body"))
+
+
+def test_defer_passes_other_fields_through_untouched() -> None:
+    """Names other than `body` are deferred exactly as given."""
+    queryset = Note.objects.defer("body", "related_data", "billing_note")
+    deferred, is_defer = queryset.query.deferred_loading
+
+    assert is_defer is True
+    assert deferred == {*NOTE_BODY_FIELDS, "related_data", "billing_note"}
+
+
+def test_defer_without_body_is_unchanged() -> None:
+    """A defer that does not name `body` defers only what it asked for."""
+    deferred, is_defer = Note.objects.defer("related_data").query.deferred_loading
+
+    assert is_defer is True
+    assert deferred == {"related_data"}
+
+
+def test_defer_none_still_clears_deferred_loading() -> None:
+    """`defer(None)` keeps its Django meaning of resetting the deferred set."""
+    control = Command.objects.defer("data").defer(None).query.deferred_loading
+
+    assert Note.objects.defer("body").defer(None).query.deferred_loading == control
+
+
+def test_only_body_loads_every_field_the_property_reads() -> None:
+    """only('body') loads the exact set the property reads, and nothing less.
+
+    An equality check rather than a subset one: omitting any of these leaves the
+    property triggering a deferred fetch per note.
+    """
+    fields, is_defer = Note.objects.only("body").query.deferred_loading
+
+    assert is_defer is False
+    assert fields == set(NOTE_BODY_READ_FIELDS)
+
+
+def test_only_body_selects_the_version_column() -> None:
+    """`_version` reaches the SELECT, so building a body costs no extra query."""
+    assert _quoted_column("_version") in _selected_columns(Note.objects.only("body"))
+
+
+def test_only_body_omits_unrelated_columns() -> None:
+    """only('body') leaves columns the property does not need out of the SELECT."""
+    selected = _selected_columns(Note.objects.only("body"))
+
+    assert _quoted_column("related_data") not in selected
+    assert _quoted_column("_body") in selected
+
+
+def test_filter_on_body_reads_the_column_for_each_version() -> None:
+    """A `body` filter reads _body_content for v2 notes and _body for the rest."""
+    where = _where_clause(Note.objects.filter(body__icontains="outreach"))
+
+    assert _quoted_column("_version") in where
+    assert _quoted_column("_body_content") in where
+    assert _quoted_column("_body") in where
+
+
+def test_filter_without_body_is_left_alone() -> None:
+    """A filter that does not mention `body` compiles without the alias."""
+    where = _where_clause(Note.objects.filter(title__icontains="x"))
+
+    assert "CASE" not in where
+    assert where == _where_clause(Note.objects.filter(title__icontains="x"))
+
+
+def test_exclude_on_body_resolves() -> None:
+    """`body` is available to exclude as well as filter."""
+    where = _where_clause(Note.objects.exclude(body__icontains="outreach"))
+
+    assert where.startswith("NOT")
+    assert _quoted_column("_body_content") in where
+
+
+def test_filter_on_body_inside_a_q_object() -> None:
+    """A `body` lookup nested in a Q is found and aliased."""
+    queryset = Note.objects.filter(Q(body__icontains="x") | Q(title__icontains="x"))
+    where = _where_clause(queryset)
+
+    assert _quoted_column("_body_content") in where
+    assert _quoted_column("title") in where
+
+
+def test_filter_on_body_inside_a_nested_negated_q() -> None:
+    """Q trees are searched at any depth, including under a negation."""
+    queryset = Note.objects.filter(~Q(Q(body__icontains="x") & Q(dbid__gt=1)))
+
+    assert _quoted_column("_body_content") in _where_clause(queryset)
+
+
+def test_filter_on_body_after_another_filter() -> None:
+    """The alias is added when `body` appears in a later call in the chain."""
+    queryset = Note.objects.filter(title="t").filter(body__icontains="x")
+    where = _where_clause(queryset)
+
+    assert _quoted_column("title") in where
+    assert _quoted_column("_body_content") in where
+
+
+def test_repeated_body_filters_do_not_collide() -> None:
+    """Filtering on `body` more than once does not re-add a conflicting alias."""
+    queryset = Note.objects.filter(body__icontains="x").filter(body__icontains="y")
+
+    assert _where_clause(queryset).count("CASE") == 2
+
+
+def test_body_can_be_filtered_while_deferred() -> None:
+    """Deferring the body still allows filtering on it, since WHERE needs no select."""
+    queryset = Note.objects.defer("body").filter(body__icontains="x")
+    body_columns = [_quoted_column(name) for name in NOTE_BODY_FIELDS]
+
+    assert not any(column in _selected_columns(queryset) for column in body_columns)
+    assert _quoted_column("_body_content") in _where_clause(queryset)
+
+
+@pytest.mark.django_db
+def test_filter_on_body_matches_both_note_versions() -> None:
+    """A body filter finds text in a version 2 note and a legacy note alike."""
+    line_uuid = uuid.uuid4()
+    NoteFactory.create(
+        _version=2,
+        _body_order=[str(line_uuid)],
+        _body_content={str(line_uuid): {"type": "text", "value": "outreach attempted"}},
+    )
+    NoteFactory.create(_body=[{"type": "text", "value": "legacy prose"}])
+
+    assert Note.objects.filter(body__icontains="outreach").count() == 1
+    assert Note.objects.filter(body__icontains="legacy prose").count() == 1
+    # A term in neither body matches nothing, so the two assertions above are
+    # not passing on a query that happens to match every row.
+    assert Note.objects.filter(body__icontains="nonexistent").count() == 0
+
+
+@pytest.mark.django_db
+def test_only_body_builds_bodies_without_further_queries(
+    django_assert_num_queries: Any,
+) -> None:
+    """A note fetched with only('body') builds its body from the row it came in.
+
+    Omitting any field the property reads turns this into a query per note.
+    """
+    line_uuid = uuid.uuid4()
+    NoteFactory.create(
+        _version=2,
+        _body_order=[str(line_uuid)],
+        _body_content={str(line_uuid): {"type": "text", "value": "outreach attempted"}},
+    )
+    NoteFactory.create(_body=[{"type": "text", "value": "legacy prose"}])
+
+    with django_assert_num_queries(1):
+        bodies = [note.body for note in Note.objects.only("body").order_by("dbid")]
+
+    assert bodies == [
+        [{"type": "text", "value": "outreach attempted"}],
+        [{"type": "text", "value": "legacy prose"}],
+    ]
+
+
+def test_values_rejects_body_with_an_actionable_message() -> None:
+    """Selecting `body` with values() is refused, pointing at only('body')."""
+    with pytest.raises(FieldError) as excinfo:
+        Note.objects.values("body")
+
+    message = str(excinfo.value)
+    assert "values()" in message
+    assert "only('body')" in message
+
+
+def test_values_list_rejects_body_with_an_actionable_message() -> None:
+    """Selecting `body` with values_list() is refused, pointing at only('body')."""
+    with pytest.raises(FieldError) as excinfo:
+        Note.objects.values_list("body", flat=True)
+
+    message = str(excinfo.value)
+    assert "values_list()" in message
+    assert "only('body')" in message
+
+
+def test_values_rejects_body_alongside_real_fields() -> None:
+    """`body` is caught wherever it sits in the requested field list.
+
+    Asserts the message, not just the exception type: Django raises FieldError
+    for an unresolvable name anyway, so the type alone proves nothing.
+    """
+    with pytest.raises(FieldError) as excinfo:
+        Note.objects.values("title", "body")
+
+    assert "only('body')" in str(excinfo.value)
+
+
+def test_values_rejects_body_after_a_body_filter() -> None:
+    """The refusal replaces Django's advice on an already-aliased queryset.
+
+    Once a body filter has added the alias, Django's own error suggests
+    promoting it with annotate, which returns the stored column rather than
+    the body.
+    """
+    with pytest.raises(FieldError) as excinfo:
+        Note.objects.filter(body__icontains="x").values("body")
+
+    message = str(excinfo.value)
+    assert "only('body')" in message
+    assert "annotate" not in message
+
+
+def test_values_passes_real_fields_through() -> None:
+    """Field names other than `body` reach the query untouched."""
+    assert _quoted_column("title") in _selected_columns(Note.objects.values("title"))
+
+
+def test_values_list_keeps_its_flat_and_named_arguments() -> None:
+    """values_list still forwards flat and named to Django."""
+    flat = Note.objects.values_list("title", flat=True)
+    named = Note.objects.values_list("title", named=True)
+
+    assert _quoted_column("title") in _selected_columns(flat)
+    assert flat._iterable_class.__name__ == "FlatValuesListIterable"
+    assert named._iterable_class.__name__ == "NamedValuesListIterable"

--- a/canvas_sdk/v1/data/note.py
+++ b/canvas_sdk/v1/data/note.py
@@ -175,7 +175,6 @@ class Note(TimestampedModel, IdentifiableModel):
         "v1.NoteType", on_delete=models.DO_NOTHING, related_name="notes"
     )
     title = models.TextField(default="", blank=True)
-    body = models.JSONField(default=empty_note_body)
     originator = models.ForeignKey("v1.CanvasUser", on_delete=models.DO_NOTHING, null=True)
     last_modified_by_staff = models.ForeignKey("v1.Staff", on_delete=models.DO_NOTHING, null=True)
     checksum = models.CharField(max_length=32)
@@ -186,6 +185,34 @@ class Note(TimestampedModel, IdentifiableModel):
     location = models.ForeignKey("v1.PracticeLocation", on_delete=models.DO_NOTHING, null=True)
     datetime_of_service = models.DateTimeField(default=timezone.now)
     place_of_service = models.CharField(max_length=255)
+
+    # properties that shouldn't be directly exposed in the API
+    # but are needed for legacy note handling and other internal logic
+    _body = models.JSONField(default=empty_note_body, db_column="body")
+    _body_content = models.JSONField(default=dict, db_column="body_content")
+    _body_order = ArrayField(models.UUIDField(), default=[], blank=True, db_column="body_order")
+    _version = models.IntegerField(null=True, db_column="version")
+
+    @property
+    def body(self) -> list[dict]:
+        """Return the note body content, handling any necessary transformations for v2 notes."""
+        if self._version == 2:
+            # For version 2 notes, we need to reconstruct the body using the content and order fields
+            legacy_body: list[dict] = []
+            for line_uuid in self._body_order:
+                line_uuid_str = str(line_uuid)
+                line = self._body_content.get(line_uuid_str)
+
+                if line is None:
+                    legacy_body.append({"type": "text", "value": ""})
+                elif line.get("type") == "command":
+                    legacy_body.append({"type": "command", "value": line["value"]})
+                else:
+                    legacy_body.append({"type": "text", "value": line.get("value", "")})
+            return legacy_body
+        else:
+            # for legacy notes we can return the body directly, as it is already in the expected format
+            return self._body
 
     def body_checksum(self) -> str:
         """Compute an MD5 checksum of the note body content only."""

--- a/canvas_sdk/v1/data/note.py
+++ b/canvas_sdk/v1/data/note.py
@@ -1,12 +1,20 @@
 import hashlib
 import json
 import uuid
+from typing import Any, Self, cast
 
 from django.contrib.postgres.fields import ArrayField
+from django.core.exceptions import FieldError
 from django.db import models
+from django.db.models.manager import BaseManager
 from django.utils import timezone
 
-from canvas_sdk.v1.data.base import IdentifiableModel, MetadataModel, TimestampedModel
+from canvas_sdk.v1.data.base import (
+    BaseQuerySet,
+    IdentifiableModel,
+    MetadataModel,
+    TimestampedModel,
+)
 from canvas_sdk.v1.data.claim import Claim
 from canvas_sdk.v1.data.coding import Coding
 from canvas_sdk.v1.data.utils import empty_note_body
@@ -155,11 +163,137 @@ class NoteType(TimestampedModel, IdentifiableModel, Coding):
     is_sig_required = models.BooleanField(default=True)
 
 
+# The fields holding the body content. Version 1 notes store the body in
+# `_body`; version 2 notes store it across `_body_content` and `_body_order`.
+NOTE_BODY_FIELDS = ("_body", "_body_content", "_body_order")
+
+# Everything the `body` property reads. It consults `_version` first to decide
+# which shape to build, so a query loading `body` has to load that too.
+NOTE_BODY_READ_FIELDS = (*NOTE_BODY_FIELDS, "_version")
+
+
+# The column holding the body for a note's version, exposed to filters as
+# `body`.
+NOTE_BODY_COLUMN = models.Case(
+    models.When(_version=2, then=models.F("_body_content")),
+    default=models.F("_body"),
+)
+
+
+def _expand_body(fields: tuple[Any, ...], replacement: tuple[str, ...]) -> tuple[Any, ...]:
+    """Replace `body` with the given fields, leaving the rest as-is."""
+    expanded: list[Any] = []
+    for field in fields:
+        if field == "body":
+            expanded.extend(replacement)
+        else:
+            expanded.append(field)
+    return tuple(expanded)
+
+
+def _is_body_lookup(name: Any) -> bool:
+    """Whether a lookup name targets `body`."""
+    return name == "body" or (isinstance(name, str) and name.startswith("body__"))
+
+
+def _references_body(condition: models.Q) -> bool:
+    """Whether a Q object looks up `body` at any depth."""
+    for child in condition.children:
+        if isinstance(child, models.Q):
+            if _references_body(child):
+                return True
+        elif isinstance(child, tuple) and _is_body_lookup(child[0]):
+            return True
+    return False
+
+
+def _reject_body_selection(fields: tuple[Any, ...], method: str) -> None:
+    """Refuse to select `body`, which no single column holds.
+
+    Django's own message for an unselectable alias suggests promoting it with
+    `annotate`, which here would hand back the stored column instead of the
+    body: for a version 2 note that is a mapping keyed by line, not the ordered
+    list of lines that `body` returns.
+    """
+    if "body" in fields:
+        raise FieldError(
+            f"'body' cannot be selected with {method}(), because it is built from "
+            "several columns rather than stored in one. Use only('body') to load "
+            "notes whose 'body' is populated."
+        )
+
+
+class NoteQuerySet(BaseQuerySet):
+    """A queryset for notes."""
+
+    def _alias_body_if_referenced(self, args: tuple[Any, ...], kwargs: dict[str, Any]) -> Self:
+        """Make `body` resolvable, but only for calls that look it up.
+
+        The alias is added per call rather than to every note queryset so that
+        queries not mentioning `body` are left exactly as they were written.
+        """
+        references_body = any(_is_body_lookup(key) for key in kwargs) or any(
+            isinstance(arg, models.Q) and _references_body(arg) for arg in args
+        )
+        return self.alias(body=NOTE_BODY_COLUMN) if references_body else self
+
+    def filter(self, *args: Any, **kwargs: Any) -> Self:
+        """Filter the queryset, resolving `body` to the note's body column.
+
+        `body` is a property rather than a field, so it is supplied as a query
+        alias here. That covers `filter`, `exclude` and `get`, including lookups
+        nested inside `Q` objects, but not `order_by`, `values`, or traversal
+        from another model's queryset.
+        """
+        return super(NoteQuerySet, self._alias_body_if_referenced(args, kwargs)).filter(
+            *args, **kwargs
+        )
+
+    def exclude(self, *args: Any, **kwargs: Any) -> Self:
+        """Exclude matching rows, resolving `body` to the note's body column."""
+        return super(NoteQuerySet, self._alias_body_if_referenced(args, kwargs)).exclude(
+            *args, **kwargs
+        )
+
+    def defer(self, *fields: Any) -> Self:
+        """Defer loading of the named fields.
+
+        `body` is a property derived from three columns, so naming it defers all
+        of them.
+        """
+        return super().defer(*_expand_body(fields, NOTE_BODY_FIELDS))
+
+    def only(self, *fields: Any) -> Self:
+        """Load only the named fields, deferring the rest.
+
+        `body` expands to every field the property reads, so that building a
+        body from the result costs no further queries.
+        """
+        return super().only(*_expand_body(fields, NOTE_BODY_READ_FIELDS))
+
+    def values(self, *fields: Any, **expressions: Any) -> models.QuerySet[Any, dict[str, Any]]:
+        """Return dictionaries of field values, refusing to select `body`."""
+        _reject_body_selection(fields, "values")
+        return super().values(*fields, **expressions)
+
+    def values_list(
+        self, *fields: Any, flat: bool = False, named: bool = False
+    ) -> models.QuerySet[Any, Any]:
+        """Return tuples of field values, refusing to select `body`."""
+        _reject_body_selection(fields, "values_list")
+        return super().values_list(*fields, flat=flat, named=named)
+
+
+NoteManager = BaseManager.from_queryset(NoteQuerySet)
+
+
 class Note(TimestampedModel, IdentifiableModel):
     """Note."""
 
     class Meta:
         db_table = "canvas_sdk_data_api_note_001"
+
+    objects = cast(NoteQuerySet, NoteManager())
 
     patient = models.ForeignKey(
         "v1.Patient", on_delete=models.DO_NOTHING, related_name="notes", null=True


### PR DESCRIPTION
[KOALA-6954](https://canvasmedical.atlassian.net/browse/KOALA-6954)

This pull request introduces a comprehensive set of tests for the `Note` model's `body` property and its integration with Django ORM query operations. It also refactors the `Note` model to support a versioned note body, adds a custom queryset/manager for advanced query support, and removes the legacy `body` field in favor of internal fields. The main themes are improved test coverage, support for versioned note bodies, and robust integration with Django query methods.

**Enhancements to the `Note` model:**

* Added internal fields (`_body`, `_body_content`, `_body_order`, `_version`) to support versioned note bodies and removed the legacy `body` field. The `body` property now reconstructs the note body based on the version and underlying fields. [[1]](diffhunk://#diff-d985c996ffa13871416f580ecd701dabf5f47d0eaeb8d8cfabd6c95afdebd443L178) [[2]](diffhunk://#diff-d985c996ffa13871416f580ecd701dabf5f47d0eaeb8d8cfabd6c95afdebd443R323-R350)
* Introduced constants (`NOTE_BODY_FIELDS`, `NOTE_BODY_READ_FIELDS`, `NOTE_BODY_COLUMN`) to centralize the logic for which fields comprise the note body and how they are queried.
* Implemented a custom `NoteQuerySet` and manager to support advanced query operations on the `body` property, including filtering, deferring, and only-loading the necessary fields.

**Test coverage and query integration:**

* Added extensive tests for the `body` property, including legacy and version 2 notes, ensuring correct reconstruction, ordering, and handling of empty or mixed content.
* Added tests verifying that Django query methods (`filter`, `exclude`, `defer`, `only`, `values`, `values_list`) interact correctly with the `body` property, including proper field expansion, aliasing, and actionable error messages when unsupported operations are attempted.
* Ensured that filtering on `body` works for both legacy and version 2 notes, and that the correct fields are selected or deferred in queries.

**Internal utilities and helpers:**

* Added utility functions to assist with SQL clause extraction and field quoting in tests, improving test clarity and reliability.

These changes collectively improve the maintainability, testability, and robustness of the `Note` model and its interaction with the Django ORM.

- [[1]](diffhunk://#diff-d985c996ffa13871416f580ecd701dabf5f47d0eaeb8d8cfabd6c95afdebd443L178) [[2]](diffhunk://#diff-d985c996ffa13871416f580ecd701dabf5f47d0eaeb8d8cfabd6c95afdebd443R323-R350) [[3]](diffhunk://#diff-d985c996ffa13871416f580ecd701dabf5f47d0eaeb8d8cfabd6c95afdebd443R166-R297) [[4]](diffhunk://#diff-ad88b7a45f588e285e781a2b28ffae24f4fd3be8d3e85974a5309553b4455396R81-R436) [[5]](diffhunk://#diff-ad88b7a45f588e285e781a2b28ffae24f4fd3be8d3e85974a5309553b4455396R3-R42)

[KOALA-6954]: https://canvasmedical.atlassian.net/browse/KOALA-6954?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ