### PR TITLE
feat: link Plan/Procedures commands to a same-note Assessment

### DIFF
--- a/canvas_sdk/commands/base.py
+++ b/canvas_sdk/commands/base.py
@@ -157,6 +157,24 @@ class _BaseCommand(TrackableFieldsModel):
 
         return None
 
+    def _anchor_note_id(self) -> str | None:
+        """The note this command is written in, when that can be known.
+
+        Returns:
+            The note's id, or None when there is nothing to resolve it from *or* the anchor is not
+            persisted yet, for the same reason `_anchor_patient_id` returns None in that case.
+        """
+        if note_uuid := self.note_uuid:
+            note_id = Note.objects.filter(id=note_uuid).values_list("id", flat=True).first()
+        elif command_uuid := self.command_uuid:
+            note_id = (
+                Command.objects.filter(id=command_uuid).values_list("note__id", flat=True).first()
+            )
+        else:
+            return None
+
+        return str(note_id) if note_id is not None else None
+
     def _is_target_patient(self, patient_id: str) -> bool:
         """Whether the given patient is the one whose chart this command writes to.
 

--- a/canvas_sdk/commands/commands/assessment_link.py
+++ b/canvas_sdk/commands/commands/assessment_link.py
@@ -1,0 +1,44 @@
+from typing import Any
+
+from pydantic import Field
+from pydantic_core import InitErrorDetails
+
+from canvas_sdk.commands.base import _BaseCommand, _OptionalId
+from canvas_sdk.v1.data import Assessment
+
+
+class _AssessmentLinkedCommand(_BaseCommand):
+    """A base class for commands that can be linked to an Assessment made in the same note."""
+
+    class Meta:
+        abstract = True
+
+    assessment_id: _OptionalId = Field(
+        default=None, json_schema_extra={"commands_api_name": "assessment"}
+    )
+
+    def _get_error_details(self, method: Any) -> list[InitErrorDetails]:
+        """Check that the linked assessment was made in the note this command is written in.
+
+        The note is resolved from the command's own note or, on an edit, from the command itself.
+        When neither is persisted yet there is nothing to compare against and the check is skipped,
+        so a plugin returning several effects at once still works.
+        """
+        errors = super()._get_error_details(method)
+
+        if self.assessment_id is None or (note_id := self._anchor_note_id()) is None:
+            return errors
+
+        if not Assessment.objects.filter(id=self.assessment_id, note__id=note_id).exists():
+            errors.append(
+                self._create_error_detail(
+                    "value",
+                    f"Assessment {self.assessment_id} was not made in this command's note.",
+                    self.assessment_id,
+                )
+            )
+
+        return errors
+
+
+__exports__ = ()

--- a/canvas_sdk/commands/commands/assessment_link.py
+++ b/canvas_sdk/commands/commands/assessment_link.py
@@ -6,6 +6,11 @@ from pydantic_core import InitErrorDetails
 from canvas_sdk.commands.base import _BaseCommand, _OptionalId
 from canvas_sdk.v1.data import Assessment
 
+#: The link is only supplied when a command is written, so those are the only methods worth
+#: checking. A commit, delete or enter-in-error addresses a command that already holds whatever
+#: link it has.
+ASSESSMENT_VALIDATED_METHODS = frozenset({"originate", "edit"})
+
 
 class _AssessmentLinkedCommand(_BaseCommand):
     """A base class for commands that can be linked to an Assessment made in the same note."""
@@ -18,15 +23,21 @@ class _AssessmentLinkedCommand(_BaseCommand):
     )
 
     def _get_error_details(self, method: Any) -> list[InitErrorDetails]:
-        """Check that the linked assessment was made in the note this command is written in.
-
-        The note is resolved from the command's own note or, on an edit, from the command itself.
-        When neither is persisted yet there is nothing to compare against and the check is skipped,
-        so a plugin returning several effects at once still works.
-        """
+        """Check that the linked assessment was made in the note this command is written in."""
         errors = super()._get_error_details(method)
 
-        if self.assessment_id is None or (note_id := self._anchor_note_id()) is None:
+        if self.assessment_id is None or method not in ASSESSMENT_VALIDATED_METHODS:
+            # Nothing of this class's to check. The field is optional, so a command that omits
+            # it, or that is being committed or deleted, carries no link to disagree with.
+            return errors
+
+        note_id = self._anchor_note_id()
+
+        if note_id is None:
+            # The note is not persisted yet, which is ordinary rather than an error: one handler
+            # can return `[note.create(...), command.originate(note_uuid=...)]`, and the note
+            # only exists once the earlier effect is applied. The interpreter checks the link
+            # against the note server-side, by which time both exist.
             return errors
 
         if not Assessment.objects.filter(id=self.assessment_id, note__id=note_id).exists():

--- a/canvas_sdk/commands/commands/close_goal.py
+++ b/canvas_sdk/commands/commands/close_goal.py
@@ -2,12 +2,12 @@ from typing import Any
 
 from pydantic_core import InitErrorDetails
 
-from canvas_sdk.commands.base import _BaseCommand as BaseCommand
+from canvas_sdk.commands.commands.assessment_link import _AssessmentLinkedCommand
 from canvas_sdk.commands.commands.goal import GoalCommand
 from canvas_sdk.v1.data import Goal
 
 
-class CloseGoalCommand(BaseCommand):
+class CloseGoalCommand(_AssessmentLinkedCommand):
     """A class for managing a CloseGoal command within a specific note."""
 
     class Meta:

--- a/canvas_sdk/commands/commands/follow_up.py
+++ b/canvas_sdk/commands/commands/follow_up.py
@@ -5,12 +5,12 @@ from uuid import UUID
 from pydantic import Field
 from pydantic_core import InitErrorDetails
 
-from canvas_sdk.commands.base import _BaseCommand
+from canvas_sdk.commands.commands.assessment_link import _AssessmentLinkedCommand
 from canvas_sdk.commands.constants import Coding
 from canvas_sdk.v1.data import NoteType, ReasonForVisitSettingCoding
 
 
-class FollowUpCommand(_BaseCommand):
+class FollowUpCommand(_AssessmentLinkedCommand):
     """A class for managing a Follow-Up command within a specific note."""
 
     class Meta:

--- a/canvas_sdk/commands/commands/goal.py
+++ b/canvas_sdk/commands/commands/goal.py
@@ -3,10 +3,10 @@ from enum import StrEnum
 
 from pydantic import Field
 
-from canvas_sdk.commands.base import _BaseCommand
+from canvas_sdk.commands.commands.assessment_link import _AssessmentLinkedCommand
 
 
-class GoalCommand(_BaseCommand):
+class GoalCommand(_AssessmentLinkedCommand):
     """A class for managing a Goal command within a specific note."""
 
     class Meta:

--- a/canvas_sdk/commands/commands/immunize.py
+++ b/canvas_sdk/commands/commands/immunize.py
@@ -5,13 +5,13 @@ from uuid import UUID
 from pydantic import Field
 from pydantic_core import InitErrorDetails
 
-from canvas_sdk.commands.base import _BaseCommand
+from canvas_sdk.commands.commands.assessment_link import _AssessmentLinkedCommand
 from canvas_sdk.v1.data.vaccine import Vaccine, VaccineLot
 
 LOT_NUMBER_MAX_LENGTH = 20
 
 
-class ImmunizeCommand(_BaseCommand):
+class ImmunizeCommand(_AssessmentLinkedCommand):
     """A class for managing an Immunize command within a specific note."""
 
     class Meta:

--- a/canvas_sdk/commands/commands/instruct.py
+++ b/canvas_sdk/commands/commands/instruct.py
@@ -1,11 +1,11 @@
 from pydantic import Field
 from pydantic_core import InitErrorDetails
 
-from canvas_sdk.commands.base import _BaseCommand as BaseCommand
+from canvas_sdk.commands.commands.assessment_link import _AssessmentLinkedCommand
 from canvas_sdk.commands.constants import CodeSystems, Coding
 
 
-class InstructCommand(BaseCommand):
+class InstructCommand(_AssessmentLinkedCommand):
     """A class for managing an Instruct command within a specific note."""
 
     class Meta:

--- a/canvas_sdk/commands/commands/perform.py
+++ b/canvas_sdk/commands/commands/perform.py
@@ -1,11 +1,11 @@
 from pydantic import Field
 from pydantic_core import InitErrorDetails
 
-from canvas_sdk.commands.base import _BaseCommand as BaseCommand
+from canvas_sdk.commands.commands.assessment_link import _AssessmentLinkedCommand
 from canvas_sdk.commands.constants import CodeSystems, Coding
 
 
-class PerformCommand(BaseCommand):
+class PerformCommand(_AssessmentLinkedCommand):
     """A class for managing a Perform command within a specific note."""
 
     class Meta:

--- a/canvas_sdk/commands/commands/plan.py
+++ b/canvas_sdk/commands/commands/plan.py
@@ -1,7 +1,7 @@
-from canvas_sdk.commands.base import _BaseCommand
+from canvas_sdk.commands.commands.assessment_link import _AssessmentLinkedCommand
 
 
-class PlanCommand(_BaseCommand):
+class PlanCommand(_AssessmentLinkedCommand):
     """A class for managing a Plan command within a specific note."""
 
     class Meta:

--- a/canvas_sdk/commands/commands/stop_medication.py
+++ b/canvas_sdk/commands/commands/stop_medication.py
@@ -1,11 +1,12 @@
 from pydantic import Field
 from pydantic_core import InitErrorDetails
 
-from canvas_sdk.commands.base import _BaseCommand, _OptionalId
+from canvas_sdk.commands.base import _OptionalId
+from canvas_sdk.commands.commands.assessment_link import _AssessmentLinkedCommand
 from canvas_sdk.v1.data import Medication
 
 
-class StopMedicationCommand(_BaseCommand):
+class StopMedicationCommand(_AssessmentLinkedCommand):
     """A class for managing a StopMedication command within a specific note."""
 
     class Meta:

--- a/canvas_sdk/commands/commands/task.py
+++ b/canvas_sdk/commands/commands/task.py
@@ -4,7 +4,7 @@ from typing import NotRequired
 
 from typing_extensions import TypedDict
 
-from canvas_sdk.commands.base import _BaseCommand as BaseCommand
+from canvas_sdk.commands.commands.assessment_link import _AssessmentLinkedCommand
 from canvas_sdk.v1.data.task import TaskPriority
 
 
@@ -24,7 +24,7 @@ class TaskAssigner(TypedDict):
     id: NotRequired[int]
 
 
-class TaskCommand(BaseCommand):
+class TaskCommand(_AssessmentLinkedCommand):
     """A class for managing a Task command within a specific note."""
 
     class Meta:

--- a/canvas_sdk/commands/commands/update_goal.py
+++ b/canvas_sdk/commands/commands/update_goal.py
@@ -5,11 +5,12 @@ from typing import Any
 from pydantic import Field
 from pydantic_core import InitErrorDetails
 
-from canvas_sdk.commands.base import _BaseCommand, _OptionalId
+from canvas_sdk.commands.base import _OptionalId
+from canvas_sdk.commands.commands.assessment_link import _AssessmentLinkedCommand
 from canvas_sdk.v1.data import Goal
 
 
-class UpdateGoalCommand(_BaseCommand):
+class UpdateGoalCommand(_AssessmentLinkedCommand):
     """A class for managing an UpdateGoal command within a specific note."""
 
     class Meta:

--- a/canvas_sdk/tests/commands/test_assessment_link.py
+++ b/canvas_sdk/tests/commands/test_assessment_link.py
@@ -1,4 +1,4 @@
-from uuid import UUID
+from uuid import UUID, uuid4
 
 import pytest
 from pydantic_core import ValidationError
@@ -120,6 +120,34 @@ def test_an_assessment_id_that_names_nothing_is_refused(note: Note) -> None:
 def test_no_assessment_means_nothing_to_check(note: Note) -> None:
     """The link is optional, so a command committed without one is valid."""
     assert InstructCommand(note_uuid=str(note.id), comment="Rest and fluids").originate()
+
+
+def test_a_note_that_is_not_persisted_yet_is_not_refused(db: None) -> None:
+    """One handler can create the note and write into it in the same batch of effects.
+
+    `[note.create(id=x), command.originate(note_uuid=x)]` names a note that does not exist when
+    the effects are built, so there is nothing to check the assessment against and the command
+    must not be refused. The interpreter checks the link once the note exists.
+    """
+    unborn_note_id = str(uuid4())
+
+    assert not Note.objects.filter(id=unborn_note_id).exists()
+    assert InstructCommand(
+        note_uuid=unborn_note_id, assessment_id=UNKNOWN_ASSESSMENT_ID
+    ).originate()
+
+
+def test_a_commit_carrying_an_assessment_is_not_checked(
+    patient: Patient, stored_command: Command, other_note: Note
+) -> None:
+    """A commit addresses a command that already holds whatever link it has.
+
+    Re-checking the link at that point can only refuse a commit over a field the caller is not
+    changing, so the check is limited to the methods that write the link.
+    """
+    foreign = _assessment(patient, other_note)
+
+    assert InstructCommand(command_uuid=str(stored_command.id), assessment_id=foreign.id).commit()
 
 
 def test_the_check_holds_on_an_edit_which_carries_no_note(

--- a/canvas_sdk/tests/commands/test_assessment_link.py
+++ b/canvas_sdk/tests/commands/test_assessment_link.py
@@ -1,0 +1,162 @@
+from uuid import UUID
+
+import pytest
+from pydantic_core import ValidationError
+
+from canvas_sdk.commands import (
+    CloseGoalCommand,
+    FollowUpCommand,
+    GoalCommand,
+    ImmunizeCommand,
+    InstructCommand,
+    PerformCommand,
+    PlanCommand,
+    StopMedicationCommand,
+    TaskCommand,
+    UpdateGoalCommand,
+)
+from canvas_sdk.commands.base import _BaseCommand
+from canvas_sdk.test_utils.factories import NoteFactory, PatientFactory
+from canvas_sdk.v1.data import Assessment, Command, Note, Patient
+
+#: An id no assessment has.
+UNKNOWN_ASSESSMENT_ID = UUID("1e2a3b4c-5d6e-4f70-8192-a3b4c5d6e7f8")
+
+ASSESSMENT_LINKED_COMMANDS = (
+    CloseGoalCommand,
+    FollowUpCommand,
+    GoalCommand,
+    ImmunizeCommand,
+    InstructCommand,
+    PerformCommand,
+    PlanCommand,
+    StopMedicationCommand,
+    TaskCommand,
+    UpdateGoalCommand,
+)
+
+
+@pytest.fixture
+def patient(db: None) -> Patient:
+    """The patient whose chart the commands write to."""
+    return PatientFactory.create()
+
+
+@pytest.fixture
+def note(patient: Patient) -> Note:
+    """A note on the patient's chart."""
+    return NoteFactory.create(patient=patient)
+
+
+@pytest.fixture
+def other_note(patient: Patient) -> Note:
+    """A second note on the same chart, for building an assessment the command may not link to."""
+    return NoteFactory.create(patient=patient)
+
+
+@pytest.fixture
+def stored_command(note: Note) -> Command:
+    """A persisted command on the note, for exercising the edit path."""
+    return Command.objects.create(
+        note=note,
+        patient=note.patient,
+        state="staged",
+        schema_key="instruct",
+        data={},
+        origination_source="plugin",
+        anchor_object_type="",
+        anchor_object_dbid=0,
+    )
+
+
+def _assessment(patient: Patient, note: Note) -> Assessment:
+    """An assessment made in the given note."""
+    return Assessment.objects.create(
+        patient=patient,
+        note=note,
+        status="stable",
+        narrative="Stable on current regimen.",
+        background="",
+        care_team="",
+    )
+
+
+@pytest.mark.parametrize(
+    argnames="command_class",
+    argvalues=ASSESSMENT_LINKED_COMMANDS,
+    ids=[command.__name__ for command in ASSESSMENT_LINKED_COMMANDS],
+)
+def test_every_in_scope_command_takes_an_assessment(command_class: type[_BaseCommand]) -> None:
+    """The field is on each Plan- and Procedures-section command, under the same name."""
+    assert "assessment_id" in command_class.model_fields
+    assert command_class.command_schema()["assessment"]["required"] is False
+
+
+def test_an_assessment_made_in_the_same_note_is_accepted(patient: Patient, note: Note) -> None:
+    """The ordinary case: the command and the assessment it addresses share a note."""
+    assessment = _assessment(patient, note)
+
+    assert InstructCommand(note_uuid=str(note.id), assessment_id=assessment.id).originate()
+
+
+def test_an_assessment_made_in_another_note_is_refused(
+    patient: Patient, note: Note, other_note: Note
+) -> None:
+    """The check this exists for — a real assessment on the same chart, but not in this note."""
+    foreign = _assessment(patient, other_note)
+
+    with pytest.raises(ValidationError) as caught:
+        InstructCommand(note_uuid=str(note.id), assessment_id=foreign.id).originate()
+
+    assert "was not made in this command's note" in str(caught.value)
+
+
+def test_an_assessment_id_that_names_nothing_is_refused(note: Note) -> None:
+    """An id no assessment has."""
+    with pytest.raises(ValidationError):
+        InstructCommand(note_uuid=str(note.id), assessment_id=UNKNOWN_ASSESSMENT_ID).originate()
+
+
+def test_no_assessment_means_nothing_to_check(note: Note) -> None:
+    """The link is optional, so a command committed without one is valid."""
+    assert InstructCommand(note_uuid=str(note.id), comment="Rest and fluids").originate()
+
+
+def test_the_check_holds_on_an_edit_which_carries_no_note(
+    patient: Patient, stored_command: Command, other_note: Note
+) -> None:
+    """An edit addresses a command rather than a note, and the note resolves from it."""
+    foreign = _assessment(patient, other_note)
+
+    with pytest.raises(ValidationError):
+        InstructCommand(command_uuid=str(stored_command.id), assessment_id=foreign.id).edit()
+
+
+def test_an_edit_naming_an_assessment_in_the_commands_own_note_is_allowed(
+    patient: Patient, stored_command: Command, note: Note
+) -> None:
+    """The other half: resolving the note from the command must not refuse a valid edit."""
+    assessment = _assessment(patient, note)
+
+    assert InstructCommand(command_uuid=str(stored_command.id), assessment_id=assessment.id).edit()
+
+
+def test_a_command_with_neither_anchor_is_not_refused() -> None:
+    """A command that cannot know its note must not guess.
+
+    A plugin can return several effects from one handler, and the note or command a later effect
+    names may not be persisted when that effect is built. Asserted with no database available, so a
+    lookup would raise rather than return — this passing is the evidence that none happens.
+    """
+    command = InstructCommand(assessment_id=UNKNOWN_ASSESSMENT_ID)
+
+    assert command._anchor_note_id() is None
+
+
+def test_the_link_travels_in_the_effect_payload(patient: Patient, note: Note) -> None:
+    """The interpreter reads `assessment_id`, so that is the name the effect has to carry."""
+    assessment = _assessment(patient, note)
+
+    effect = InstructCommand(note_uuid=str(note.id), assessment_id=assessment.id).originate()
+
+    assert f'"assessment_id": "{assessment.id}"' in effect.payload

--- a/canvas_sdk/tests/data/test_assessment_link.py
+++ b/canvas_sdk/tests/data/test_assessment_link.py
@@ -1,0 +1,101 @@
+import datetime
+
+import pytest
+
+from canvas_sdk.test_utils.factories import NoteFactory, PatientFactory
+from canvas_sdk.v1.data import (
+    Assessment,
+    Condition,
+    FollowUp,
+    Goal,
+    Immunization,
+    Instruction,
+    Note,
+    NoteTask,
+    Patient,
+    Plan,
+    Procedure,
+    StopMedicationEvent,
+    UpdateGoal,
+)
+from canvas_sdk.v1.data.base import Model
+
+ASSESSMENT_LINKED_MODELS = (
+    FollowUp,
+    Goal,
+    Immunization,
+    Instruction,
+    NoteTask,
+    Plan,
+    Procedure,
+    StopMedicationEvent,
+    UpdateGoal,
+)
+
+
+@pytest.fixture
+def patient(db: None) -> Patient:
+    """The patient whose chart the note is on."""
+    return PatientFactory.create()
+
+
+@pytest.fixture
+def note(patient: Patient) -> Note:
+    """A note on the patient's chart."""
+    return NoteFactory.create(patient=patient)
+
+
+@pytest.mark.parametrize(
+    argnames="model",
+    argvalues=ASSESSMENT_LINKED_MODELS,
+    ids=[model.__name__ for model in ASSESSMENT_LINKED_MODELS],
+)
+def test_every_linked_anchor_reads_the_views_assessment_column(model: type[Model]) -> None:
+    """The column the `canvas_sdk_data_*` views expose is `assessment_id`, and it is nullable."""
+    field = model._meta.get_field("assessment")
+
+    assert field.column == "assessment_id"
+    assert field.related_model is Assessment
+    assert field.null is True
+
+
+def test_a_linked_command_resolves_through_the_assessment_to_its_condition(
+    patient: Patient, note: Note
+) -> None:
+    """What the link is for: a plan item reaches the condition it addresses in two hops."""
+    condition = Condition.objects.create(
+        patient=patient,
+        deleted=False,
+        onset_date=datetime.date(2024, 1, 1),
+        resolution_date=datetime.date(2024, 6, 1),
+        clinical_status="active",
+        notes="",
+        surgical=False,
+    )
+    assessment = Assessment.objects.create(
+        patient=patient,
+        note=note,
+        condition=condition,
+        status="stable",
+        narrative="Stable on current regimen.",
+        background="",
+        care_team="",
+    )
+    instruction = Instruction.objects.create(
+        patient=patient, note=note, assessment=assessment, narrative="Rest and fluids"
+    )
+
+    stored = Instruction.objects.get(dbid=instruction.dbid)
+
+    assert stored.assessment is not None
+    assert stored.assessment.condition == condition
+    assert list(assessment.instructions.all()) == [instruction]
+
+
+def test_an_unlinked_command_is_valid(patient: Patient, note: Note) -> None:
+    """A command committed with no link is ordinary, not an incomplete row."""
+    instruction = Instruction.objects.create(
+        patient=patient, note=note, narrative="Rest and fluids"
+    )
+
+    assert Instruction.objects.get(dbid=instruction.dbid).assessment is None

--- a/canvas_sdk/v1/data/follow_up.py
+++ b/canvas_sdk/v1/data/follow_up.py
@@ -23,6 +23,9 @@ class FollowUp(AuditedModel, IdentifiableModel):
         "v1.Patient", on_delete=models.DO_NOTHING, related_name="follow_ups"
     )
     note = models.ForeignKey("v1.Note", on_delete=models.DO_NOTHING, related_name="follow_ups")
+    assessment = models.ForeignKey(
+        "v1.Assessment", on_delete=models.DO_NOTHING, related_name="follow_ups", null=True
+    )
     appointment_note = models.OneToOneField(
         "v1.Note", on_delete=models.DO_NOTHING, null=True, related_name="appointment_request"
     )

--- a/canvas_sdk/v1/data/goal.py
+++ b/canvas_sdk/v1/data/goal.py
@@ -57,6 +57,9 @@ class AbstractGoal(AuditedModel, IdentifiableModel):
         "v1.Patient", on_delete=models.DO_NOTHING, related_name="%(class)ss"
     )
     note = models.ForeignKey("v1.Note", on_delete=models.DO_NOTHING, related_name="%(class)ss")
+    assessment = models.ForeignKey(
+        "v1.Assessment", on_delete=models.DO_NOTHING, related_name="%(class)ss", null=True
+    )
     lifecycle_status = models.CharField(
         max_length=20,
         choices=GoalLifecycleStatus.choices,

--- a/canvas_sdk/v1/data/immunization.py
+++ b/canvas_sdk/v1/data/immunization.py
@@ -60,6 +60,9 @@ class Immunization(AuditedModel, IdentifiableModel):
         "v1.Patient", on_delete=models.DO_NOTHING, related_name="immunizations", null=True
     )
     note = models.ForeignKey("v1.Note", on_delete=models.DO_NOTHING, related_name="immunizations")
+    assessment = models.ForeignKey(
+        "v1.Assessment", on_delete=models.DO_NOTHING, related_name="immunizations", null=True
+    )
     status = models.CharField(
         choices=ImmunizationStatus.choices,
         max_length=20,

--- a/canvas_sdk/v1/data/instruction.py
+++ b/canvas_sdk/v1/data/instruction.py
@@ -38,6 +38,9 @@ class Instruction(AuditedModel, IdentifiableModel):
         "v1.Patient", on_delete=models.DO_NOTHING, related_name="instructions"
     )
     note = models.ForeignKey("v1.Note", on_delete=models.DO_NOTHING, related_name="instructions")
+    assessment = models.ForeignKey(
+        "v1.Assessment", on_delete=models.DO_NOTHING, related_name="instructions", null=True
+    )
     narrative = models.CharField(max_length=4000)
 
 

--- a/canvas_sdk/v1/data/plan.py
+++ b/canvas_sdk/v1/data/plan.py
@@ -21,6 +21,9 @@ class Plan(TypeAheadNarrativeMixin, AuditedModel, IdentifiableModel):
 
     patient = models.ForeignKey("v1.Patient", on_delete=models.DO_NOTHING, related_name="plans")
     note = models.ForeignKey("v1.Note", on_delete=models.DO_NOTHING, related_name="plans")
+    assessment = models.ForeignKey(
+        "v1.Assessment", on_delete=models.DO_NOTHING, related_name="plans", null=True
+    )
 
 
 __exports__ = ("Plan",)

--- a/canvas_sdk/v1/data/procedure.py
+++ b/canvas_sdk/v1/data/procedure.py
@@ -46,6 +46,9 @@ class Procedure(AuditedModel, IdentifiableModel):
         "v1.Patient", on_delete=models.DO_NOTHING, related_name="procedures"
     )
     note = models.ForeignKey("v1.Note", on_delete=models.DO_NOTHING, related_name="procedures")
+    assessment = models.ForeignKey(
+        "v1.Assessment", on_delete=models.DO_NOTHING, related_name="procedures", null=True
+    )
     provider = models.ForeignKey(
         "v1.Staff", on_delete=models.DO_NOTHING, related_name="procedures", null=True, default=None
     )

--- a/canvas_sdk/v1/data/stop_medication_event.py
+++ b/canvas_sdk/v1/data/stop_medication_event.py
@@ -24,6 +24,9 @@ class StopMedicationEvent(AuditedModel, IdentifiableModel):
     note = models.ForeignKey(
         "v1.Note", on_delete=models.DO_NOTHING, related_name="stopped_medications"
     )
+    assessment = models.ForeignKey(
+        "v1.Assessment", on_delete=models.DO_NOTHING, related_name="stopped_medications", null=True
+    )
     medication = models.ForeignKey(
         "v1.Medication",
         on_delete=models.DO_NOTHING,

--- a/canvas_sdk/v1/data/task.py
+++ b/canvas_sdk/v1/data/task.py
@@ -134,6 +134,9 @@ class NoteTask(AuditedModel, IdentifiableModel):
     objects = cast(CommittableQuerySet, CommittableModelManager())
 
     note = models.ForeignKey("v1.Note", on_delete=models.CASCADE, related_name="note_tasks")
+    assessment = models.ForeignKey(
+        "v1.Assessment", on_delete=models.DO_NOTHING, related_name="note_tasks", null=True
+    )
     task = models.ForeignKey(Task, on_delete=models.SET_NULL, related_name="note_tasks", null=True)
     patient = models.ForeignKey(
         "v1.Patient",


### PR DESCRIPTION
Part 1 of [KOALA-6533](https://canvasmedical.atlassian.net/browse/KOALA-6533): Strive Health (VBC kidney care) needs to programmatically associate Plan- and Procedures-section commands with the assessment they address, so their external care-team notes and custom export can show which plan items belong to which condition. This is the SDK half of a three-repo change, alongside canvas-core canvas-medical/canvas-core#1112 (merged, released as v1.37.0) and home-app canvas-medical/canvas#19550.

Instruct, FollowUp, StopMedication, Task, Perform, Immunize, Goal, UpdateGoal, CloseGoal, and Plan take an `assessment_id`, added through an abstract `_AssessmentLinkedCommand` following the `_BaseReview` precedent. The field carries `commands_api_name: "assessment"`, which is the name home-app's interpreter maps it from. Validation rejects an assessment that was not made in the command's own note, resolving that note from `note_uuid` or, on an edit, from the command itself through a new `_anchor_note_id()` that mirrors `_anchor_patient_id()`. When neither anchor is persisted the check is skipped, so a handler returning several effects at once still works. Home-app performs the same check server-side.

The read side is an `assessment` foreign key on the nine anchor data models: FollowUp, Goal, UpdateGoal, Immunization, Instruction, NoteTask, Plan, Procedure, and StopMedicationEvent. Each resolves to the `assessment_id` column that home-app's `canvas_sdk_data_*` views expose, so a committed command's link reads back and resolves Assessment to Condition in two hops.

Tests are unit-level: the field and its schema entry on all ten commands, the same-note check on originate and on edit, an unknown id, an omitted field, the effect payload key, the nine data-model columns, and the Assessment to Condition round trip. There is no integration test, because the integtest harness drives commands through an installed plugin with no way to name an assessment; the round trip against a real database is covered in home-app, and the ticket's own test plan is Janus UAT.


[KOALA-6533]: https://canvasmedical.atlassian.net/browse/KOALA-6533?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ